### PR TITLE
Clear old logs

### DIFF
--- a/protected/humhub/modules/admin/Events.php
+++ b/protected/humhub/modules/admin/Events.php
@@ -9,6 +9,7 @@
 namespace humhub\modules\admin;
 
 use Yii;
+use humhub\modules\admin\models\Log;
 
 
 /**
@@ -45,6 +46,15 @@ class Events extends \yii\base\Object
     public static function onCronDailyRun($event)
     {
         $controller = $event->sender;
+
+        $controller->stdout("Deleting old logs... ");
+        
+        $settings = Yii::$app->settings;
+        $timeAgo = strtotime($settings->get('logsDateLimit'));
+        $deleted = Log::deleteAll(['<', 'log_time', $timeAgo]);
+
+        $controller->stdout('done - ' . $deleted . ' records deleted.' . PHP_EOL, \yii\helpers\Console::FG_GREEN);
+
 
         if (!Yii::$app->getModule('admin')->dailyCheckForNewVersion) {
             return;

--- a/protected/humhub/modules/admin/controllers/SettingController.php
+++ b/protected/humhub/modules/admin/controllers/SettingController.php
@@ -12,6 +12,7 @@ use Yii;
 use humhub\libs\ThemeHelper;
 use humhub\models\UrlOembed;
 use humhub\modules\admin\components\Controller;
+use humhub\modules\admin\models\Log;
 
 /**
  * SettingController
@@ -224,6 +225,39 @@ class SettingController extends Controller
     {
         $providers = UrlOembed::getProviders();
         return $this->render('oembed', array('providers' => $providers));
+    }
+
+    public function actionLogs()
+    {
+        $logsCount = Log::find()->count();
+        $dating = Log::find()
+            ->orderBy('log_time', 'asc')
+            ->limit(1)
+            ->one();
+
+        // I wish..
+        if ($dating) {
+            $dating = date('Y-m-d H:i:s', $dating->log_time);
+        } else {
+            $dating = "the begining of time";
+        }
+
+        $form = new \humhub\modules\admin\models\forms\LogsSettingsForm;
+        $limitAgeOptions = $form->options;
+        if ($form->load(Yii::$app->request->post()) && $form->validate() && $form->save()) {
+
+            $timeAgo = strtotime($form->logsDateLimit);
+            Log::deleteAll(['<', 'log_time', $timeAgo]);
+            Yii::$app->getSession()->setFlash('data-saved', Yii::t('AdminModule.controllers_SettingController', 'Saved'));
+            return $this->redirect(['/admin/setting/logs']);
+        }
+
+        return $this->render('logs', array(
+            'logsCount' => $logsCount,
+            'model' => $form,
+            'limitAgeOptions' => $limitAgeOptions,
+            'dating' => $dating
+        ));
     }
 
     /**

--- a/protected/humhub/modules/admin/models/forms/LogsSettingsForm.php
+++ b/protected/humhub/modules/admin/models/forms/LogsSettingsForm.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace humhub\modules\admin\models\forms;
+
+use Yii;
+
+/**
+ * LogsSettingsForm
+ * 
+ * @since 1.2
+ */
+class LogsSettingsForm extends \yii\base\Model
+{
+
+    public $logsDateLimit;
+
+    /**
+     * @inheritdoc
+     */
+    public function init()
+    {
+        parent::init();
+
+        $settingsManager = Yii::$app->settings;
+        $this->logsDateLimit = $settingsManager->get('logsDateLimit');
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getOptions()
+    {
+        return [
+            '-1 week' => Yii::t('AdminModule.forms_LogsSettingsForm', '1 week'),
+            '-2 weeks' => Yii::t('AdminModule.forms_LogsSettingsForm', '2 weeks'),
+            '-1 month' => Yii::t('AdminModule.forms_LogsSettingsForm', '1 month'),
+            '-3 months' => Yii::t('AdminModule.forms_LogsSettingsForm', '3 months'),
+            '-6 months' => Yii::t('AdminModule.forms_LogsSettingsForm', '6 months'),
+            '-1 year' => Yii::t('AdminModule.forms_LogsSettingsForm', '1 year'),
+            '' => Yii::t('AdminModule.forms_LogsSettingsForm', 'never'),
+        ];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function rules()
+    {
+        return array(
+            array('logsDateLimit', 'in', 'range' => array_keys($this->options)),
+        );
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function attributeLabels()
+    {
+        return array(
+            'logsDateLimit' => Yii::t('AdminModule.forms_StatisticSettingsForm', 'Maximum allowed age for logs.'),
+        );
+    }
+
+    /**
+     * Saves the form
+     * 
+     * @return boolean
+     */
+    public function save()
+    {
+        $settingsManager = Yii::$app->settings;
+        $settingsManager->set('logsDateLimit', $this->logsDateLimit);
+
+        return true;
+    }
+
+}

--- a/protected/humhub/modules/admin/views/setting/logs.php
+++ b/protected/humhub/modules/admin/views/setting/logs.php
@@ -1,0 +1,32 @@
+<?php
+
+use humhub\compat\CActiveForm;
+use humhub\compat\CHtml;
+
+
+?>
+<?php $this->beginContent('@admin/views/setting/_advancedLayout.php') ?>
+
+<p><?php echo Yii::t('AdminModule.views_setting_logs', 
+	'Old logs can significantly increase the size of your database while providing little information.')?></p>
+<p><?php echo Yii::t('AdminModule.views_setting_logs', 
+	'Currently there are {count} records in the database dating from {dating}.',
+	['count' => $logsCount, 'dating' => $dating])?></p>
+<br />
+
+<?php $form = CActiveForm::begin(); ?>
+
+<?php echo $form->errorSummary($model); ?>
+
+<div class="form-group">
+    <?php echo $form->labelEx($model, 'logsDateLimit'); ?>
+    <?php echo $form->dropDownList($model, 'logsDateLimit', $limitAgeOptions, array('class' => 'form-control')); ?>
+</div>
+<hr>
+
+<?php echo CHtml::submitButton(Yii::t('AdminModule.views_setting_logs', 'Save'), array('class' => 'btn btn-primary', 'data-ui-loader' => "")); ?>
+
+<?php echo \humhub\widgets\DataSaved::widget(); ?>
+<?php CActiveForm::end(); ?>
+
+<?php $this->endContent(); ?>

--- a/protected/humhub/modules/admin/widgets/AdvancedSettingMenu.php
+++ b/protected/humhub/modules/admin/widgets/AdvancedSettingMenu.php
@@ -69,6 +69,15 @@ class AdvancedSettingMenu extends \humhub\widgets\BaseMenu
             'isVisible' => Yii::$app->user->isAdmin(),
         ));
 
+        $this->addItem(array(
+            'label' => Yii::t('AdminModule.widgets_AdminMenuWidget', 'Logs'),
+            'url' => Url::toRoute('/admin/setting/logs'),
+            'icon' => '<i class="fa fa-terminal"></i>',
+            'sortOrder' => 600,
+            'isActive' => (Yii::$app->controller->module && Yii::$app->controller->module->id == 'admin' && Yii::$app->controller->id == 'setting' && (Yii::$app->controller->action->id == 'logs' || Yii::$app->controller->action->id == 'logs-edit')),
+            'isVisible' => Yii::$app->user->isAdmin(),
+        ));
+
 
         parent::init();
     }


### PR DESCRIPTION
Reason behind this pull request is that after one year of running in production, the logs table got to aprox. 5GB.

It lets the admin set a maximum age for logs. Logs older than this max age will be deleted by the daily cron.