### PR TITLE
Fix  translation in views_auth_login.php

### DIFF
--- a/protected/humhub/modules/user/messages/ru/views_auth_login.php
+++ b/protected/humhub/modules/user/messages/ru/views_auth_login.php
@@ -29,5 +29,5 @@ return [
     'Sign in' => 'Войти',
     'email' => 'email',
     'password' => 'Пароль',
-    'username or email' => 'Имя пользователя или пароль',
+    'username or email' => 'Имя пользователя или e-mail',
 ];


### PR DESCRIPTION
Now the Russian version of literally translated as follows: `user name or password`.
I just replaced the `пароль` (password) on `e-mail`.