### PR TITLE
Added enrichText() to About Field

### DIFF
--- a/protected/modules_core/user/views/profile/about.php
+++ b/protected/modules_core/user/views/profile/about.php
@@ -25,9 +25,17 @@
                             <div class="form-group">
                                 <label class="col-sm-3 control-label"><?php echo Yii::t($field->getTranslationCategory(), $field->title); ?></label>
 
+
+								<?php if ( strtolower($field->title) == 'about' ) { ?>
+                                <div class="col-sm-9">
+                                    <p class="form-control-static"><?php echo HHtml::enrichText($field->getUserValue($user, false)); ?></p>
+                                </div>
+								<?php } else { ?>
                                 <div class="col-sm-9">
                                     <p class="form-control-static"><?php echo $field->getUserValue($user, false); ?></p>
                                 </div>
+								<?php } ?>
+                            </div>
                             </div>
 
 


### PR DESCRIPTION
The about field is a text field which allows line-breaks, but the output is condense. This allows those line-breaks to be used by passing the content through the Hhtml::enrichText() function. This will also allow links within the about content.