### PR TITLE
Small Enhancement: add css class to collapsed panels

### DIFF
--- a/js/panelMenu.js
+++ b/js/panelMenu.js
@@ -6,6 +6,7 @@ function togglePanelUp($id) {
         // Animation complete.
         $('#' + $id + ' .panel-collapse').hide();
         $('#' + $id + ' .panel-expand').show();
+        $('#' + $id).addClass('panel-collapsed');
 
         $.cookie('pm_' + $id, 'collapsed', 5*365);
     });
@@ -19,6 +20,7 @@ function togglePanelDown($id) {
         // Animation complete.
         $('#' + $id + ' .panel-expand').hide();
         $('#' + $id + ' .panel-collapse').show();
+        $('#' + $id).removeClass('panel-collapsed');
 
         $.cookie('pm_' + $id, 'expanded', 5*365);
     });
@@ -45,6 +47,7 @@ function checkPanelMenuCookie($id) {
         // change menu to 'collapsed' state
         $('#' + $id + ' .panel-collapse').hide();
         $('#' + $id + ' .panel-expand').show();
+        $('#' + $id).addClass('panel-collapsed');
 
     }
 }


### PR DESCRIPTION
to allow adjusted styling for collapsed panels, that is different from
expanded panels add a css class `panel-collapsed` when panel is collapsed.
Works when panel is collapsed manually as well as with saved collapse status from cookie.

