### PR TITLE
Enh: removed unused ldap class reference since new auth. method

### DIFF
--- a/protected/humhub/modules/admin/controllers/SettingController.php
+++ b/protected/humhub/modules/admin/controllers/SettingController.php
@@ -13,7 +13,6 @@ use yii\helpers\Url;
 use humhub\models\Setting;
 use humhub\models\UrlOembed;
 use humhub\modules\admin\components\Controller;
-use humhub\modules\user\libs\Ldap;
 /**
  * SettingController 
  * 

--- a/protected/humhub/modules/user/Events.php
+++ b/protected/humhub/modules/user/Events.php
@@ -8,7 +8,6 @@ use humhub\modules\user\models\Password;
 use humhub\modules\user\models\Profile;
 use humhub\modules\user\models\Mentioning;
 use humhub\modules\user\models\Follow;
-use humhub\modules\user\libs\Ldap;
 use humhub\models\Setting;
 
 /**

--- a/protected/humhub/modules/user/models/forms/AccountLogin.php
+++ b/protected/humhub/modules/user/models/forms/AccountLogin.php
@@ -5,7 +5,6 @@ namespace humhub\modules\user\models\forms;
 use Yii;
 use yii\base\Model;
 use humhub\modules\user\models\User;
-use humhub\modules\user\libs\Ldap;
 use humhub\models\Setting;
 use yii\db\Expression;
 


### PR DESCRIPTION
Since "Enh #117: Refactored authentication (pluggable yii2-authclient support)" (https://github.com/humhub/humhub/commit/8191d4ef86e4490da1b0fa4d27f256de106f0f28) some lines of code are no longer used. Better to remove them.