### PR TITLE
OEmbed: Follow redirects when fetching data

### DIFF
--- a/protected/models/UrlOembed.php
+++ b/protected/models/UrlOembed.php
@@ -179,6 +179,7 @@ class UrlOembed extends HActiveRecord
         $curl = curl_init($url);
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($curl, CURLOPT_TIMEOUT, 15);
+        curl_setopt($curl, CURLOPT_FOLLOWLOCATION, true);
         if (HSetting::Get('enabled', 'proxy')) {
             curl_setopt($curl, CURLOPT_PROXY, HSetting::Get('server', 'proxy'));
             curl_setopt($curl, CURLOPT_PROXYPORT, HSetting::Get('port', 'proxy'));


### PR DESCRIPTION
Some OEmbed providers may not work correctly if redirections are not
followed. One such example is Flickr.