### PR TITLE
Load JS on HEAD instead of BODY

### DIFF
--- a/protected/humhub/assets/AppAsset.php
+++ b/protected/humhub/assets/AppAsset.php
@@ -22,7 +22,7 @@ class AppAsset extends AssetBundle
         'css/flatelements.css',
         'resources/at/jquery.atwho.css',
     ];
-    public $jsOptions = ['position' => \yii\web\View::POS_BEGIN];
+    public $jsOptions = ['position' => \yii\web\View::POS_HEAD];
     public $js = [
         'js/ekko-lightbox-modified.js',
         'js/modernizr.js',


### PR DESCRIPTION
Since the `<head>` loads before the `<body>`, placing JS in the <head> ensures that it is available when needed.