### PR TITLE
Update SpaceUrlRule.php

### DIFF
--- a/protected/modules_core/space/components/SpaceUrlRule.php
+++ b/protected/modules_core/space/components/SpaceUrlRule.php
@@ -80,12 +80,12 @@ class SpaceUrlRule extends CBaseUrlRule
         }
         return false;
     }
-	
-	public static function isGuid($guid) {
-		if (preg_match('/^(\{)?[a-f\d]{8}(-[a-f\d]{4}){4}[a-f\d]{8}(?(1)\})$/i', $guid)) {
-			return true;
-		}
-		return false;
+    
+    public static function isGuid($guid) {
+        if (preg_match('/^(\{)?[a-f\d]{8}(-[a-f\d]{4}){4}[a-f\d]{8}(?(1)\})$/i', $guid)) {
+	    return true;
 	}
+	return false;
+    }
 
 }

--- a/protected/modules_core/space/components/SpaceUrlRule.php
+++ b/protected/modules_core/space/components/SpaceUrlRule.php
@@ -37,7 +37,7 @@ class SpaceUrlRule extends CBaseUrlRule
             /* Can we use a name instead? */
             $space = Space::model()->findByAttributes(array('guid' => $params['sguid']));
             if(strlen($space->name) == mb_strlen($space->name, 'utf-8') && !is_array((Space::model()->findByAttributes(array('name' => $space->name))))) {
-                $params['sguid'] = $space->attributes['name'];
+                $params['sguid'] = $space->name;
             }
             
             if ($route == 'space/space' || $route == 'space/space/index') {

--- a/protected/modules_core/space/components/SpaceUrlRule.php
+++ b/protected/modules_core/space/components/SpaceUrlRule.php
@@ -58,15 +58,16 @@ class SpaceUrlRule extends CBaseUrlRule
         if (substr($pathInfo, 0, 2) == "s/") {
             $parts = explode('/', $pathInfo, 3);
             if (isset($parts[1])) {
-                
+				
                 /* Are we handling a GUID or Name? */
-                if (($space = @Space::model()->findByAttributes(array('guid' => $parts[1]))) == false) {
-                    if (($space = @Space::model()->findByAttributes(array('name' => urldecode(trim($parts[1]))))) == false && !is_array($space)) {
-                        throw new CHttpException('404', Yii::t('SpaceModule.components_SpaceUrlRule', 'Space not found!'));
-                    }
+				$space = $this->isGuid($parts[1]) ? Space::model()->findByAttributes(array('guid' => $parts[1])) 
+                    : Space::model()->findByAttributes(array('name' => urldecode(trim($parts[1]))));
+
+	    		/* Not valid space or multiple occurrences. */
+                if (!is_object($space)) {
+                    throw new CHttpException('404', Yii::t('SpaceModule.components_SpaceUrlRule', 'Space not found!'));
                 }
                    
-                // What's this? 
                 $_GET['sguid'] = $space->guid;
                 
                 if (!isset($parts[2]) || substr($parts[2], 0, 4) == 'home') {
@@ -79,5 +80,12 @@ class SpaceUrlRule extends CBaseUrlRule
         }
         return false;
     }
+	
+	public static function isGuid($guid) {
+		if (preg_match('/^(\{)?[a-f\d]{8}(-[a-f\d]{4}){4}[a-f\d]{8}(?(1)\})$/i', $guid)) {
+			return true;
+		}
+		return false;
+	}
 
 }

--- a/protected/modules_core/space/components/SpaceUrlRule.php
+++ b/protected/modules_core/space/components/SpaceUrlRule.php
@@ -60,7 +60,7 @@ class SpaceUrlRule extends CBaseUrlRule
             if (isset($parts[1])) {
 				
                 /* Are we handling a GUID or Name? */
-				$space = $this->isGuid($parts[1]) ? Space::model()->findByAttributes(array('guid' => $parts[1])) 
+                $space = $this->isGuid($parts[1]) ? Space::model()->findByAttributes(array('guid' => $parts[1])) 
                     : Space::model()->findByAttributes(array('name' => urldecode(trim($parts[1]))));
 
 	    		/* Not valid space or multiple occurrences. */


### PR DESCRIPTION
***Dual-Purpose GUID / Name system for Spaces***

Space names now used in URL for human-readable links.
<img src="http://img.prntscr.com/img?url=http://i.imgur.com/6pkpFEL.jpg" />

**Non-compliant** characters cause URL controller to fallback to GUID.
<img src="http://img.prntscr.com/img?url=http://i.imgur.com/ErSg2KY.jpg" />

I would like to add "article" like urls, but unfortunately I cannot until full text indexing is enabled on HumHub data tables. For example a url like 
`s/Nutrients+%26+Deficiencies/home` could be `s/Nutrients-Deficiencies/home`
and
`s/Seed+Banks/home` could be `s/Seed-Banks/home`

Using a similar query like this through Yii match functions
```sql
SELECT name FROM space WHERE MATCH (name) AGAINST ('%Nutrients-Deficiencies%' IN BOOLEAN MODE)
```