### PR TITLE
Update UserUrlRule.php

### DIFF
--- a/protected/modules_core/user/components/UserUrlRule.php
+++ b/protected/modules_core/user/components/UserUrlRule.php
@@ -63,10 +63,13 @@ class UserUrlRule extends CBaseUrlRule
             if (isset($parts[1])) {
 
                 $user = User::model()->findByAttributes(array('username' => $parts[1]));
-
+                /* Set default page */
+                if (!isset($parts[2])) {
+                    $parts[2] = 'home'; 
+                }
                 if ($user !== null) {
                     $_GET['uguid'] = $user->guid;
-                    if (!isset($parts[2]) || substr($parts[2], 0, 4) == 'home') {
+                    if (substr($parts[2], 0, 4) == 'home') {
                         $temp = 1;
                         return 'user/profile/index'. str_replace('home', '', $parts[2], $temp);
                     } else {


### PR DESCRIPTION
Assign default page when none is set.

Currently if `/home` was not specified the profile will present a `$parts - undefined offset of 2` error. 

This edit allows a user to link up to their username, as most users will naturally do when copying their profile link.