### PR TITLE
Implement Issue #463

### DIFF
--- a/protected/components/HPhpMessageSource.php
+++ b/protected/components/HPhpMessageSource.php
@@ -93,19 +93,26 @@ class HPhpMessageSource extends CPhpMessageSource {
                 $extensionCategory = substr($category, $pos + 1);
                 // First check if there's an extension registered for this class.
                 if (isset($this->extensionPaths[$extensionClass]))
-                    $this->_files[$category][$language] = Yii::getPathOfAlias($this->extensionPaths[$extensionClass]) . DIRECTORY_SEPARATOR . $language . DIRECTORY_SEPARATOR . $extensionCategory . '.php';
+                    $messageFile = Yii::getPathOfAlias($this->extensionPaths[$extensionClass]) . DIRECTORY_SEPARATOR . $language . DIRECTORY_SEPARATOR . $extensionCategory . '.php';
                 else {
                     // No extension registered, need to find it.
                     try {
                         $class = new ReflectionClass($extensionClass);
-                        $this->_files[$category][$language] = dirname($class->getFileName()) . DIRECTORY_SEPARATOR . 'messages' . DIRECTORY_SEPARATOR . $language . DIRECTORY_SEPARATOR . $extensionCategory . '.php';
+                        $messageFile = dirname($class->getFileName()) . DIRECTORY_SEPARATOR . 'messages' . DIRECTORY_SEPARATOR . $language . DIRECTORY_SEPARATOR . $extensionCategory . '.php';
                     } catch (Exception $e) {
                         return "";
                     }
                 }
-            } else
-                $this->_files[$category][$language] = $this->basePath . DIRECTORY_SEPARATOR . $language . DIRECTORY_SEPARATOR . $category . '.php';
+            } else 
+                $messageFile = $this->basePath . DIRECTORY_SEPARATOR . $language . DIRECTORY_SEPARATOR . $category . '.php';
         }
+        if (Yii::app()->theme && Yii::app()->theme != "") {
+        	$this->_files[$category][$language] = Yii::app()->theme->getMessageFile($messageFile);
+        }
+        else {
+        	$this->_files[$category][$language] = $messageFile;
+        }
+        
         return $this->_files[$category][$language];
     }
 

--- a/protected/components/HTheme.php
+++ b/protected/components/HTheme.php
@@ -21,7 +21,7 @@
 /**
  * HTheme is an overwrite of CTheme
  *
- * This is caused by our view path for modules is also separeted into modules/ folders.
+ * This is caused by our view path for modules is also separated into modules/ folders.
  *
  * @author Lucas Bartholemy <lucas@bartholemy.com>
  * @package humhub.components
@@ -105,6 +105,27 @@ class HTheme extends CTheme
         return Yii::app()->getBaseUrl($absolute) . '/' . $file;
     }
 
+    /**
+     * Searches for a themed version of an language message file
+     *
+     * @param string $messageFile
+     * @return string
+     */
+    public function getMessageFile($messageFile)
+    {
+    	// Replace: application.messages -> webroot.themes.CURRENTTHEME.messages
+    	$themeMessageFile = str_replace(Yii::app()->basePath, $this->basePath, $messageFile);
+    	
+    	// Replace: application.modules[_core].MODULEID.messages -> webroot.themes.CURRENTTHEME.messages.MODULEID
+    	$themeMessageFile = preg_replace('/modules(?:_core)?\/(.*?)\/messages\/(.*)\/(.*)/i', 'messages/\1/\2/\3', $themeMessageFile);
+    	
+    	// Check if file exists
+    	if (is_file($themeMessageFile)) {
+    		return $themeMessageFile;
+    	}
+    
+    	return $messageFile;
+    }
 }
 
 ?>


### PR DESCRIPTION
This adds the ability for an admin to override a language message file within a theme.  The structure of overrided message files mirrors that of theme view files.  A "messages" directory is added within the theme base directory with the following hierarchy:

/mytheme/messages/<language>/<category>.php  (no / base class)
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;/<class>/<language>/<category>.php
