### PR TITLE
proxy support

### DIFF
--- a/protected/models/UrlOembed.php
+++ b/protected/models/UrlOembed.php
@@ -179,6 +179,19 @@ class UrlOembed extends HActiveRecord
         $curl = curl_init($url);
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($curl, CURLOPT_TIMEOUT, 15);
+        if (HSetting::Get('enabled', 'proxy')) {
+            curl_setopt($curl, CURLOPT_PROXY, HSetting::Get('server', 'proxy'));
+            curl_setopt($curl, CURLOPT_PROXYPORT, HSetting::Get('port', 'proxy'));
+            if (defined('CURLOPT_PROXYUSERNAME')) {
+                curl_setopt($curl, CURLOPT_PROXYUSERNAME, HSetting::Get('user', 'proxy'));
+            }
+            if (defined('CURLOPT_PROXYPASSWORD')) {
+                curl_setopt($curl, CURLOPT_PROXYPASSWORD, HSetting::Get('pass', 'proxy'));
+            }
+            if (defined('CURLOPT_NOPROXY')) {
+                curl_setopt($curl, CURLOPT_NOPROXY, HSetting::Get('noproxy', 'proxy'));
+            }
+        }
         $return = curl_exec($curl);
         curl_close($curl);
         return $return;

--- a/protected/modules_core/admin/controllers/SettingController.php
+++ b/protected/modules_core/admin/controllers/SettingController.php
@@ -554,6 +554,51 @@ class SettingController extends Controller
     }
 
     /**
+     * Proxy Settings
+     */
+    public function actionProxy()
+    {
+        Yii::import('admin.forms.*');
+
+        $form = new ProxySettingsForm;
+
+        // uncomment the following code to enable ajax-based validation
+/*        if (isset($_POST['ajax']) && $_POST['ajax'] === 'design-settings-form') {
+            echo CActiveForm::validate($form);
+            Yii::app()->end();
+        }*/
+
+        if (isset($_POST['ProxySettingsForm'])) {
+            $_POST['ProxySettingsForm'] = Yii::app()->input->stripClean($_POST['ProxySettingsForm']);
+            $form->attributes = $_POST['ProxySettingsForm'];
+
+            if ($form->validate()) {
+
+                HSetting::Set('enabled', $form->enabled, 'proxy');
+                HSetting::Set('server', $form->server, 'proxy');
+                HSetting::Set('port', $form->port, 'proxy');
+                HSetting::Set('user', $form->user, 'proxy');
+                HSetting::Set('password', $form->password, 'proxy');
+                HSetting::Set('noproxy', $form->noproxy, 'proxy');
+
+                // set flash message
+                Yii::app()->user->setFlash('data-saved', Yii::t('AdminModule.controllers_ProxyController', 'Saved'));
+
+                $this->redirect(Yii::app()->createUrl('//admin/setting/proxy'));
+            }
+        } else {
+            $form->enabled = HSetting::Get('enabled', 'proxy');
+            $form->server = HSetting::Get('server', 'proxy');
+            $form->port = HSetting::Get('port', 'proxy');
+            $form->user = HSetting::Get('user', 'proxy');
+            $form->password = HSetting::Get('password', 'proxy');
+            $form->noproxy = HSetting::Get('noproxy', 'proxy');
+        }
+
+        $this->render('proxy', array('model' => $form));
+    }
+
+    /**
      * List of OEmbed Providers
      */
     public function actionOEmbed()

--- a/protected/modules_core/admin/forms/ProxySettingsForm.php
+++ b/protected/modules_core/admin/forms/ProxySettingsForm.php
@@ -8,6 +8,9 @@ class ProxySettingsForm extends CFormModel {
     public $enabled;
     public $server;
     public $port;
+    public $user;
+    public $password;
+    public $noproxy;
 
     /**
      * Declares the validation rules.
@@ -15,8 +18,8 @@ class ProxySettingsForm extends CFormModel {
     public function rules() {
 
         return array(
-            array('enabled, server', 'length', 'max'=>255),
-            array('port', 'numerical', 'integerOnly' => true, 'max'=>65535, 'min'=>0),
+            array('enabled, server, user, password, noproxy', 'length', 'max'=>255),
+            array('port', 'numerical', 'integerOnly' => true, 'max'=>65535, 'min'=>1),
         );
     }
 
@@ -30,6 +33,9 @@ class ProxySettingsForm extends CFormModel {
             'enabled' => Yii::t('AdminModule.forms_ProxySettingsForm', 'Enabled'),
             'server' => Yii::t('AdminModule.forms_ProxySettingsForm', 'Server'),
             'port' => Yii::t('AdminModule.forms_ProxySettingsForm', 'Port'),
+            'user' => Yii::t('AdminModule.forms_ProxySettingsForm', 'User'),
+            'password' => Yii::t('AdminModule.forms_ProxySettingsForm', 'Password'),
+            'noproxy' => Yii::t('AdminModule.forms_ProxySettingsForm', 'No Proxy Hosts'),
         );
     }
 

--- a/protected/modules_core/admin/libs/OnlineModuleManager.php
+++ b/protected/modules_core/admin/libs/OnlineModuleManager.php
@@ -216,11 +216,27 @@ class OnlineModuleManager
 
     private function getCurlOptions()
     {
-        return array(
+        $options = array(
             CURLOPT_SSL_VERIFYPEER => true,
             CURLOPT_SSL_VERIFYHOST => 2,
             CURLOPT_CAINFO => Yii::getPathOfAlias('application.config.ssl_certs') . DIRECTORY_SEPARATOR . 'humhub.crt'
         );
+
+        if (HSetting::Get('enabled', 'proxy')) {
+            $options[CURLOPT_PROXY] = HSetting::Get('server', 'proxy');
+            $options[CURLOPT_PROXYPORT] = HSetting::Get('port', 'proxy');
+            if (defined('CURLOPT_PROXYUSERNAME')) {
+                $options[CURLOPT_PROXYUSERNAME] = HSetting::Get('user', 'proxy');
+            }
+            if (defined('CURLOPT_PROXYPASSWORD')) {
+                $options[CURLOPT_PROXYPASSWORD] = HSetting::Get('pass', 'proxy');
+            }
+            if (defined('CURLOPT_NOPROXY')) {
+                $options[CURLOPT_NOPROXY] = HSetting::Get('noproxy', 'proxy');
+            }
+        }
+
+        return $options;
     }
 
 }

--- a/protected/modules_core/admin/views/setting/proxy.php
+++ b/protected/modules_core/admin/views/setting/proxy.php
@@ -30,6 +30,27 @@
             <?php echo $form->textField($model, 'port', array('class' => 'form-control')); ?>
         </div>
 
+        <?php if (defined('CURLOPT_PROXYUSERNAME')) { ?>
+        <div class="form-group">
+            <?php echo $form->labelEx($model, 'user'); ?>
+            <?php echo $form->textField($model, 'user', array('class' => 'form-control')); ?>
+        </div>
+        <?php } ?>
+
+        <?php if (defined('CURLOPT_PROXYPASSWORD')) { ?>
+        <div class="form-group">
+            <?php echo $form->labelEx($model, 'password'); ?>
+            <?php echo $form->textField($model, 'password', array('class' => 'form-control')); ?>
+        </div>
+        <?php } ?>
+
+        <?php if (defined('CURLOPT_NOPROXY')) { ?>
+        <div class="form-group">
+            <?php echo $form->labelEx($model, 'noproxy'); ?>
+            <?php echo $form->textArea($model, 'noproxy', array('class' => 'form-control', 'rows' => '4')); ?>
+        </div>
+        <?php } ?>
+
         <hr>
         <?php echo CHtml::submitButton(Yii::t('AdminModule.views_setting_proxy', 'Save'), array('class' => 'btn btn-primary')); ?>
 

--- a/protected/modules_core/admin/widgets/AdminMenuWidget.php
+++ b/protected/modules_core/admin/widgets/AdminMenuWidget.php
@@ -189,6 +189,15 @@ class AdminMenuWidget extends MenuWidget
             'isVisible' => Yii::app()->user->isAdmin(),
         ));
         $this->addItem(array(
+            'label' => Yii::t('AdminModule.widgets_AdminMenuWidget', 'Proxy'),
+            'url' => Yii::app()->createUrl('admin/setting/proxy'),
+            'icon' => '<i class="fa fa-sitemap"></i>',
+            'group' => 'settings',
+            'sortOrder' => 800,
+            'isActive' => (Yii::app()->controller->module && Yii::app()->controller->module->id == 'admin' && Yii::app()->controller->id == 'setting' && Yii::app()->controller->action->id == 'proxy'),
+            'isVisible' => Yii::app()->user->isAdmin(),
+        ));
+        $this->addItem(array(
             'label' => Yii::t('AdminModule.widgets_AdminMenuWidget', 'Statistics'),
             'url' => Yii::app()->createUrl('admin/setting/statistic'),
             'icon' => '<i class="fa fa-bar-chart-o"></i>',

--- a/protected/modules_core/file/libs/RemoteFileDownloader.php
+++ b/protected/modules_core/file/libs/RemoteFileDownloader.php
@@ -58,6 +58,20 @@ class RemoteFileDownloader
                 curl_setopt($ch, CURLOPT_FOLLOWLOCATION, false);
                 curl_setopt($ch, CURLOPT_HEADER, true);
 
+                if (HSetting::Get('enabled', 'proxy')) {
+                    curl_setopt($ch, CURLOPT_PROXY, HSetting::Get('server', 'proxy'));
+                    curl_setopt($ch, CURLOPT_PROXYPORT, HSetting::Get('port', 'proxy'));
+                    if (defined('CURLOPT_PROXYUSERNAME')) {
+                        curl_setopt($ch, CURLOPT_PROXYUSERNAME, HSetting::Get('user', 'proxy'));
+                    }
+                    if (defined('CURLOPT_PROXYPASSWORD')) {
+                        curl_setopt($ch, CURLOPT_PROXYPASSWORD, HSetting::Get('pass', 'proxy'));
+                    }
+                    if (defined('CURLOPT_NOPROXY')) {
+                        curl_setopt($ch, CURLOPT_NOPROXY, HSetting::Get('noproxy', 'proxy'));
+                    }
+                }
+
                 $ret = curl_exec($ch);
                 $contentType = curl_getinfo($ch, CURLINFO_CONTENT_TYPE);
                 $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);


### PR DESCRIPTION
Basic proxy support implemented for modules installation, oembed and remote file downloader.
Note that proxy auth and noproxy features require php5.5+ as there are no curl constants defined in older versions. I couldn't test if the auth works as our proxy doesn't require authentication.
