### PR TITLE
Removed share-panel styles

### DIFF
--- a/themes/HumHub/css/theme.less
+++ b/themes/HumHub/css/theme.less
@@ -3009,36 +3009,3 @@ img.bounceIn {
   border: 1px solid @info !important;
   background: lighten(@info, 25%) !important;
 }
-
-/**** Share Widget ****/
-
-#share-panel {
-
-  .share-icon {
-    float: left;
-    font-size: 20px;
-    width: 20px;
-  }
-
-  .share-text {
-    float: left;
-    padding: 4px 0 0 5px;
-  }
-
-  .share-icon-twitter {
-    color: #55acee;
-  }
-
-  .share-icon-facebook {
-    color: #3a5795;
-  }
-
-  .share-icon-google-plus {
-    color: #f44336;
-  }
-
-  .share-icon-linkedin {
-    color: #0177b5;
-  }
-
-}


### PR DESCRIPTION
share widget has been removed in 0471bdc229dfe80e8b1ef03f3535037561513257 but style is still present in .less file in the theme.

Am I correct, that version 1.1 is now developed on master?