### PR TITLE
#912 fix user model overwrite after LDAP mapping

### DIFF
--- a/protected/modules_core/user/components/UserIdentity.php
+++ b/protected/modules_core/user/components/UserIdentity.php
@@ -49,7 +49,7 @@ class UserIdentity extends CUserIdentity
         } elseif ($user->status == User::STATUS_NEED_APPROVAL) {
             $this->errorCode = self::ERROR_NOT_APPROVED;
         } else {
-            $this->onSuccessfulAuthenticate($user);
+            $this->onSuccessfulAuthenticate($this->getUser());
         }
 
         return !$this->errorCode;


### PR DESCRIPTION
get current user model for onSuccessfulAuthenticate to prevent overwrite after LDAP mapping