### PR TITLE
Fix issue #1515 Edit post with empty string

### DIFF
--- a/protected/humhub/modules/post/controllers/PostController.php
+++ b/protected/humhub/modules/post/controllers/PostController.php
@@ -54,10 +54,14 @@ class PostController extends \humhub\modules\content\components\ContentContainer
         }
 
 
-        if ($model->load(Yii::$app->request->post()) && $model->validate() && $model->save()) {
+        if ($model->load(Yii::$app->request->post())) {
             // Reload record to get populated updated_at field
-            $model = Post::findOne(['id' => $id]);
-            return $this->renderAjaxContent($model->getWallOut(['justEdited' => true]));
+            if($model->validate() && $model->save()) {
+                $model = Post::findOne(['id' => $id]);
+                return $this->renderAjaxContent($model->getWallOut(['justEdited' => true]));
+            } else {
+                Yii::$app->response->statusCode = 400;
+            }
         }
 
         return $this->renderAjax('edit', array('post' => $model, 'edited' => $edited));

--- a/protected/humhub/modules/post/views/post/edit.php
+++ b/protected/humhub/modules/post/views/post/edit.php
@@ -7,12 +7,12 @@ use yii\helpers\Url;
 ?>
 <div class="content_edit" id="post_edit_<?php echo $post->id; ?>">
     <?php $form = CActiveForm::begin(['id' => 'post-edit-form_'+$post->id]); ?>
-
-    <?php echo $form->textArea($post, 'message', array('class' => 'form-control', 'id' => 'post_input_' . $post->id, 'placeholder' => Yii::t('PostModule.views_edit', 'Edit your post...'))); ?>
-
+    
     <!-- create contenteditable div for HEditorWidget to place the data -->
     <div id="post_input_<?php echo $post->id; ?>_contenteditable" class="form-control atwho-input"
          contenteditable="true"><?php echo \humhub\widgets\RichText::widget(['text' => $post->message, 'edit' => true]); ?></div>
+
+    <?php echo $form->field($post, 'message')->label(false)->textArea(array('class' => 'form-control', 'id' => 'post_input_' . $post->id, 'placeholder' => Yii::t('PostModule.views_edit', 'Edit your post...'))); ?>
 
     <?= \humhub\widgets\RichTextEditor::widget(['id' => 'post_input_' . $post->id, 'inputContent' => $post->message, 'record' => $post]); ?>
 
@@ -33,6 +33,7 @@ use yii\helpers\Url;
                 'type' => 'POST',
                 'beforeSend' => new yii\web\JsExpression('function(html){  $("#post_input_' . $post->id . '_contenteditable").hide(); showLoader("' . $post->id . '"); }'),
                 'success' => new yii\web\JsExpression('function(html){ $(".wall_' . $post->getUniqueId() . '").replaceWith(html); }'),
+                'statusCode' => ['400' => new yii\web\JsExpression('function(xhr) { $("#post_edit_'. $post->id.'").html(xhr.responseText); }')],
                 'url' => $post->content->container->createUrl('/post/post/edit', ['id' => $post->id]),
             ],
             'htmlOptions' => [

--- a/protected/humhub/modules/post/views/post/edit.php
+++ b/protected/humhub/modules/post/views/post/edit.php
@@ -33,7 +33,7 @@ use yii\helpers\Url;
                 'type' => 'POST',
                 'beforeSend' => new yii\web\JsExpression('function(html){  $("#post_input_' . $post->id . '_contenteditable").hide(); showLoader("' . $post->id . '"); }'),
                 'success' => new yii\web\JsExpression('function(html){ $(".wall_' . $post->getUniqueId() . '").replaceWith(html); }'),
-                'statusCode' => ['400' => new yii\web\JsExpression('function(xhr) { $("#post_edit_'. $post->id.'").html(xhr.responseText); }')],
+                'statusCode' => ['400' => new yii\web\JsExpression('function(xhr) { $("#post_edit_'. $post->id.'").replaceWith(xhr.responseText); }')],
                 'url' => $post->content->container->createUrl('/post/post/edit', ['id' => $post->id]),
             ],
             'htmlOptions' => [

--- a/protected/humhub/widgets/views/richTextEditor.php
+++ b/protected/humhub/widgets/views/richTextEditor.php
@@ -101,12 +101,11 @@ use yii\helpers\Url;
                 $(this).focus();
             }
         }).on('focusout', function () {
+            $('#<?php echo $id; ?>').val(getPlainInput($(this).clone()));
             // add placeholder text, if input is empty
             if ($(this).html() == "" || $(this).html() == " " || $(this).html() == " <br>") {
                 $(this).html(placeholder);
                 $(this).addClass('atwho-placeholder');
-            } else {
-                $('#<?php echo $id; ?>').val(getPlainInput($(this).clone()));
             }
         }).on('paste', function (event) {
 


### PR DESCRIPTION
Fix issue #1515 Edit post with empty string

Now editing a Post with empty string renders the Yii model rule error correctly
(Tested on Chromium, Firefox, Opera, Edge and IE11)
![edit_post_rule](https://cloud.githubusercontent.com/assets/15964842/13494099/cedde640-e14a-11e5-85ac-de76b4b653a5.png)