### PR TITLE
Add var keyword for container in like.js

### DIFF
--- a/resources/like/like.js
+++ b/resources/like/like.js
@@ -11,7 +11,7 @@ function initLikeModule() {
     // Handle Click on a Like Button
     $('.likeAnchor').on("click", function (event) {
         event.preventDefault();
-        likeContainerDiv = $(this).closest(".likeLinkContainer");
+        var likeContainerDiv = $(this).closest(".likeLinkContainer");
 
         $.ajax({
             dataType: "json",


### PR DESCRIPTION
It can be an issue on slow connections.

When two requests are sent concurrently , `likeContainerDiv` is the same for both requests.