### PR TITLE
attach event onInit to ProfileFieldType Class

### DIFF
--- a/protected/modules_core/admin/controllers/UserprofileController.php
+++ b/protected/modules_core/admin/controllers/UserprofileController.php
@@ -115,8 +115,8 @@ class UserProfileController extends Controller {
             $field = new ProfileField;
 
         // Get all Available Field Class Instances, also bind current profilefield to the type
-        $fieldTypes = ProfileFieldType::getTypeInstances($field);
-
+        $profileFieldTypes = new ProfileFieldType();
+        $fieldTypes = $profileFieldTypes->getTypeInstances();
         // Build Form Definition
         $definition = array();
 

--- a/protected/modules_core/user/models/ProfileField.php
+++ b/protected/modules_core/user/models/ProfileField.php
@@ -196,6 +196,7 @@ class ProfileField extends HActiveRecord
     {
 
         $categories = ProfileFieldCategory::model()->findAll(array('order' => 'sort_order'));
+        $profileFieldTypes = new ProfileFieldType();
         $definition = array(
             'ProfileField' => array(
                 'type' => 'form',
@@ -251,7 +252,7 @@ class ProfileField extends HActiveRecord
                     ),
                     'field_type_class' => array(
                         'type' => 'dropdownlist',
-                        'items' => ProfileFieldType::getFieldTypes(),
+                        'items' => $profileFieldTypes->getFieldTypes(),
                         'class' => 'form-control',
                     ),
                 )
@@ -312,7 +313,8 @@ class ProfileField extends HActiveRecord
                 $this->addError('field_type_class', Yii::t('UserModule.models_ProfileField', 'Field Type could not be changed!'));
             }
         } else {
-            if (!key_exists($this->field_type_class, ProfileFieldType::getFieldTypes())) {
+            $profileFieldTypes = new ProfileFieldType();
+            if (!key_exists($this->field_type_class, $profileFieldTypes->getFieldTypes())) {
                 $this->addError('field_type_class', Yii::t('UserModule.models_ProfileField', 'Invalid field type!'));
             }
         }


### PR DESCRIPTION
Adding ability to create custom profile field types to use in modules using events
To add new field(s) simply attach this to events
array('class' => 'ProfileFieldType', 'event' => 'onInit', 'callback' => array('YourModule', 'AddCustomProfileFields'))
in module autostart.php file

then to add new custom profile field type you can use as following:
single type:
$event->sender->addFieldType('ProfileFieldTypeCompany', 'Company');
or
$event->sender->fieldTypes['ProfileFieldTypeCompany']='Company';
or you can attach array:
$event->sender->fieldTypes = array(
                'ProfileFieldTypeCompany' => 'Company',
                'ProfileFieldTypeEmpStatus' => 'Employment Status');

Where "ProfileFieldTypeCompany" is the class for the profile field type and "Company" is profile field type name.