### PR TITLE
Fix $filePath generation with Nginx when X-Sendfile is used

### DIFF
--- a/protected/humhub/modules/file/controllers/FileController.php
+++ b/protected/humhub/modules/file/controllers/FileController.php
@@ -171,7 +171,7 @@ class FileController extends \humhub\components\Controller
                 // make path relative to docroot
                 $docroot = rtrim($_SERVER['DOCUMENT_ROOT'], DIRECTORY_SEPARATOR);
                 if (substr($filePath, 0, strlen($docroot)) == $docroot) {
-                    $filePath = substr($file, strlen($docroot));
+                    $filePath = substr($filePath, strlen($docroot));
                 }
             }
             


### PR DESCRIPTION
When I tried to use the "X-Sendfile" option with Nginx no images were displayed and I got a bunch of `substr() expects parameter 1 to be string, object given` in the logs.

Seems like we should use $filePath instead of $file here, I tried it and everything works great now :3