### PR TITLE
Fixed file upload list to work with new models

### DIFF
--- a/protected/humhub/modules/content/components/ActiveQueryContent.php
+++ b/protected/humhub/modules/content/components/ActiveQueryContent.php
@@ -96,9 +96,9 @@ class ActiveQueryContent extends \yii\db\ActiveQuery
      * 
      * @inheritdoc
      * 
-     * @param type $condition
-     * @param type $params
-     * @return type
+     * @param array|string $condition
+     * @param array $params
+     * @return $this
      */
     public function where($condition, $params = array())
     {

--- a/protected/humhub/modules/file/widgets/FileUploadList.php
+++ b/protected/humhub/modules/file/widgets/FileUploadList.php
@@ -1,6 +1,8 @@
 <?php
 
 namespace humhub\modules\file\widgets;
+use humhub\components\ActiveRecord;
+use humhub\modules\file\models\File;
 
 /**
  * FileUploadListWidget works in combination of FileUploadButtonWidget and is
@@ -24,7 +26,7 @@ class FileUploadList extends \yii\base\Widget
     /**
      * If object is set, display also already uploaded files
      *
-     * @var HActiveRecord
+     * @var ActiveRecord
      */
     public $object = null;
 
@@ -36,7 +38,11 @@ class FileUploadList extends \yii\base\Widget
 
         $files = array();
         if ($this->object !== null) {
-            $files = \humhub\modules\file\models\File::getFilesOfObject($this->object);
+            if ($this->object->isNewRecord && $this->object->getRelation('content', false) !== null) {
+                $files = File::findAll(['guid' => array_map('trim', explode(',', $this->object->content->attachFileGuidsAfterSave))]);
+            } else {
+                $files = File::getFilesOfObject($this->object);
+            }
         }
 
         return $this->render('fileUploadList', array(
@@ -46,5 +52,3 @@ class FileUploadList extends \yii\base\Widget
     }
 
 }
-
-?>


### PR DESCRIPTION
When using FileUploadList in a form with normal validation (not client
validation) all uploaded files are lost after a validation error occurs.

This fixes the widget to keep files in that case, i.e. when
$model->isNewRecord is true, it will take the file list from the post
field assigned to the record instead of from the database.