### PR TITLE
Apply aad2063e6ca3ca87d708956ad173fbc45fe9db1f to v1.1-dev

### DIFF
--- a/protected/config/common.php
+++ b/protected/config/common.php
@@ -1,9 +1,4 @@
 <?php
 
 return [
-    'params' => [
-        'moduleAutoloadPaths' => [
-            '/srv/www/translate.humhub.org/modules'
-        ]
-    ],
 ];


### PR DESCRIPTION
aad2063e6ca3ca87d708956ad173fbc45fe9db1f has been fixed on master, applied it to v1.1-dev too.