### PR TITLE
Add table name 'user' before column 'status'

### DIFF
--- a/protected/humhub/modules/content/Events.php
+++ b/protected/humhub/modules/content/Events.php
@@ -134,7 +134,7 @@ class Events extends \yii\base\Object
             return;
         }
 
-        $users = User::find()->distinct()->joinWith(['httpSessions', 'profile'])->where(['status' => User::STATUS_ENABLED]);
+        $users = User::find()->distinct()->joinWith(['httpSessions', 'profile'])->where(['user.status' => User::STATUS_ENABLED]);
         $totalUsers = $users->count();
         $done = 0;
         $mailsSent = 0;


### PR DESCRIPTION
Because there are column status on 'user' and 'profile' table we should add table name 'user'  to column 'status' to  avoid error: SQLSTATE[23000]: Integrity constraint violation: 1052 Column 'status' in where clause is ambiguous