### PR TITLE
Update OnlineModuleManager.php

### DIFF
--- a/protected/modules_core/admin/libs/OnlineModuleManager.php
+++ b/protected/modules_core/admin/libs/OnlineModuleManager.php
@@ -73,6 +73,7 @@ class OnlineModuleManager
             $http = new Zend_Http_Client($downloadUrl, array(
                 'adapter' => 'Zend_Http_Client_Adapter_Curl',
                 'curloptions' => $this->getCurlOptions(),
+                'timeout' => 30
             ));
             $response = $http->request();
             file_put_contents($downloadTargetFileName, $response->getBody());


### PR DESCRIPTION
Useful on slow server environment when we download/install module on HumHub. The default is 10000ms now become 30000ms and this is based on my VPS environment.
