### PR TITLE
cleanup overall usage of redirect()

### DIFF
--- a/protected/humhub/components/Application.php
+++ b/protected/humhub/components/Application.php
@@ -31,7 +31,7 @@ class Application extends \yii\web\Application
          * Check if it's already installed - if not force controller module
          */
         if (!$this->params['installed'] && $this->controller->module != null && $this->controller->module->id != 'installer') {
-            $this->controller->redirect(\yii\helpers\Url::to(['/installer/index']));
+            $this->controller->redirect(['/installer/index']);
             return false;
         }
 

--- a/protected/humhub/components/behaviors/AccessControl.php
+++ b/protected/humhub/components/behaviors/AccessControl.php
@@ -48,7 +48,8 @@ class AccessControl extends \yii\base\ActionFilter
         $identity = Yii::$app->user->getIdentity();
         if($identity != null && !$identity->isActive()) {
             Yii::$app->user->logout();
-            Yii::$app->response->redirect(Yii::$app->urlManager->createUrl('user/auth/login'));
+            Yii::$app->response->redirect(['/user/auth/login']);
+            return false;
         }
 
         if (Yii::$app->user->isGuest) {

--- a/protected/humhub/modules/admin/controllers/GroupController.php
+++ b/protected/humhub/modules/admin/controllers/GroupController.php
@@ -62,7 +62,7 @@ class GroupController extends Controller
         
         if ($group->load(Yii::$app->request->post()) && $group->validate()) {
             $group->save();
-            $this->redirect(Url::toRoute(["/admin/group/manage-group-users", 'id' => $group->id]));
+            return $this->redirect(['/admin/group/manage-group-users', 'id' => $group->id]);
         }
         
         return $this->render('edit', [
@@ -113,7 +113,7 @@ class GroupController extends Controller
         $this->forcePostRequest();
         $group = Group::findOne(['id' => Yii::$app->request->get('id')]);
         $group->removeUser(Yii::$app->request->get('userId'));
-        $this->redirect(Url::toRoute(["/admin/group/manage-group-users", 'id' => $group->id]));
+        return $this->redirect(['/admin/group/manage-group-users', 'id' => $group->id]);
     }
 
     /**
@@ -135,7 +135,7 @@ class GroupController extends Controller
             $group->delete();
         }
         
-        $this->redirect(Url::toRoute("/admin/group"));
+        return $this->redirect(['/admin/group']);
     }
     
     public function actionEditManagerRole()
@@ -171,7 +171,7 @@ class GroupController extends Controller
         if($form->load(Yii::$app->request->post()) && $form->validate()) {
             $form->save();
         }
-        $this->redirect(Url::toRoute(["/admin/group/manage-group-users", 'id' => $form->groupId]));
+        return $this->redirect(['/admin/group/manage-group-users', 'id' => $form->groupId]);
     }
     
     public function actionNewMemberSearch()

--- a/protected/humhub/modules/admin/controllers/IndexController.php
+++ b/protected/humhub/modules/admin/controllers/IndexController.php
@@ -25,7 +25,7 @@ class IndexController extends Controller
      */
     public function actionIndex()
     {
-        return Yii::$app->response->redirect(Url::toRoute('/admin/setting'));
+        return $this->redirect(['/admin/setting']);
     }
 
 }

--- a/protected/humhub/modules/admin/controllers/LoggingController.php
+++ b/protected/humhub/modules/admin/controllers/LoggingController.php
@@ -46,7 +46,7 @@ class LoggingController extends Controller
     {
         $this->forcePostRequest();
         \humhub\modules\admin\models\Log::deleteAll();
-        $this->redirect(Url::toRoute('index'));
+        return $this->redirect(['index']);
     }
 
 }

--- a/protected/humhub/modules/admin/controllers/SettingController.php
+++ b/protected/humhub/modules/admin/controllers/SettingController.php
@@ -51,7 +51,7 @@ class SettingController extends Controller
 
     public function actionIndex()
     {
-        Yii::$app->response->redirect(Url::toRoute('basic'));
+        return $this->redirect(['basic']);
     }
 
     /**
@@ -106,7 +106,7 @@ class SettingController extends Controller
 
             // set flash message
             Yii::$app->getSession()->setFlash('data-saved', Yii::t('AdminModule.controllers_SettingController', 'Saved'));
-            return Yii::$app->response->redirect(Url::toRoute('/admin/setting/basic'));
+            return $this->redirect(['/admin/setting/basic']);
         }
 
         return $this->render('basic', array('model' => $form));
@@ -213,7 +213,7 @@ class SettingController extends Controller
             // set flash message
             Yii::$app->getSession()->setFlash('data-saved', Yii::t('AdminModule.controllers_SettingController', 'Saved'));
 
-            Yii::$app->response->redirect(Url::toRoute('/admin/setting/authentication-ldap'));
+            return $this->redirect(['/admin/setting/authentication-ldap']);
         }
 
 
@@ -229,7 +229,7 @@ class SettingController extends Controller
                 $userCount = $ldap->count(Setting::Get('userFilter', 'authentication_ldap'), Setting::Get('baseDn', 'authentication_ldap'), \Zend\Ldap\Ldap::SEARCH_SCOPE_SUB);
             } catch (\Zend\Ldap\Exception\LdapException $ex) {
                 $errorMessage = $ex->getMessage();
-            } catch (Exception $ex) {
+            } catch (\Exception $ex) {
                 $errorMessage = $ex->getMessage();
             }
         }
@@ -237,9 +237,10 @@ class SettingController extends Controller
         return $this->render('authentication_ldap', array('model' => $form, 'enabled' => $enabled, 'userCount' => $userCount, 'errorMessage' => $errorMessage));
     }
 
-    public function actionLdapRefresh() {
+    public function actionLdapRefresh()
+    {
         Ldap::getInstance()->refreshUsers();
-        Yii::$app->response->redirect(Url::toRoute('/admin/setting/authentication-ldap'));
+        return $this->redirect(['/admin/setting/authentication-ldap']);
     }
     
     /**
@@ -262,7 +263,7 @@ class SettingController extends Controller
             // set flash message
             Yii::$app->getSession()->setFlash('data-saved', Yii::t('AdminModule.controllers_SettingController', 'Saved and flushed cache'));
 
-            return Yii::$app->response->redirect(Url::toRoute('/admin/setting/caching'));
+            return $this->redirect(['/admin/setting/caching']);
         }
 
         $cacheTypes = array(
@@ -285,7 +286,7 @@ class SettingController extends Controller
         if ($form->load(Yii::$app->request->post()) && $form->validate()) {
             $form->trackingHtmlCode = Setting::SetText('trackingHtmlCode', $form->trackingHtmlCode);
             Yii::$app->getSession()->setFlash('data-saved', Yii::t('AdminModule.controllers_SettingController', 'Saved'));
-            Yii::$app->response->redirect(Url::toRoute('/admin/setting/statistic'));
+            return $this->redirect(['/admin/setting/statistic']);
         }
 
         return $this->render('statistic', array('model' => $form));
@@ -348,7 +349,7 @@ class SettingController extends Controller
             // set flash message
             Yii::$app->getSession()->setFlash('data-saved', Yii::t('AdminModule.controllers_SettingController', 'Saved'));
 
-            Yii::$app->response->redirect(Url::toRoute('/admin/setting/mailing-server'));
+            return $this->redirect(['/admin/setting/mailing-server']);
         }
 
         $encryptionTypes = array('' => 'None', 'ssl' => 'SSL', 'tls' => 'TLS');
@@ -395,7 +396,7 @@ class SettingController extends Controller
                 DynamicConfig::rewrite();
 
                 Yii::$app->getSession()->setFlash('data-saved', Yii::t('AdminModule.controllers_SettingController', 'Saved'));
-                Yii::$app->response->redirect(Url::toRoute('/admin/setting/design'));
+                return $this->redirect(['/admin/setting/design']);
             }
         }
 
@@ -417,7 +418,7 @@ class SettingController extends Controller
 
         if ($form->load(Yii::$app->request->post()) && $form->validate()) {
             $form->canAdminAlwaysDeleteContent = Setting::Set('canAdminAlwaysDeleteContent', $form->canAdminAlwaysDeleteContent, 'security');
-            Yii::$app->response->redirect(Url::toRoute('/admin/setting/security'));
+            return $this->redirect(['/admin/setting/security']);
         }
         return $this->render('security', array('model' => $form));
     }
@@ -452,7 +453,7 @@ class SettingController extends Controller
             // set flash message
             Yii::$app->getSession()->setFlash('data-saved', Yii::t('AdminModule.controllers_SettingController', 'Saved'));
 
-            return Yii::$app->response->redirect(Url::toRoute('/admin/setting/file'));
+            return $this->redirect(['/admin/setting/file']);
         }
 
         // Determine PHP Upload Max FileSize
@@ -501,7 +502,7 @@ class SettingController extends Controller
 
             // set flash message
             Yii::$app->getSession()->setFlash('data-saved', Yii::t('AdminModule.controllers_ProxyController', 'Saved'));
-            return Yii::$app->response->redirect(Url::toRoute('/admin/setting/proxy'));
+            return $this->redirect(['/admin/setting/proxy']);
         }
 
         return $this->render('proxy', array('model' => $form));
@@ -539,7 +540,7 @@ class SettingController extends Controller
             $providers[$form->prefix] = $form->endpoint;
             UrlOembed::setProviders($providers);
 
-            return Yii::$app->response->redirect(Url::toRoute('/admin/setting/oembed'));
+            return $this->redirect(['/admin/setting/oembed']);
         }
 
         return $this->render('oembed_edit', array('model' => $form, 'prefix' => $prefix));
@@ -559,7 +560,7 @@ class SettingController extends Controller
             unset($providers[$prefix]);
             UrlOembed::setProviders($providers);
         }
-        return Yii::$app->response->redirect(Url::toRoute('/admin/setting/oembed'));
+        return $this->redirect(['/admin/setting/oembed']);
     }
 
     /**

--- a/protected/humhub/modules/admin/controllers/SpaceController.php
+++ b/protected/humhub/modules/admin/controllers/SpaceController.php
@@ -59,7 +59,7 @@ class SpaceController extends Controller
 
             // set flash message
             Yii::$app->getSession()->setFlash('data-saved', Yii::t('AdminModule.controllers_SpaceController', 'Saved'));
-            $this->redirect(Url::toRoute('settings'));
+            return $this->redirect(['settings']);
         }
 
         return $this->render('settings', array('model' => $form));

--- a/protected/humhub/modules/admin/controllers/UserController.php
+++ b/protected/humhub/modules/admin/controllers/UserController.php
@@ -10,6 +10,7 @@ namespace humhub\modules\admin\controllers;
 
 use Yii;
 use yii\helpers\Url;
+use yii\web\HttpException;
 use humhub\compat\HForm;
 use humhub\modules\user\models\forms\Registration;
 use humhub\modules\admin\components\Controller;
@@ -134,7 +135,7 @@ class UserController extends Controller
         if ($form->submitted('save') && $form->validate()) {
             if ($form->save()) {
                 
-                return $this->redirect(Url::toRoute('/admin/user'));
+                return $this->redirect(['/admin/user']);
             }
         }
 
@@ -146,7 +147,7 @@ class UserController extends Controller
         }
 
         if ($form->submitted('delete')) {
-            return $this->redirect(Url::toRoute(['/admin/user/delete', 'id' => $user->id]));
+            return $this->redirect(['/admin/user/delete', 'id' => $user->id]);
         }
 
         return $this->render('edit', array('hForm' => $form));
@@ -158,7 +159,7 @@ class UserController extends Controller
         $registration->enableEmailField = true;
         $registration->enableUserApproval = false;
         if ($registration->submitted('save') && $registration->validate() && $registration->register()) {
-            return $this->redirect(Url::to(['edit', 'id' => $registration->getUser()->id]));
+            return $this->redirect(['edit', 'id' => $registration->getUser()->id]);
         }
         return $this->render('add', array('hForm' => $registration));
     }
@@ -192,7 +193,7 @@ class UserController extends Controller
                 }
             }
             $user->delete();
-            return $this->redirect(Url::to(['/admin/user']));
+            return $this->redirect(['/admin/user']);
         }
 
         return $this->render('delete', array('model' => $user));

--- a/protected/humhub/modules/admin/controllers/UserProfileController.php
+++ b/protected/humhub/modules/admin/controllers/UserProfileController.php
@@ -10,6 +10,7 @@ namespace humhub\modules\admin\controllers;
 
 use Yii;
 use yii\helpers\Url;
+use yii\web\HttpException;
 use humhub\compat\HForm;
 use humhub\modules\admin\components\Controller;
 use humhub\modules\user\models\ProfileFieldCategory;
@@ -53,7 +54,7 @@ class UserProfileController extends Controller
         $category->translation_category = $category->getTranslationCategory();
 
         if ($category->load(Yii::$app->request->post()) && $category->validate() && $category->save()) {
-            return $this->redirect(Url::to(['/admin/user-profile']));
+            return $this->redirect(['/admin/user-profile']);
         }
 
         return $this->render('editCategory', array('category' => $category));
@@ -75,7 +76,7 @@ class UserProfileController extends Controller
 
         $category->delete();
 
-        return $this->redirect(Url::to(['/admin/user-profile']));
+        return $this->redirect(['/admin/user-profile']);
     }
 
     public function actionEditField()
@@ -135,12 +136,12 @@ class UserProfileController extends Controller
             $fieldType = $form->models[$field->field_type_class];
 
             if ($field->save() && $fieldType->save()) {
-                return $this->redirect(Url::to(['/admin/user-profile']));
+                return $this->redirect(['/admin/user-profile']);
             }
         }
         if ($form->submitted('delete')) {
             $field->delete();
-            return $this->redirect(Url::to(['/admin/user-profile']));
+            return $this->redirect(['/admin/user-profile']);
         }
 
 

--- a/protected/humhub/modules/directory/controllers/DirectoryController.php
+++ b/protected/humhub/modules/directory/controllers/DirectoryController.php
@@ -64,11 +64,11 @@ class DirectoryController extends \humhub\modules\directory\components\Controlle
      */
     public function actionIndex()
     {
-
-        if (\humhub\modules\user\models\Group::find()->count() > 1)
-            $this->redirect(Url::to(['groups']));
-        else
-            $this->redirect(Url::to(['members']));
+        if (\humhub\modules\user\models\Group::find()->count() > 1) {
+            return $this->redirect(['groups']);
+        } else {
+            return $this->redirect(['members']);
+        }
     }
 
     /**

--- a/protected/humhub/modules/installer/controllers/ConfigController.php
+++ b/protected/humhub/modules/installer/controllers/ConfigController.php
@@ -57,14 +57,14 @@ class ConfigController extends Controller
 
             // Database Connection seems not to work
             if (!$this->module->checkDBConnection()) {
-                $this->redirect(Url::to(['/installer/setup']));
+                $this->redirect(['/installer/setup']);
                 return false;
             }
 
             // When not at index action, verify that database is not already configured
             if ($action->id != 'finished') {
                 if ($this->module->isConfigured()) {
-                    $this->redirect(Url::to(['finished']));
+                    $this->redirect(['finished']);
                     return false;
                 }
             }
@@ -480,7 +480,7 @@ class ConfigController extends Controller
 
         \humhub\libs\DynamicConfig::rewrite();
 
-        $this->redirect(['finished']);
+        return $this->redirect(['finished']);
     }
 
     /**

--- a/protected/humhub/modules/installer/controllers/IndexController.php
+++ b/protected/humhub/modules/installer/controllers/IndexController.php
@@ -36,9 +36,9 @@ class IndexController extends Controller
     public function actionGo()
     {
         if ($this->module->checkDBConnection()) {
-            return $this->redirect(Url::to(['setup/init']));
+            return $this->redirect(['setup/init']);
         } else {
-            return $this->redirect(Url::to(['setup/prerequisites']));
+            return $this->redirect(['setup/prerequisites']);
         }
     }
 

--- a/protected/humhub/modules/installer/controllers/SetupController.php
+++ b/protected/humhub/modules/installer/controllers/SetupController.php
@@ -28,7 +28,7 @@ class SetupController extends Controller
 
     public function actionIndex()
     {
-        return $this->redirect(Url::to(['prerequisites']));
+        return $this->redirect(['prerequisites']);
     }
 
     /**
@@ -106,10 +106,8 @@ class SetupController extends Controller
 
                 DynamicConfig::save($config);
 
-                return $this->redirect(array('init'));
-            } catch (Exception $e) {
-                $errorMessage = $e->getMessage();
-            } catch (\yii\base\Exception $e) {
+                return $this->redirect(['init']);
+            } catch (\Exception $e) {
                 $errorMessage = $e->getMessage();
             }
         }
@@ -125,7 +123,7 @@ class SetupController extends Controller
     {
 
         if (!$this->module->checkDBConnection()) {
-            return $this->redirect(Url::to(['/installer/setup/database']));
+            return $this->redirect(['/installer/setup/database']);
         }
 
         // Flush Caches
@@ -141,7 +139,7 @@ class SetupController extends Controller
 
         $this->module->setDatabaseInstalled();
 
-        return $this->redirect(Url::to(['/installer/config/index']));
+        return $this->redirect(['/installer/config/index']);
     }
 
 }

--- a/protected/humhub/modules/notification/controllers/EntryController.php
+++ b/protected/humhub/modules/notification/controllers/EntryController.php
@@ -59,7 +59,7 @@ class EntryController extends Controller
         }
 
         // Redirect to notification URL
-        $this->redirect($notification->getUrl());
+        return $this->redirect($notification->getUrl());
     }
 
 }

--- a/protected/humhub/modules/space/controllers/CreateController.php
+++ b/protected/humhub/modules/space/controllers/CreateController.php
@@ -41,7 +41,7 @@ class CreateController extends Controller
 
     public function actionIndex()
     {
-        return $this->redirect(Url::to(['create']));
+        return $this->redirect(['create']);
     }
 
     /**

--- a/protected/humhub/modules/space/controllers/MembershipController.php
+++ b/protected/humhub/modules/space/controllers/MembershipController.php
@@ -146,7 +146,7 @@ class MembershipController extends \humhub\modules\content\components\ContentCon
 
         $space->removeMember();
 
-        return $this->redirect(Url::home());
+        return $this->goHome();
     }
 
     /**

--- a/protected/humhub/modules/space/modules/manage/controllers/DefaultController.php
+++ b/protected/humhub/modules/space/modules/manage/controllers/DefaultController.php
@@ -82,7 +82,7 @@ class DefaultController extends Controller
         $model = new DeleteForm();
         if ($model->load(Yii::$app->request->post()) && $model->validate()) {
             $this->getSpace()->delete();
-            return $this->redirect(Url::home());
+            return $this->goHome();
         }
 
         return $this->render('delete', array('model' => $model, 'space' => $this->getSpace()));

--- a/protected/humhub/modules/tour/controllers/TourController.php
+++ b/protected/humhub/modules/tour/controllers/TourController.php
@@ -101,7 +101,7 @@ class TourController extends \humhub\components\Controller
         if ($user->id == 1 && $user->load(Yii::$app->request->post()) && $user->validate() && $user->save()) {
             if ($profile->load(Yii::$app->request->post()) && $profile->validate() && $profile->save()) {
                 $user->setSetting("welcome", 1, "tour");
-                return $this->redirect(Url::to(['/dashboard/dashboard']));
+                return $this->redirect(['/dashboard/dashboard']);
             }
         }
 

--- a/protected/humhub/modules/user/controllers/AccountController.php
+++ b/protected/humhub/modules/user/controllers/AccountController.php
@@ -74,7 +74,7 @@ class AccountController extends BaseAccountController
             $user->save();
 
             Yii::$app->getSession()->setFlash('data-saved', Yii::t('UserModule.controllers_AccountController', 'Saved'));
-            return $this->redirect(Url::to(['edit']));
+            return $this->redirect(['edit']);
         }
 
         return $this->render('edit', array('hForm' => $form));
@@ -208,7 +208,7 @@ class AccountController extends BaseAccountController
             $user->enableModule($moduleId);
         }
 
-        return $this->redirect(Url::toRoute('/user/account/edit-modules'));
+        return $this->redirect(['/user/account/edit-modules']);
     }
 
     public function actionDisableModule()
@@ -222,7 +222,7 @@ class AccountController extends BaseAccountController
             $user->disableModule($moduleId);
         }
 
-        return $this->redirect(Url::toRoute('/user/account/edit-modules'));
+        return $this->redirect(['/user/account/edit-modules']);
     }
 
     /**
@@ -251,7 +251,7 @@ class AccountController extends BaseAccountController
         if (!$isSpaceOwner && $model->load(Yii::$app->request->post()) && $model->validate()) {
             $user->delete();
             Yii::$app->user->logout();
-            $this->redirect(Yii::$app->homeUrl);
+            return $this->goHome();
         }
 
         return $this->render('delete', array(

--- a/protected/humhub/modules/user/controllers/AuthController.php
+++ b/protected/humhub/modules/user/controllers/AuthController.php
@@ -68,7 +68,7 @@ class AuthController extends Controller
     {
         // If user is already logged in, redirect him to the dashboard
         if (!Yii::$app->user->isGuest) {
-            return $this->redirect(Yii::$app->user->returnUrl);
+            return $this->goBack();
         }
 
         // Login Form Handling
@@ -206,7 +206,7 @@ class AuthController extends Controller
             Yii::$app->getResponse()->getCookies()->add($cookie);
         }
 
-        $this->redirect(($this->module->logoutUrl) ? $this->module->logoutUrl : Yii::$app->homeUrl);
+        return $this->redirect(($this->module->logoutUrl) ? $this->module->logoutUrl : Yii::$app->homeUrl);
     }
 
     /**

--- a/protected/humhub/modules/user/controllers/RegistrationController.php
+++ b/protected/humhub/modules/user/controllers/RegistrationController.php
@@ -80,7 +80,7 @@ class RegistrationController extends Controller
             // Autologin when user is enabled (no approval required)
             if ($registration->getUser()->status === User::STATUS_ENABLED) {
                 Yii::$app->user->switchIdentity($registration->models['User']);
-                return $this->redirect(Url::to(['/dashboard/dashboard']));
+                return $this->redirect(['/dashboard/dashboard']);
             }
 
             return $this->render('success', [


### PR DESCRIPTION
- make sure response instance is returned and nothing else is executed
  after redirect
- use consistent syntax, avoid extra calls to Url helper, which are not
  needed
- use controller redirect methods instead of
  Yii::$app->response->redirect()
- use goHome() and goBack() shortcut methods where applicable
- fixed some excpetion imports and catch blocks I found while fixing the
  above.