### PR TITLE
Add backslashes before characters that need to be escaped

### DIFF
--- a/protected/components/HClientScript.php
+++ b/protected/components/HClientScript.php
@@ -41,7 +41,7 @@ class HClientScript extends CClientScript
     public function setJavascriptVariable($name, $value)
     {
 
-        $jsCode = "var " . $name . " = '" . $value . "';\n";
+        $jsCode = "var " . $name . " = '" . addslashes($value) . "';\n";
         $this->registerScript('jsVar_' . $name, $jsCode, CClientScript::POS_BEGIN);
     }
 


### PR DESCRIPTION
Fixes #1066.