### PR TITLE
Add authentication mode for LDAP to use the local database

### DIFF
--- a/protected/modules_core/admin/controllers/SettingController.php
+++ b/protected/modules_core/admin/controllers/SettingController.php
@@ -170,6 +170,7 @@ class SettingController extends Controller
         $form->loginFilter = HSetting::Get('loginFilter', 'authentication_ldap');
         $form->userFilter = HSetting::Get('userFilter', 'authentication_ldap');
         $form->usernameAttribute = HSetting::Get('usernameAttribute', 'authentication_ldap');
+        $form->authMode = HSetting::Get('authMode', 'authentication_ldap');
 
         if ($form->password != '')
             $form->password = '---hidden---';
@@ -197,6 +198,7 @@ class SettingController extends Controller
                 HSetting::Set('loginFilter', $form->loginFilter, 'authentication_ldap');
                 HSetting::Set('userFilter', $form->userFilter, 'authentication_ldap');
                 HSetting::Set('usernameAttribute', $form->usernameAttribute, 'authentication_ldap');
+                HSetting::Set('authMode', $form->authMode, 'authentication_ldap');
 
                 // set flash message
                 Yii::app()->user->setFlash('data-saved', Yii::t('AdminModule.controllers_SettingController', 'Saved'));

--- a/protected/modules_core/admin/forms/AuthenticationLdapSettingsForm.php
+++ b/protected/modules_core/admin/forms/AuthenticationLdapSettingsForm.php
@@ -19,11 +19,17 @@ class AuthenticationLdapSettingsForm extends CFormModel {
     public $loginFilter;
     public $userFilter;
     public $usernameAttribute;
+    public $authMode;
     
    public $encryptionTypes = array(
         '' => 'None',
         'tls' => 'TLS (aka SSLV2)',
         'ssl' => 'SSL',
+    );
+
+    public $authModeTypes = array(
+        'ldap' => 'LDAP',
+        'local' => 'Local Database',
     );
 
     /**
@@ -34,6 +40,7 @@ class AuthenticationLdapSettingsForm extends CFormModel {
         return array(
             array('enabled, refreshUsers, usernameAttribute, username, password, hostname, port, baseDn, loginFilter, userFilter',  'length', 'max' => 255),
             array('encryption', 'in', 'range'=>array('', 'ssl', 'tls')),
+            array('authMode', 'in', 'range'=>array('ldap', 'local')),
         );
     }
 
@@ -55,6 +62,7 @@ class AuthenticationLdapSettingsForm extends CFormModel {
             'loginFilter' => Yii::t('AdminModule.forms_AuthenticationLdapSettingsForm', 'Login Filter'),
             'userFilter' => Yii::t('AdminModule.forms_AuthenticationLdapSettingsForm', 'User Filer'),
             'usernameAttribute' => Yii::t('AdminModule.forms_AuthenticationLdapSettingsForm', 'Username Attribute'),
+            'authMode' => Yii::t('AdminModule.forms_AuthenticationLdapSettingsForm', 'Authentication Mode'),
         );
     }
 

--- a/protected/modules_core/admin/views/setting/authentication_ldap.php
+++ b/protected/modules_core/admin/views/setting/authentication_ldap.php
@@ -89,6 +89,12 @@
         </div>
 
         <div class="form-group">
+            <?php echo $form->labelEx($model, 'authMode'); ?>
+            <?php echo $form->dropDownList($model, 'authMode', $model->authModeTypes, array('class' => 'form-control', 'readonly' => HSetting::IsFixed('authMode', 'authentication_ldap'))); ?>
+            <p class="help-block"><?php echo Yii::t('AdminModule.views_setting_authentication_ldap', 'Authentication Mode. It is possible to get the users from LDAP but authenticate them with the local database.'); ?></p>
+        </div>
+
+        <div class="form-group">
             <div class="checkbox">
                 <label>
                     <?php echo $form->checkBox($model, 'refreshUsers', array('readonly' => HSetting::IsFixed('refreshUsers', 'authentication_ldap'))); ?> <?php echo $model->getAttributeLabel('refreshUsers'); ?>

--- a/protected/modules_core/user/models/User.php
+++ b/protected/modules_core/user/models/User.php
@@ -646,6 +646,36 @@ class User extends HActiveRecordContentContainer implements ISearchable
     }
 
     /**
+      * Sends the Welcome email to the user with password recovery token.
+      * This is only used when LDAP is enabled, but authentication mode is 'local'.
+      *
+      */
+    public function sendWelcomeEmailWithPaswordRecoveryToken()
+    {
+        if ($this->auth_mode != User::AUTH_MODE_LOCAL || !HSetting::Get('enabled', 'authentication_ldap'))
+            return;
+
+        // Switch to users language
+        Yii::app()->language = Yii::app()->user->language;
+
+        $token = UUID::v4();
+        $this->setSetting('passwordRecoveryToken', $token.'.'.time(), 'user');
+
+        $message = new HMailMessage();
+        $message->view = "application.modules_core.user.views.mails.Welcome";
+        $message->addFrom(HSetting::Get('systemEmailAddress', 'mailing'), HSetting::Get('systemEmailName', 'mailing'));
+        $message->addTo($this->email);
+        $message->subject = Yii::t('UserModule.models_User', 'Welcome to {appName}', array('{appName}' => Yii::app()->name));
+        $message->setBody(array(
+            'username' => $this->username,
+            'displayName' => $this->displayName,
+            'linkPasswordReset' => Yii::app()->createAbsoluteUrl("//user/auth/resetPassword", array('token'=>$token, 'guid'=>$this->guid))
+        ), 'text/html');
+        Yii::app()->mail->send($message);
+    }
+
+
+    /**
      * Checks if this records belongs to the current user
      *
      * @return boolean is current User

--- a/protected/modules_core/user/views/mails/Welcome.php
+++ b/protected/modules_core/user/views/mails/Welcome.php
@@ -1,0 +1,156 @@
+<?php $this->beginContent('application.views.mail.template'); ?>
+
+<tr>
+    <td align="center" valign="top"   class="fix-box">
+
+        <!-- start  container width 600px -->
+        <table width="600"  align="center" border="0" cellspacing="0" cellpadding="0" class="container"  style="background-color: #ffffff; ">
+
+
+            <tr>
+                <td valign="top">
+
+                    <!-- start container width 560px -->
+                    <table width="540"  align="center" border="0" cellspacing="0" cellpadding="0" class="full-width" bgcolor="#ffffff" style="background-color:#ffffff;">
+
+
+                        <!-- start text content -->
+                        <tr>
+                            <td valign="top">
+                                <table width="100%" border="0" cellspacing="0" cellpadding="0" align="center" >
+                                    <tr>
+                                        <td valign="top" width="auto" align="center">
+                                            <!-- start button -->
+                                            <table border="0" align="center" cellpadding="0" cellspacing="0">
+                                                <tr>
+                                                    <td width="auto"  align="center" valign="middle" height="28" style=" background-color:#ffffff; background-clip: padding-box; font-size:26px; font-family:Open Sans, Arial,Tahoma, Helvetica, sans-serif; text-align:center;  color:#a3a2a2; font-weight: 300; padding-left:18px; padding-right:18px; ">
+
+                             <span style="color: #555555; font-weight: 300;">
+                               <?php echo Yii::t('UserModule.views_mails_Welcome', 'Welcome to {appName}', array('{appName}' => '<strong>' . CHtml::encode(Yii::app()->name) . '</strong>')); ?>
+                             </span>
+                                                    </td>
+                                                </tr>
+                                            </table>
+                                            <!-- end button -->
+                                        </td>
+                                    </tr>
+
+
+
+                                </table>
+                            </td>
+                        </tr>
+                        <!-- end text content -->
+
+
+                    </table>
+                    <!-- end  container width 560px -->
+                </td>
+            </tr>
+        </table>
+        <!-- end  container width 600px -->
+    </td>
+</tr>
+
+
+<tr>
+    <td align="center" valign="top"   class="fix-box">
+
+        <!-- start  container width 600px -->
+        <table width="600"  align="center" border="0" cellspacing="0" cellpadding="0" class="container"  style="background-color: #ffffff; border-bottom-left-radius: 4px; border-bottom-right-radius: 4px;">
+
+
+            <tr>
+                <td valign="top">
+
+                    <!-- start container width 560px -->
+                    <table width="540"  align="center" border="0" cellspacing="0" cellpadding="0" class="full-width" bgcolor="#ffffff" style="background-color:#ffffff;">
+
+
+                        <!-- start text content -->
+                        <tr>
+                            <td valign="top">
+                                <table width="100%" border="0" cellspacing="0" cellpadding="0" align="left" >
+
+
+                                    <!-- start text content -->
+                                    <tr>
+                                        <td valign="top">
+                                            <table border="0" cellspacing="0" cellpadding="0" align="left" >
+
+
+                                                <!--start space height -->
+                                                <tr>
+                                                    <td height="30" ></td>
+                                                </tr>
+                                                <!--end space height -->
+
+                                                <tr>
+                                                    <td  style="font-size: 14px; line-height: 22px; font-family:Open Sans,Arial,Tahoma, Helvetica, sans-serif; color:#777777; font-weight:300; text-align:left; ">
+
+                                                        <?php echo Yii::t('UserModule.views_mails_Welcome', 'Hello {displayName}', array('{displayName}' => CHtml::encode($displayName))); ?>
+                                                        <br><br>
+                                                        <?php echo Yii::t('UserModule.views_mails_Welcome', 'The user {userName} has been created for you at {appName}. Please use the following link within the next day to set up your password.', array('{userName}' => '<strong>' . CHtml::encode($username) . '</strong>', '{appName}' => CHtml::encode(Yii::app()->name))); ?>
+                                                        <br>
+                                                        <?php echo Yii::t('UserModule.views_mails_Welcome', "If you don't use this link within 24 hours, it will expire. In that case, you can still use the recover password option at the login dialog."); ?>
+                                                        <br>
+
+                                                    </td>
+                                                </tr>
+
+                                                <!--start space height -->
+                                                <tr>
+                                                    <td height="30" ></td>
+                                                </tr>
+                                                <!--end space height -->
+
+
+
+                                            </table>
+                                        </td>
+                                    </tr>
+                                    <!-- end text content -->
+
+                                    <tr>
+                                        <td valign="top" width="auto" align="center">
+                                            <!-- start button -->
+                                            <table border="0" align="center" cellpadding="0" cellspacing="0">
+                                                <tr>
+                                                    <td width="auto"  align="center" valign="middle" height="32" style=" background-color:#7191a8;  border-radius:5px; background-clip: padding-box;font-size:14px; font-family:Open Sans, Arial,Tahoma, Helvetica, sans-serif; text-align:center;  color:#ffffff; font-weight: 600; padding-left:30px; padding-right:30px; padding-top: 5px; padding-bottom: 5px;">
+
+                             <span style="color: #ffffff; font-weight: 300;">
+                               <a href="<?php echo $linkPasswordReset; ?>" style="text-decoration: none; color: #ffffff; font-weight: 300;">
+                                   <strong><?php echo Yii::t('UserModule.views_mails_Welcome', 'Setup Password'); ?></strong>
+                               </a>
+                             </span>
+                                                    </td>
+
+                                                </tr>
+                                            </table>
+                                            <!-- end button -->
+                                        </td>
+
+                                    </tr>
+
+                                </table>
+                            </td>
+                        </tr>
+                        <!-- end text content -->
+
+                        <!--start space height -->
+                        <tr>
+                            <td height="20" ></td>
+                        </tr>
+                        <!--end space height -->
+
+
+                    </table>
+                    <!-- end  container width 560px -->
+                </td>
+            </tr>
+        </table>
+        <!-- end  container width 600px -->
+    </td>
+</tr>
+
+<?php $this->endContent(); ?>


### PR DESCRIPTION
Add a new LDAP setting auth-mode, that can be set to LDAP to use the
LDAP to authenticate users like always, or local to import the users
from LDAP but setting their authentication mode to local.
When a new user is imported from the LDAP and the auth-mode setting is
set to local, a Welcome email is sent to the user with a reset password
token so that the user can set up the password.