### PR TITLE
Update File.php

### DIFF
--- a/protected/humhub/modules/file/models/File.php
+++ b/protected/humhub/modules/file/models/File.php
@@ -217,7 +217,7 @@ class File extends \humhub\components\ActiveRecord
 
         $fileParts = pathinfo($this->file_name);
 
-        return $fileParts['filename'] . "_" . $suffix . "." . $fileParts['extension'];
+        return $fileParts['filename'] . '_' . $suffix . (!empty($fileParts['extension']) ? '.' . $fileParts['extension'] : '');
     }
 
     /**


### PR DESCRIPTION
fixed crash with files that do not have a file extension, e.g. simple text file "MyFile" would crash here when uploaded.