### PR TITLE
fix following count

### DIFF
--- a/protected/humhub/modules/user/widgets/ProfileHeader.php
+++ b/protected/humhub/modules/user/widgets/ProfileHeader.php
@@ -69,7 +69,7 @@ class ProfileHeader extends \yii\base\Widget
             $countFriends = Friendship::getFriendsQuery($this->user)->count();
         }
 
-        $countFollowing = $this->user->getFollowingCount(User::className()) + $this->user->getFollowingCount(Space::className());
+        $countFollowing = $this->user->getFollowingCount(User::className());
 
         $countUserSpaces = Membership::getUserSpaceQuery($this->user)
                 ->andWhere(['!=', 'space.visibility', Space::VISIBILITY_NONE])


### PR DESCRIPTION
If we visit someones user profile, which is subscribed for other users and spaces, we will see the total number of subscribed entities (users and spaces). But If we open this window we'll see only followed users.
![joxi_screenshot_1471609624899](https://cloud.githubusercontent.com/assets/6141193/17809772/45076e10-6632-11e6-94c8-f0b040aa3995.png)
![joxi_screenshot_1471609664173](https://cloud.githubusercontent.com/assets/6141193/17809776/4723d2ec-6632-11e6-8ff9-6af4160b5772.png)


