### PR TITLE
ShowFilesWidget blacklist to hide widget for blacklisted objects from wa...

### DIFF
--- a/protected/modules_core/admin/controllers/SettingController.php
+++ b/protected/modules_core/admin/controllers/SettingController.php
@@ -509,6 +509,7 @@ class SettingController extends Controller
         $form->hideImageFileInfo = HSetting::Get('hideImageFileInfo', 'file');
         $form->useXSendfile = HSetting::Get('useXSendfile', 'file');
         $form->allowedExtensions = HSetting::Get('allowedExtensions', 'file');
+        $form->showFilesWidgetBlacklist = HSetting::Get('showFilesWidgetBlacklist','file');
 
         // Ajax Validation
         if (isset($_POST['ajax']) && $_POST['ajax'] === 'file-settings-form') {
@@ -528,6 +529,7 @@ class SettingController extends Controller
                 $form->hideImageFileInfo = HSetting::Set('hideImageFileInfo', $form->hideImageFileInfo, 'file');
                 $form->useXSendfile = HSetting::Set('useXSendfile', $form->useXSendfile, 'file');
                 $form->allowedExtensions = HSetting::Set('allowedExtensions', strtolower($form->allowedExtensions), 'file');
+                $form->showFilesWidgetBlacklist = HSetting::Set('showFilesWidgetBlacklist',$form->showFilesWidgetBlacklist,'file');
 
                 // set flash message
                 Yii::app()->user->setFlash('data-saved', Yii::t('AdminModule.controllers_SettingController', 'Saved'));

--- a/protected/modules_core/admin/forms/FileSettingsForm.php
+++ b/protected/modules_core/admin/forms/FileSettingsForm.php
@@ -13,6 +13,7 @@ class FileSettingsForm extends CFormModel {
     public $hideImageFileInfo;
     public $useXSendfile;
     public $allowedExtensions;
+    public $showFilesWidgetBlacklist;
 
     /**
      * Declares the validation rules.
@@ -22,7 +23,7 @@ class FileSettingsForm extends CFormModel {
             array('imageMagickPath', 'checkImageMagick'),
             array('maxFileSize, useXSendfile, maxPreviewImageWidth, maxPreviewImageHeight, hideImageFileInfo', 'numerical', 'integerOnly' => true),
             array('imageMagickPath, maxFileSize, maxPreviewImageWidth, maxPreviewImageHeight', 'safe'),
-            array('allowedExtensions', 'safe'),
+            array('allowedExtensions, showFilesWidgetBlacklist', 'safe'),
 
         );
     }
@@ -41,6 +42,7 @@ class FileSettingsForm extends CFormModel {
         	'maxPreviewImageHeight' => Yii::t('AdminModule.forms_FileSettingsForm', 'Maximum preview image height (in pixels, optional)'),
         	'hideImageFileInfo' => Yii::t('AdminModule.forms_FileSettingsForm', 'Hide file info (name, size) for images on wall'),
             'allowedExtensions' =>  Yii::t('AdminModule.forms_FileSettingsForm', 'Allowed file extensions'),
+            'showFilesWidgetBlacklist' => Yii::t('AdminModule.forms_FileSettingsForm', 'Hide file list widget from showing files for these objects on wall.'),
         );
     }
 

--- a/protected/modules_core/admin/views/setting/file.php
+++ b/protected/modules_core/admin/views/setting/file.php
@@ -62,6 +62,12 @@
             
         </div>
 
+        <div class="form-group">
+            <?php echo $form->labelEx($model, 'showFilesWidgetBlacklist'); ?>
+            <?php echo $form->textField($model, 'showFilesWidgetBlacklist', array('class' => 'form-control')); ?>
+            <p class="help-block"><?php echo Yii::t('AdminModule.views_setting_file', 'Comma separated list. Leave empty to show file list for all objects on wall.') ?></p>
+        </div>
+        
         <hr>
 
         <?php echo CHtml::submitButton(Yii::t('AdminModule.views_setting_file', 'Save'), array('class' => 'btn btn-primary')); ?>

--- a/protected/modules_core/file/widgets/ShowFilesWidget.php
+++ b/protected/modules_core/file/widgets/ShowFilesWidget.php
@@ -19,12 +19,15 @@ class ShowFilesWidget extends HWidget
      */
     public function run()
     {
-        $files = File::getFilesOfObject($this->object);
-        $this->render('showFiles', array('files' => $files, 
-        		'maxPreviewImageWidth' => HSetting::Get('maxPreviewImageWidth', 'file'),
-        		'maxPreviewImageHeight' => HSetting::Get('maxPreviewImageHeight', 'file'),
-        		'hideImageFileInfo' => HSetting::Get('hideImageFileInfo', 'file')
-        ));
+        $blacklisted_objects = explode(',', HSetting::Get('showFilesWidgetBlacklist','file'));
+        if (!in_array(get_class($this->object), $blacklisted_objects)) {
+            $files = File::getFilesOfObject($this->object);
+            $this->render('showFiles', array('files' => $files, 
+                            'maxPreviewImageWidth' => HSetting::Get('maxPreviewImageWidth', 'file'),
+                            'maxPreviewImageHeight' => HSetting::Get('maxPreviewImageHeight', 'file'),
+                            'hideImageFileInfo' => HSetting::Get('hideImageFileInfo', 'file')
+            ));
+        }
     }
 
 }


### PR DESCRIPTION
In some situations we don't want to show our files on wall enrty i.e for Album Images  we don't want to show the files  using ShowFilesWidget on a wall. for to control this behavior this feature was created. The Admin can configure this behavior via File Settings Administration menu.