### PR TITLE
fixed group registration default value

### DIFF
--- a/protected/humhub/modules/user/models/forms/Registration.php
+++ b/protected/humhub/modules/user/models/forms/Registration.php
@@ -317,6 +317,8 @@ class Registration extends HForm
         if ($this->_groupUser === null) {
             $this->_groupUser = new GroupUser();
             $this->_groupUser->scenario = GroupUser::SCENARIO_REGISTRATION;
+            // assign default value for group_id
+            $this->_groupUser->group_id = \humhub\models\Setting::Get('defaultUserGroup', 'authentication_internal');
         }
 
         return $this->_groupUser;


### PR DESCRIPTION
fixed group registration default value to make automatic registration (e.g. via oauth) work directly without showing the registration form.

this default value is the same as set by the registration form.

fixes #1672