### PR TITLE
Fixed #1465 Double notifications for comments

### DIFF
--- a/protected/humhub/modules/comment/notifications/NewComment.php
+++ b/protected/humhub/modules/comment/notifications/NewComment.php
@@ -33,12 +33,10 @@ class NewComment extends \humhub\modules\notification\components\BaseNotificatio
      */
     public function send(User $user)
     {
-        // Check there is also an mentioned notifications, so ignore this notification
-        /*
-          if (Notification::model()->findByAttributes(array('class' => 'MentionedNotification', 'source_object_model' => 'Comment', 'source_object_id' => $comment->id)) !== null) {
-          continue;
-          }
-         */
+        // Check if there is also a mention notification, so skip this notification
+		if (\humhub\modules\notification\models\Notification::find()->where(['class' => \humhub\modules\user\notifications\Mentioned::className(), 'user_id' => $user->id, 'source_class' => $this->source->className(), 'source_pk' => $this->source->getPrimaryKey()])->count() > 0) {
+            return;
+        }
 
         return parent::send($user);
     }


### PR DESCRIPTION
Skip new comment notification if the user was mentioned in a comment.