### PR TITLE
Load .min. versions of jQuery and Bootstrap Assets

### DIFF
--- a/protected/humhub/config/common.php
+++ b/protected/humhub/config/common.php
@@ -86,6 +86,17 @@ $config = [
         'assetManager' => [
             'class' => '\humhub\components\AssetManager',
             'appendTimestamp' => true,
+            'bundles' => [
+                'yii\web\JqueryAsset' => [
+                    'js' => [ YII_ENV_DEV ? 'jquery.js' : 'jquery.min.js' ]
+                ],
+                'yii\bootstrap\BootstrapAsset' => [
+                    'css' => [ YII_ENV_DEV ? 'css/bootstrap.css' : 'css/bootstrap.min.css' ]
+                ],
+                'yii\bootstrap\BootstrapPluginAsset' => [
+                    'js' => [ YII_ENV_DEV ? 'js/bootstrap.js' : 'js/bootstrap.min.js' ]
+                ],
+            ],
         ],
         'view' => [
             'class' => '\humhub\components\View',


### PR DESCRIPTION
This way in `Development` environment you'll have the unminified version, but in `Production` Yii2 will use the minified file.