### PR TITLE
.gitignore for themes folder

### DIFF
--- a/themes/.gitignore
+++ b/themes/.gitignore
@@ -1,0 +1,6 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore
+# and the default Theme
+!HumHub/


### PR DESCRIPTION
Added .gitignore to themes folder, as well. Similar to the protected/modules folder.

Makes developing own themes with own repositories a lot easier.