### PR TITLE
fix  undefined property $_sequence

### DIFF
--- a/protected/extensions/yii-mail/vendors/swiftMailer/classes/Swift/Transport/StreamBuffer.php
+++ b/protected/extensions/yii-mail/vendors/swiftMailer/classes/Swift/Transport/StreamBuffer.php
@@ -23,6 +23,7 @@ class Swift_Transport_StreamBuffer
   extends Swift_ByteStream_AbstractFilterableInputStream
   implements Swift_Transport_IoBuffer
 {
+  private $_sequence;
   
   /** A primary socket */
   private $_stream;


### PR DESCRIPTION
cf. http://imgur.com/qip4nQT

was required when running : 
- PHP 5.5.9-1ubuntu4.4
- on ubuntu LTS 14.04

similar issue : https://bitbucket.org/zurmo/zurmo/issue/196/swiftmailer-problems-under-php-55
