### PR TITLE
Fix admin dashboard user profiles menu was not highlighting on this page

### DIFF
--- a/protected/humhub/modules/admin/widgets/AdminMenu.php
+++ b/protected/humhub/modules/admin/widgets/AdminMenu.php
@@ -137,7 +137,7 @@ class AdminMenu extends \humhub\widgets\BaseMenu
             'icon' => '<i class="fa fa-wrench"></i>',
             'group' => 'settings',
             'sortOrder' => 500,
-            'isActive' => (Yii::$app->controller->module && Yii::$app->controller->module->id == 'admin' && Yii::$app->controller->id == 'userprofile'),
+            'isActive' => (Yii::$app->controller->module && Yii::$app->controller->module->id == 'admin' && Yii::$app->controller->id == 'user-profile'),
             'isVisible' => Yii::$app->user->isAdmin(),
         ));
 


### PR DESCRIPTION
Fixed - User profiles menu was not highlighted on admin dashboard user profiles page.