### PR TITLE
Update File.php

### DIFF
--- a/protected/humhub/modules/file/models/File.php
+++ b/protected/humhub/modules/file/models/File.php
@@ -327,8 +327,11 @@ class File extends \humhub\components\ActiveRecord
     public function canDelete($userId = "")
     {
         $object = $this->getPolymorphicRelation();
-        if ($object !== null && ($object instanceof ContentActiveRecord || $object instanceof ContentAddonActiveRecord)) {
-            return $object->content->canWrite($userId);
+        if ($object !== null) {
+            if ($object instanceof ContentAddonActiveRecord)
+                return $object->canWrite($userId);
+            else if ($object instanceof ContentActiveRecord)
+                return $object->content->canWrite($userId);
         }
 
         // File is not bound to an object


### PR DESCRIPTION
#1616  Delete file from comment editing

the old code check only content creator not contentActiveRecord creator 

if Object is a comment (ContentAddonActiveRecord)
fire canWrite of it that means (comment creator can delete comment files)
else if object is a post (content) fire canWrite of it that means (post creator can delete post files)``