### PR TITLE
Additional placeholder for top level foot code

### DIFF
--- a/protected/views/layouts/main.php
+++ b/protected/views/layouts/main.php
@@ -227,6 +227,10 @@
 </div>
 <!-- end: Modal -->
 
+<!-- start: render additional foot -->
+<?php $this->renderPartial('//layouts/foot'); ?>
+<!-- end: render additional foot -->
+
 <script type="text/javascript">
 
     // Replace the standard checkbox and radio buttons


### PR DESCRIPTION
We have to include some foot code on all pages. It seems that currently there's no way to do this but to copy whole main.php into our own theme. This PR introduces additional placeholder to handle such cases (similar to head.php which is inserted into head element).
The code is inserted just before the last script to enable things like replacement of standard input elements.