### PR TITLE
Fix user profile banner error.

### DIFF
--- a/resources/user/profileHeaderImageUpload.js
+++ b/resources/user/profileHeaderImageUpload.js
@@ -73,14 +73,12 @@ $(function() {
                     } else {
                         $('#user-banner-image').attr('src', data.result.files.url + '&c=' + Math.random());
                         $('#user-banner-image').addClass('animated bounceIn');
+                        $('#banner-image-upload-edit-button').show();
+                        $('#deleteLinkPost_modal_bannerimagedelete').show();
                     }
 
                     $('#banner-image-upload-loader').hide();
                     $('#banner-image-upload-bar .progress-bar').css('width', '0%');
-                    $('#banner-image-upload-edit-button').show();
-                    $('#deleteLinkPost_modal_bannerimagedelete').show();
-
-
                 }
             }).bind('fileuploadstart', function(e) {
                 $('#banner-image-upload-loader').show();


### PR DESCRIPTION
Got an error:

> yii\base\ErrorException: imagecreatefromjpeg(/home/humhub/humhub/uploads/profile_image/banner/db6d3351-957f-49b9-8248-343de23a266a_org.jpg): failed to open stream: No such file or directory in /home/humhub/humhub/protected/humhub/libs/ProfileImage.php:134

That was because banner image size was too big. And after getting error-window, we could crop or delete our non-existing image.