### PR TITLE
extend locking of ldap-synced fields to also work in non-admin mode

### DIFF
--- a/protected/modules_core/user/models/Profile.php
+++ b/protected/modules_core/user/models/Profile.php
@@ -156,10 +156,10 @@ class Profile extends HActiveRecord
                 if ($this->scenario == 'adminEdit') {
                     $profileField->editable = true;
 
-                    // Dont allow editing of ldap syned fields - will be overwritten on next ldap sync.
-                    if ($this->user->auth_mode == User::AUTH_MODE_LDAP && $profileField->ldap_attribute != "") {
-                        $profileField->editable = false;
-                    }
+                }
+                // Dont allow editing of ldap syned fields - will be overwritten on next ldap sync.
+                if ($this->user->auth_mode == User::AUTH_MODE_LDAP && $profileField->ldap_attribute != "") {
+                    $profileField->editable = false;
                 }
 
                 $fieldDefinition = $profileField->fieldType->getFieldFormDefinition();


### PR DESCRIPTION
Currently user can change ldap-synced fields in his own profile while admin is forbidden to do so. The change extends this behavior to user profile view.
