### PR TITLE
set default language cookie when does not exists in the available languages

### DIFF
--- a/protected/components/Controller.php
+++ b/protected/components/Controller.php
@@ -259,7 +259,8 @@ class Controller extends EController
             if (isset(Yii::app()->request->cookies['language'])) {
                 $language = (string) Yii::app()->request->cookies['language'];
                 if (!array_key_exists($language, Yii::app()->params['availableLanguages'])) {
-                    throw new CHttpException(500, 'Invalid language cookie!');
+                    Yii::app()->request->cookies['language'] = new CHttpCookie('language', 'en');
+                    $language = 'en';
                 }
             }
 


### PR DESCRIPTION
Set the default language to english when the existing language cookie does not exist in the available languages.