### PR TITLE
change unique id of post-files

### DIFF
--- a/protected/modules_core/file/widgets/views/showFiles.php
+++ b/protected/modules_core/file/widgets/views/showFiles.php
@@ -12,7 +12,7 @@
 <?php if (count($files) != 0) : ?>
 
     <!-- Show Images as Thumbnails -->
-    <div class="post-files" id="post-files-<?php echo $this->object->getPrimaryKey(); ?>">
+    <div class="post-files" id="post-files-<?php echo $this->object->getUniqueId(); ?>">
         <?php foreach ($files as $file) : ?>
             <?php if ($file->getMimeBaseType() == "image") : ?>
                 <?php


### PR DESCRIPTION
I think should be used getUniqueId() for get unique post id, because only id of post can be the same id of another content type.
