### PR TITLE
Update style.css to include basic truncate

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -47,6 +47,12 @@ hr {
 textarea {
   height: 1.5em;
 }
+.truncate {
+  width: 150px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
 .topbar {
   position: fixed;
   display: block;


### PR DESCRIPTION
In the event that a user title is to long, the truncate class should be applied to it.

For example, my Random User Module will break if a username is too long. The user account dropdown looks out of sync with a large user title, and also breaks if you minimize the browser into a smaller frame. 