### PR TITLE
removed created/updated_at/by fields from model rules

### DIFF
--- a/protected/humhub/modules/comment/models/Comment.php
+++ b/protected/humhub/modules/comment/models/Comment.php
@@ -8,8 +8,9 @@
 
 namespace humhub\modules\comment\models;
 
-use Yii;
+use humhub\modules\post\models\Post;
 use humhub\modules\content\components\ContentAddonActiveRecord;
+use Yii;
 
 /**
  * This is the model class for table "comment".
@@ -47,10 +48,9 @@ class Comment extends ContentAddonActiveRecord
      */
     public function rules()
     {
-        return array(
-            array(['created_by', 'updated_by'], 'integer'),
-            array(['message', 'created_at', 'updated_at'], 'safe'),
-        );
+        return [
+            [['message'], 'safe'],
+        ];
     }
 
     /**
@@ -67,7 +67,6 @@ class Comment extends ContentAddonActiveRecord
      */
     public function afterDelete()
     {
-
         try {
             $this->updateContentSearch();
         } catch (\yii\base\Exception $ex) {

--- a/protected/humhub/modules/content/models/Content.php
+++ b/protected/humhub/modules/content/models/Content.php
@@ -91,9 +91,8 @@ class Content extends \humhub\components\ActiveRecord
     public function rules()
     {
         return [
-            [['object_id', 'visibility', 'sticked', 'created_by', 'updated_by'], 'integer'],
+            [['object_id', 'visibility', 'sticked'], 'integer'],
             [['archived'], 'safe'],
-            [['created_at', 'updated_at'], 'safe'],
             [['guid'], 'string', 'max' => 45],
             [['object_model'], 'string', 'max' => 100],
             [['object_model', 'object_id'], 'unique', 'targetAttribute' => ['object_model', 'object_id'], 'message' => 'The combination of Object Model and Object ID has already been taken.'],
@@ -170,8 +169,9 @@ class Content extends \humhub\components\ActiveRecord
             }
         }
 
-        if ($this->created_by == "")
+        if ($this->created_by == "") {
             throw new Exception("Could not save content without created_by!");
+        }
 
         return parent::beforeSave($insert);
     }

--- a/protected/humhub/modules/content/models/Wall.php
+++ b/protected/humhub/modules/content/models/Wall.php
@@ -2,7 +2,7 @@
 
 namespace humhub\modules\content\models;
 
-
+use humhub\components\ActiveRecord;
 
 /**
  * This is the model class for table "wall".
@@ -15,7 +15,7 @@ namespace humhub\modules\content\models;
  * @property string $updated_at
  * @property integer $updated_by
  */
-class Wall extends \yii\db\ActiveRecord
+class Wall extends ActiveRecord
 {
     /**
      * @inheritdoc
@@ -32,8 +32,7 @@ class Wall extends \yii\db\ActiveRecord
     {
         return [
             [['object_model', 'object_id'], 'required'],
-            [['object_id', 'created_by', 'updated_by'], 'integer'],
-            [['created_at', 'updated_at'], 'safe'],
+            [['object_id'], 'integer'],
             [['object_model'], 'string', 'max' => 50]
         ];
     }

--- a/protected/humhub/modules/content/models/WallEntry.php
+++ b/protected/humhub/modules/content/models/WallEntry.php
@@ -2,7 +2,6 @@
 
 namespace humhub\modules\content\models;
 
-
 use humhub\components\ActiveRecord;
 
 /**
@@ -34,8 +33,7 @@ class WallEntry extends ActiveRecord
     {
         return [
             [['wall_id', 'content_id'], 'required'],
-            [['wall_id', 'content_id', 'created_by', 'updated_by'], 'integer'],
-            [['created_at', 'updated_at'], 'safe']
+            [['wall_id', 'content_id'], 'integer'],
         ];
     }
 

--- a/protected/humhub/modules/file/models/File.php
+++ b/protected/humhub/modules/file/models/File.php
@@ -83,14 +83,13 @@ class File extends \humhub\components\ActiveRecord
     public function rules()
     {
         return array(
-            array(['created_by', 'updated_by', 'size'], 'integer'),
+            array(['size'], 'integer'),
             array(['guid'], 'string', 'max' => 45),
             array(['mime_type'], 'string', 'max' => 150),
             array('filename', 'validateExtension'),
             array('filename', 'validateSize'),
             array('mime_type', 'match', 'not' => true, 'pattern' => '/[^a-zA-Z0-9\.ä\/\-]/', 'message' => Yii::t('FileModule.models_File', 'Invalid Mime-Type')),
             array(['file_name', 'title'], 'string', 'max' => 255),
-            array(['created_at', 'updated_at'], 'safe'),
         );
     }
 

--- a/protected/humhub/modules/like/models/Like.php
+++ b/protected/humhub/modules/like/models/Like.php
@@ -51,8 +51,7 @@ class Like extends ContentAddonActiveRecord
     {
         return array(
             array(['object_model', 'object_id'], 'required'),
-            array(['id', 'object_id', 'target_user_id', 'created_by', 'updated_by'], 'integer'),
-            array(['updated_at', 'created_at'], 'safe')
+            array(['id', 'object_id', 'target_user_id'], 'integer'),
         );
     }
 

--- a/protected/humhub/modules/post/models/Post.php
+++ b/protected/humhub/modules/post/models/Post.php
@@ -30,7 +30,7 @@ class Post extends ContentActiveRecord implements Searchable
     /**
      * @inheritdoc
      */
-    public $wallEntryClass = "humhub\modules\post\widgets\WallEntry";
+    public $wallEntryClass = 'humhub\modules\post\widgets\WallEntry';
 
     /**
      * @inheritdoc
@@ -48,8 +48,6 @@ class Post extends ContentActiveRecord implements Searchable
         return [
             [['message'], 'required'],
             [['message'], 'string'],
-            [['created_at', 'updated_at'], 'safe'],
-            [['created_by', 'updated_by'], 'integer'],
             [['url'], 'string', 'max' => 255]
         ];
     }

--- a/protected/humhub/modules/space/models/Membership.php
+++ b/protected/humhub/modules/space/models/Membership.php
@@ -3,6 +3,7 @@
 namespace humhub\modules\space\models;
 
 use Yii;
+use humhub\components\ActiveRecord;
 use humhub\modules\user\models\User;
 use humhub\modules\content\models\WallEntry;
 use humhub\modules\activity\models\Activity;
@@ -25,7 +26,7 @@ use humhub\modules\activity\models\Activity;
  * @property string $updated_at
  * @property integer $updated_by
  */
-class Membership extends \yii\db\ActiveRecord
+class Membership extends ActiveRecord
 {
 
     const STATUS_INVITED = 1;
@@ -47,9 +48,9 @@ class Membership extends \yii\db\ActiveRecord
     {
         return [
             [['space_id', 'user_id'], 'required'],
-            [['space_id', 'user_id', 'originator_user_id', 'status', 'created_by', 'updated_by'], 'integer'],
+            [['space_id', 'user_id', 'originator_user_id', 'status'], 'integer'],
             [['request_message'], 'string'],
-            [['last_visit', 'created_at', 'group_id', 'updated_at'], 'safe'],
+            [['last_visit', 'group_id'], 'safe'],
         ];
     }
 

--- a/protected/humhub/modules/space/models/Space.php
+++ b/protected/humhub/modules/space/models/Space.php
@@ -76,10 +76,9 @@ class Space extends ContentContainerActiveRecord implements \humhub\modules\sear
     public function rules()
     {
         $rules = [
-            [['join_policy', 'visibility', 'status', 'created_by', 'updated_by', 'auto_add_new_members', 'default_content_visibility'], 'integer'],
+            [['join_policy', 'visibility', 'status', 'auto_add_new_members', 'default_content_visibility'], 'integer'],
             [['name'], 'required'],
             [['description', 'tags', 'color'], 'string'],
-            [['created_at', 'updated_at'], 'safe'],
             [['join_policy'], 'in', 'range' => [0, 1, 2]],
             [['visibility'], 'in', 'range' => [0, 1, 2]],
             [['visibility'], 'checkVisibility'],

--- a/protected/humhub/modules/user/models/Group.php
+++ b/protected/humhub/modules/user/models/Group.php
@@ -9,6 +9,7 @@
 namespace humhub\modules\user\models;
 
 use Yii;
+use humhub\components\ActiveRecord;
 use humhub\modules\space\models\Space;
 
 
@@ -24,7 +25,7 @@ use humhub\modules\space\models\Space;
  * @property string $updated_at
  * @property integer $updated_by
  */
-class Group extends \yii\db\ActiveRecord
+class Group extends ActiveRecord
 {
 
     const SCENARIO_EDIT = 'edit';
@@ -47,9 +48,8 @@ class Group extends \yii\db\ActiveRecord
     {
         return [
             [['name'], 'required', 'on' => self::SCENARIO_EDIT],
-            [['space_id', 'created_by', 'updated_by'], 'integer'],
+            [['space_id'], 'integer'],
             [['description', 'managerGuids', 'defaultSpaceGuid'], 'string'],
-            [['created_at', 'updated_at'], 'safe'],
             [['name'], 'string', 'max' => 45]
         ];
     }

--- a/protected/humhub/modules/user/models/GroupAdmin.php
+++ b/protected/humhub/modules/user/models/GroupAdmin.php
@@ -2,8 +2,7 @@
 
 namespace humhub\modules\user\models;
 
-
-
+use humhub\components\ActiveRecord;
 
 /**
  * This is the model class for table "group_admin".
@@ -16,7 +15,7 @@ namespace humhub\modules\user\models;
  * @property string $updated_at
  * @property integer $updated_by
  */
-class GroupAdmin extends \yii\db\ActiveRecord
+class GroupAdmin extends ActiveRecord
 {
 
     /**
@@ -34,8 +33,7 @@ class GroupAdmin extends \yii\db\ActiveRecord
     {
         return [
             [['user_id', 'group_id'], 'required'],
-            [['user_id', 'group_id', 'created_by', 'updated_by'], 'integer'],
-            [['created_at', 'updated_at'], 'safe'],
+            [['user_id', 'group_id'], 'integer'],
             [['user_id', 'group_id'], 'unique', 'targetAttribute' => ['user_id', 'group_id'], 'message' => 'The combination of User ID and Group ID has already been taken.']
         ];
     }

--- a/protected/humhub/modules/user/models/GroupUser.php
+++ b/protected/humhub/modules/user/models/GroupUser.php
@@ -8,8 +8,7 @@
 
 namespace humhub\modules\user\models;
 
-
-
+use humhub\components\ActiveRecord;
 
 /**
  * This is the model class for table "group_admin".
@@ -22,7 +21,7 @@ namespace humhub\modules\user\models;
  * @property string $updated_at
  * @property integer $updated_by
  */
-class GroupUser extends \humhub\components\ActiveRecord
+class GroupUser extends ActiveRecord
 {
 
     const SCENARIO_REGISTRATION = 'registration';
@@ -42,8 +41,7 @@ class GroupUser extends \humhub\components\ActiveRecord
     {
         return [
             [['user_id', 'group_id'], 'required'],
-            [['user_id', 'group_id', 'created_by', 'updated_by'], 'integer'],
-            [['created_at', 'updated_at'], 'safe'],
+            [['user_id', 'group_id'], 'integer'],
             [['group_id'], 'validateGroupId'],
             [['user_id', 'group_id'], 'unique', 'targetAttribute' => ['user_id', 'group_id'], 'message' => 'The combination of User ID and Group ID has already been taken.']
         ];

--- a/protected/humhub/modules/user/models/Invite.php
+++ b/protected/humhub/modules/user/models/Invite.php
@@ -8,6 +8,7 @@
 
 namespace humhub\modules\user\models;
 
+use humhub\components\ActiveRecord;
 use Yii;
 use yii\helpers\Url;
 
@@ -28,7 +29,7 @@ use yii\helpers\Url;
  * @property string $firstname
  * @property string $lastname
  */
-class Invite extends \yii\db\ActiveRecord
+class Invite extends ActiveRecord
 {
 
     const SOURCE_SELF = "self";
@@ -49,7 +50,7 @@ class Invite extends \yii\db\ActiveRecord
     public function rules()
     {
         return [
-            [['user_originator_id', 'space_invite_id', 'created_by', 'updated_by'], 'integer'],
+            [['user_originator_id', 'space_invite_id'], 'integer'],
             [['token'], 'unique'],
             [['firstname', 'lastname'], 'string', 'max' => 255],
             [['email', 'source', 'token'], 'string', 'max' => 45],

--- a/protected/humhub/modules/user/models/Mentioning.php
+++ b/protected/humhub/modules/user/models/Mentioning.php
@@ -8,6 +8,7 @@
 
 namespace humhub\modules\user\models;
 
+use humhub\components\ActiveRecord;
 use humhub\modules\content\components\ContentActiveRecord;
 use humhub\modules\content\components\ContentAddonActiveRecord;
 
@@ -20,7 +21,7 @@ use humhub\modules\content\components\ContentAddonActiveRecord;
  * @property integer $object_id
  * @property integer $user_id
  */
-class Mentioning extends \humhub\components\ActiveRecord
+class Mentioning extends ActiveRecord
 {
 
     /**

--- a/protected/humhub/modules/user/models/Password.php
+++ b/protected/humhub/modules/user/models/Password.php
@@ -72,7 +72,6 @@ class Password extends \yii\db\ActiveRecord
             [['newPassword', 'newPasswordConfirm'], 'trim'],
             [['user_id'], 'integer'],
             [['password', 'salt'], 'string'],
-            [['created_at'], 'safe'],
             [['algorithm'], 'string', 'max' => 20],
             [['currentPassword'], CheckPasswordValidator::className(), 'on' => 'changePassword'],
             [['newPassword', 'newPasswordConfirm', 'currentPassword'], 'required', 'on' => 'changePassword'],

--- a/protected/humhub/modules/user/models/ProfileField.php
+++ b/protected/humhub/modules/user/models/ProfileField.php
@@ -8,7 +8,9 @@
 
 namespace humhub\modules\user\models;
 
+use humhub\components\ActiveRecord;
 use Yii;
+use yii\db\ActiveQuery;
 
 /**
  * This is the model class for table "profile_field".
@@ -34,7 +36,7 @@ use Yii;
  * @property string $translation_category
  * @property integer $is_system
  */
-class ProfileField extends \yii\db\ActiveRecord
+class ProfileField extends ActiveRecord
 {
 
     /**
@@ -59,25 +61,23 @@ class ProfileField extends \yii\db\ActiveRecord
     {
         return array(
             array(['profile_field_category_id', 'field_type_class', 'internal_name', 'title', 'sort_order'], 'required'),
-            array(['profile_field_category_id', 'required', 'editable', 'searchable', 'show_at_registration', 'visible', 'sort_order', 'created_by', 'updated_by'], 'integer'),
+            array(['profile_field_category_id', 'required', 'editable', 'searchable', 'show_at_registration', 'visible', 'sort_order'], 'integer'),
             array(['module_id', 'field_type_class', 'title'], 'string', 'max' => 255),
             array('internal_name', 'string', 'max' => 100),
             array(['ldap_attribute', 'translation_category'], 'string', 'max' => 255),
             array('internal_name', 'checkInternalName'),
             array('internal_name', 'match', 'not' => true, 'pattern' => '/[^a-zA-Z0-9_]/', 'message' => Yii::t('UserModule.models_ProfileField', 'Only alphanumeric characters allowed!')),
             array('field_type_class', 'checkType'),
-            array(['description', 'created_at', 'updated_at'], 'safe'),
+            array(['description'], 'safe'),
         );
     }
 
     /**
-     * @return array relational rules.
+     * @return ActiveQuery
      */
-    public function relations()
+    public function getCategory()
     {
-        return array(
-            'category' => array(self::BELONGS_TO, 'ProfileFieldCategory', 'profile_field_category_id'),
-        );
+        return $this->hasOne(ProfileFieldCategory::className(), ['id' => 'profile_field_category_id']);
     }
 
     /**

--- a/protected/humhub/modules/user/models/ProfileFieldCategory.php
+++ b/protected/humhub/modules/user/models/ProfileFieldCategory.php
@@ -8,7 +8,7 @@
 
 namespace humhub\modules\user\models;
 
-
+use humhub\components\ActiveRecord;
 
 /**
  * This is the model class for table "profile_field_category".
@@ -26,7 +26,7 @@ namespace humhub\modules\user\models;
  * @property string $translation_category
  * @property integer $is_system
  */
-class ProfileFieldCategory extends \yii\db\ActiveRecord
+class ProfileFieldCategory extends ActiveRecord
 {
 
     /**
@@ -45,8 +45,7 @@ class ProfileFieldCategory extends \yii\db\ActiveRecord
         return [
             [['title', 'sort_order'], 'required'],
             [['description'], 'string'],
-            [['sort_order', 'module_id', 'visibility', 'created_by', 'updated_by', 'is_system'], 'integer'],
-            [['created_at', 'updated_at'], 'safe'],
+            [['sort_order', 'module_id', 'visibility', 'is_system'], 'integer'],
             [['title', 'translation_category'], 'string', 'max' => 255]
         ];
     }

--- a/protected/humhub/modules/user/models/User.php
+++ b/protected/humhub/modules/user/models/User.php
@@ -95,9 +95,9 @@ class User extends ContentContainerActiveRecord implements \yii\web\IdentityInte
     {
         return [
             [['username', 'email'], 'required'],
-            [['wall_id', 'status', 'created_by', 'updated_by', 'visibility'], 'integer'],
+            [['wall_id', 'status', 'visibility'], 'integer'],
             [['tags'], 'string'],
-            [['last_activity_email', 'created_at', 'updated_at', 'last_login'], 'safe'],
+            [['last_activity_email', 'last_login'], 'safe'],
             [['guid'], 'string', 'max' => 45],
             [['username'], 'string', 'max' => 50, 'min' => Yii::$app->params['user']['minUsernameLength']],
             [['time_zone'], 'in', 'range' => \DateTimeZone::listIdentifiers()],


### PR DESCRIPTION
- these do not receive user input and should not be changeable via forms.
  I have not seen a concrete case where it was possible to exploit these
  but it is still wrong to have them in there.
- Made sure the AR classes that have these fields extend
  `humhub\components\ActiveRecord` so these fields are actually
  mainained. For a lot of tables they are all null right now.
- Fixed a relation definition in ProfileField, which was a relict from
  Yii 1.1.