### PR TITLE
 [FIXED] SelfTest | Check Runtime Directory - undefined variable 'path' (#767)

### DIFF
--- a/protected/libs/SelfTest.php
+++ b/protected/libs/SelfTest.php
@@ -176,7 +176,8 @@ class SelfTest {
 
         // Check Runtime Directory
         $title = 'Permissions - Runtime';
-        if (is_writeable(Yii::app()->runtimePath)) {
+        $path = Yii::app()->runtimePath;
+        if (is_writeable($path)) {
             $checks[] = array(
                 'title' => Yii::t('base', $title),
                 'state' => 'OK'
@@ -242,5 +243,3 @@ class SelfTest {
     }
 
 }
-
-?>


### PR DESCRIPTION
introduced variable 'path'

[MINOR] removed redundant closing tag (following best practice)