### PR TITLE
adding the date at mail messages to avoid quoting. resolve #1052

### DIFF
--- a/protected/views/mail/template.php
+++ b/protected/views/mail/template.php
@@ -508,7 +508,7 @@ td[class="image-124px"] img {
 
 </head>
 
-<body style="font-size:12px; font-family:Open Sans, Arial,Tahoma, Helvetica, sans-serif; background-color:#ededed; ">
+<body style="font-size:12px; font-family:Open Sans, Arial,Tahoma, Helvetica, sans-serif; background-color:#ededed; color: #ededed;">
 
 <!--start 100% wrapper (white background) -->
 <table width="100%" id="mainStructure" border="0" cellspacing="0" cellpadding="0" style="background-color:#ededed;">
@@ -641,6 +641,8 @@ td[class="image-124px"] img {
 <!-- START EMAIL CONTENT -->
 
 <?php echo $content; ?>
+<br>
+Sending time: <?php echo date('c'); ?>
 
 <!-- END EMAIL CONTENT -->
 


### PR DESCRIPTION
fixed issues #1052 using this post as base http://stackoverflow.com/questions/11078264/how-to-get-rid-of-show-trimmed-content-in-gmail-html-emails

- Was just tested on gmail (and inbox by gmail) both in browser and in android.
- Show the message "Sending time: <time>" when printed.