### PR TITLE
Update Issue #514, added setter

### DIFF
--- a/protected/modules_core/user/components/ConsoleUser.php
+++ b/protected/modules_core/user/components/ConsoleUser.php
@@ -149,6 +149,10 @@ class ConsoleUser extends CApplicationComponent implements IWebUser {
     function getAuthTimeout() {
     	return HSetting::Get('defaultUserIdleTimeoutSec', 'authentication_internal');
     }
+    
+    function setAuthTimeout() {
+    	return true;
+    }
 }
 
 ?>


### PR DESCRIPTION
Needed an authTimeout setter as well, started getting "Property "ConsoleUser.authTimeout" is read only." errors, fixed.
