### PR TITLE
Update admin-adv-auth.md

### DIFF
--- a/protected/humhub/docs/guide/admin-adv-auth.md
+++ b/protected/humhub/docs/guide/admin-adv-auth.md
@@ -11,7 +11,7 @@ Authentication
     'components' => [
         // ...
         'authClientCollection' => [
-            'class' => 'yii\authclient\Collection',
+            'class' => 'humhub\modules\user\authclient\Collection',
             'clients' => [
                 'github' => [
                     'class' => 'yii\authclient\clients\GitHub',
@@ -46,7 +46,7 @@ Authentication
     'components' => [
         // ...
         'authClientCollection' => [
-            'class' => 'yii\authclient\Collection',
+            'class' => 'humhub\modules\user\authclient\Collection',
             'clients' => [
                 'facebook' => [
                     'class' => 'yii\authclient\clients\Facebook',


### PR DESCRIPTION
fixed class name in auth config example.

must be `humhub\modules\user\authclient\Collection` otherwise password auth will not work anymore.