### PR TITLE
allow manual setting of 'updated_by' property of ActiveRecord

### DIFF
--- a/protected/humhub/components/ActiveRecord.php
+++ b/protected/humhub/components/ActiveRecord.php
@@ -36,7 +36,7 @@ class ActiveRecord extends \yii\db\ActiveRecord
         if ($this->hasAttribute('updated_at')) {
             $this->updated_at = new \yii\db\Expression('NOW()');
         }
-        if (isset(Yii::$app->user) && $this->hasAttribute('updated_by')) {
+        if (isset(Yii::$app->user) && $this->hasAttribute('updated_by') && $this->updated_by == "") {
             $this->updated_by = Yii::$app->user->id;
         }
         return parent::beforeSave($insert);


### PR DESCRIPTION
set 'updated_by' property to Yii::$app->user->id only when it is not set, otherwise use the current value.