### PR TITLE
Email appended to the URL, not a mailto:-link

### DIFF
--- a/protected/modules_core/user/models/ProfileFieldTypeText.php
+++ b/protected/modules_core/user/models/ProfileFieldTypeText.php
@@ -178,7 +178,7 @@ class ProfileFieldTypeText extends ProfileFieldType {
         $value = $user->profile->$internalName;
 
         if (!$raw && $this->validator == self::VALIDATOR_EMAIL) {
-            return HHtml::link($value, $value);
+            return HHtml::link($value, 'mailto:'.$value);
         } elseif (!$raw && $this->validator == self::VALIDATOR_URL) {
             return HHtml::link($value, $value, array('target'=> '_blank'));
         }

--- a/protected/modules_core/user/views/profile/about.php
+++ b/protected/modules_core/user/views/profile/about.php
@@ -37,7 +37,12 @@
                                     </div>
                                 <?php } else { ?>
                                     <div class="col-sm-9">
-                                        <p class="form-control-static"><?php echo $field->getUserValue($user, false); ?></p>
+                                        <p class="form-control-static"><?php 
+                                            if($field['field_type_class'] == 'ProfileFieldTypeTextArea') {
+                                                echo nl2br($field->getUserValue($user, false)); 
+                                            } else {
+                                                echo $field->getUserValue($user, false);
+                                            } ?></p>
                                     </div>
                                 <?php } ?>
                             </div>


### PR DESCRIPTION
HHtml::link only appends field value (email address) to the actual URL. With the (right) URI protocol the right link will be created.