### PR TITLE
Fix(?) for Like event notification

### DIFF
--- a/protected/humhub/modules/like/models/Like.php
+++ b/protected/humhub/modules/like/models/Like.php
@@ -85,12 +85,10 @@ class Like extends ContentAddonActiveRecord
         $activity->create();
         
         // source itsself does not need to have creadedBy attribute
-        if ($this->getSource()->hasAttribute('content') && $this->getSource()->content->createdBy !== null) {
-            $notification = new \humhub\modules\like\notifications\NewLike();
-            $notification->source = $this;
-            $notification->originator = $this->user;
-            $notification->send($this->getSource()->content->createdBy);
-        }
+        $notification = new \humhub\modules\like\notifications\NewLike();
+        $notification->source = $this;
+        $notification->originator = $this->user;
+        $notification->send($this->getSource()->content->createdBy);
 
         return parent::afterSave($insert, $changedAttributes);
     }


### PR DESCRIPTION
Like module don't send event to users once their post/reply has been liked. Culprit is "if ($this->getSource()->hasAttribute('content') && $this->getSource()->content->createdBy !== null)"
I tried to workaround here but couldn't find any except removing condition entirely.