### PR TITLE
Update admin-authentication.md

### DIFF
--- a/protected/humhub/docs/guide/admin-authentication.md
+++ b/protected/humhub/docs/guide/admin-authentication.md
@@ -90,6 +90,9 @@ return [
                     'class' => 'humhub\modules\user\authclient\GitHub',
                     'clientId' => 'Your GitHub Client ID here',
                     'clientSecret' => 'Your GitHub Client Secret here',
+                    // require read access to the users email
+                    // https://developer.github.com/v3/oauth/#scopes
+                    'scope' => 'user:email',
                 ],
             ],
         ],


### PR DESCRIPTION
Make Github client less eager in permissions. The default seems to be read/write access on all profile fields. This one will allow read access on the private email. all public info has read permission anyway.