### PR TITLE
added option to disable automatic fetching of ldap users

### DIFF
--- a/protected/commands/shell/ZCron/ZCronRunner.php
+++ b/protected/commands/shell/ZCron/ZCronRunner.php
@@ -76,7 +76,7 @@ class ZCronRunner extends HConsoleCommand {
             // Optimize Search Index
             HSearch::getInstance()->Optimize();
 
-            if (HSetting::Get('enabled', 'authentication_ldap')) {
+            if (HSetting::Get('enabled', 'authentication_ldap') && HSetting::Get('refreshUsers', 'authentication_ldap')) {
                 print "- Updating LDAP Users\n";
                 HLdap::getInstance()->refreshUsers();
             }

--- a/protected/modules_core/admin/controllers/SettingController.php
+++ b/protected/modules_core/admin/controllers/SettingController.php
@@ -158,6 +158,7 @@ class SettingController extends Controller
 
         // Load Defaults
         $form->enabled = HSetting::Get('enabled', 'authentication_ldap');
+        $form->refreshUsers = HSetting::Get('refreshUsers', 'authentication_ldap');
         $form->username = HSetting::Get('username', 'authentication_ldap');
         $form->password = HSetting::Get('password', 'authentication_ldap');
         $form->hostname = HSetting::Get('hostname', 'authentication_ldap');
@@ -183,6 +184,7 @@ class SettingController extends Controller
 
             if ($form->validate()) {
                 HSetting::Set('enabled', $form->enabled, 'authentication_ldap');
+                HSetting::Set('refreshUsers', $form->refreshUsers, 'authentication_ldap');
                 HSetting::Set('hostname', $form->hostname, 'authentication_ldap');
                 HSetting::Set('port', $form->port, 'authentication_ldap');
                 HSetting::Set('encryption', $form->encryption, 'authentication_ldap');

--- a/protected/modules_core/admin/forms/AuthenticationLdapSettingsForm.php
+++ b/protected/modules_core/admin/forms/AuthenticationLdapSettingsForm.php
@@ -7,6 +7,7 @@
 class AuthenticationLdapSettingsForm extends CFormModel {
 
     public $enabled;
+    public $refreshUsers;
     public $username;
     public $password;
     public $hostname;
@@ -31,7 +32,7 @@ class AuthenticationLdapSettingsForm extends CFormModel {
     public function rules() {
 
         return array(
-            array('enabled, usernameAttribute, username, password, hostname, port, baseDn, loginFilter, userFilter',  'length', 'max' => 255),
+            array('enabled, refreshUsers, usernameAttribute, username, password, hostname, port, baseDn, loginFilter, userFilter',  'length', 'max' => 255),
             array('encryption', 'in', 'range'=>array('', 'ssl', 'tls')),
         );
     }
@@ -44,6 +45,7 @@ class AuthenticationLdapSettingsForm extends CFormModel {
     public function attributeLabels() {
         return array(
             'enabled' => Yii::t('AdminModule.forms_AuthenticationLdapSettingsForm', 'Enable LDAP Support'),
+            'refreshUsers' => Yii::t('AdminModule.forms_AuthenticationLdapSettingsForm', 'Fetch/Update Users Automatically'),
             'username' => Yii::t('AdminModule.forms_AuthenticationLdapSettingsForm', 'Username'),
             'password' => Yii::t('AdminModule.forms_AuthenticationLdapSettingsForm', 'Password'),
             'encryption' => Yii::t('AdminModule.forms_AuthenticationLdapSettingsForm', 'Encryption'),

--- a/protected/modules_core/admin/views/setting/authentication_ldap.php
+++ b/protected/modules_core/admin/views/setting/authentication_ldap.php
@@ -88,6 +88,14 @@
             <p class="help-block"><?php echo Yii::t('AdminModule.views_setting_authentication_ldap', 'LDAP Attribute for Username. Example: &quotuid&quot; or &quot;sAMAccountName&quot;'); ?></p>
         </div>
 
+        <div class="form-group">
+            <div class="checkbox">
+                <label>
+                    <?php echo $form->checkBox($model, 'refreshUsers', array('readonly' => HSetting::IsFixed('refreshUsers', 'authentication_ldap'))); ?> <?php echo $model->getAttributeLabel('refreshUsers'); ?>
+                </label>
+            </div>
+        </div>
+
         <hr>
 
         <?php echo CHtml::submitButton(Yii::t('AdminModule.views_setting_authentication_ldap', 'Save'), array('class' => 'btn btn-primary')); ?>

--- a/protected/modules_core/installer/controllers/ConfigController.php
+++ b/protected/modules_core/installer/controllers/ConfigController.php
@@ -294,6 +294,7 @@ class ConfigController extends Controller
         // Authentication
         HSetting::Set('authInternal', '1', 'authentication');
         HSetting::Set('authLdap', '0', 'authentication');
+        HSetting::Set('refreshUsers', '1', 'authentication_ldap');
         HSetting::Set('needApproval', '0', 'authentication_internal');
         HSetting::Set('anonymousRegistration', '1', 'authentication_internal');
         HSetting::Set('internalUsersCanInvite', '1', 'authentication_internal');


### PR DESCRIPTION
Our LDAP is pretty big and we don't want to pull all users automatically but create them on first login. This pull-request adds option to disable fetching/updating/disabling of users in the hourly cron job.
