### PR TITLE
Implement Issue #472

### DIFF
--- a/protected/modules_core/space/controllers/SpaceController.php
+++ b/protected/modules_core/space/controllers/SpaceController.php
@@ -79,8 +79,7 @@ class SpaceController extends Controller
      */
     public function actionIndex()
     {
-        $this->pageTitle = HSetting::Get('name') . " - " . $this->getSpace()->name;
-
+        $this->pageTitle = $this->getSpace()->name;
 
         if ($this->getSpace()->isMember()) {
 


### PR DESCRIPTION
Page title is already appending the site name to the end of the title.  I removed the setting in SpaceController.php that also prepended the site name.
