### PR TITLE
fix issue #1512: Allow the content owner (post creator) to delete any of post's comment

### DIFF
--- a/protected/humhub/modules/comment/models/Comment.php
+++ b/protected/humhub/modules/comment/models/Comment.php
@@ -201,6 +201,9 @@ class Comment extends ContentAddonActiveRecord
 
         if ($this->created_by == $userId)
             return true;
+        
+        if ($this->content->user_id == $userId)
+            return true;
 
         if (Yii::$app->user->isAdmin()) {
             return true;


### PR DESCRIPTION
Fix issue #1512:

Investigate the delete permission of comment, i find that the following users has permission to delete the comment:
- the comment creator
- the humhub admins
- the space admins if the post on space

but if the post creator is not humhub admin and want to delete a comment (example: spam or bad comment), it doesn't allow him to delete.