### PR TITLE
allow pre-selected visibility for space creation

### DIFF
--- a/protected/humhub/modules/space/controllers/CreateController.php
+++ b/protected/humhub/modules/space/controllers/CreateController.php
@@ -49,16 +49,16 @@ class CreateController extends Controller
     /**
      * Creates a new Space
      */
-    public function actionCreate()
+    public function actionCreate($visibility = null)
     {
         // User cannot create spaces (public or private)
-        if (!Yii::$app->user->permissionmanager->can(new CreatePublicSpace) && !Yii::$app->user->permissionmanager->can(new CreatePrivateSpace())) {
+        if (!Yii::$app->user->permissionmanager->can(new CreatePublicSpace) && !Yii::$app->user->permissionmanager->can(new CreatePrivateSpace)) {
             throw new HttpException(400, 'You are not allowed to create spaces!');
         }
 
         $model = $this->createSpaceModel();
 
-        if ($model->load(Yii::$app->request->post()) && $model->validate() && $model->save()) {
+        if ($model->load(Yii::$app->request->post()) && $model->save()) {
             return $this->actionModules($model->id);
         }
 
@@ -69,8 +69,13 @@ class CreateController extends Controller
         if (Yii::$app->user->permissionmanager->can(new CreatePublicSpace)) {
             $visibilityOptions[Space::VISIBILITY_REGISTERED_ONLY] = Yii::t('SpaceModule.base', 'Public (Members only)');
         }
-        if (Yii::$app->user->permissionmanager->can(new CreatePrivateSpace())) {
+        if (Yii::$app->user->permissionmanager->can(new CreatePrivateSpace)) {
             $visibilityOptions[Space::VISIBILITY_NONE] = Yii::t('SpaceModule.base', 'Private (Invisible)');
+        }
+
+        // allow setting pre-selected visibility
+        if ($visibility !== null && isset($visibilityOptions[$visibility])) {
+            $model->visibility = $visibility;
         }
 
         $joinPolicyOptions = [


### PR DESCRIPTION
this allows themes to create links for "create public space" and "create private space" like so:

create private space:

    Url::to(['/space/create/create', 'visibility' => \humhub\modules\space\models\Space::VISIBILITY_NONE])

also save() includes validate so the duplicate call has been removed.