### PR TITLE
update spelling for internalAllowAnonymousRegistration

### DIFF
--- a/protected/humhub/libs/Helpers.php
+++ b/protected/humhub/libs/Helpers.php
@@ -201,4 +201,19 @@ class Helpers
         return $check === 0;
     }
 
+    /**
+     * Set sql_mode=TRADITIONAL for mysql server.
+     *
+     * This static function is intended as closure for on afterOpen raised by yii\db\Connection and
+     * should be configured in dynamic.php like this: 'on afterOpen' => ['humhub\libs\Helpers', 'SqlMode'],
+     *
+     * @param $event
+     */
+    public static function SqlMode($event) {
+        /* set sql_mode only for mysql */
+        if ($event->sender->driverName == 'mysql') {
+            $event->sender->createCommand('SET sql_mode="TRADITIONAL"')->execute();
+        }
+    }
+
 }

--- a/protected/humhub/modules/installer/controllers/SetupController.php
+++ b/protected/humhub/modules/installer/controllers/SetupController.php
@@ -80,6 +80,7 @@ class SetupController extends Controller
                 'username' => $model->username,
                 'password' => $password,
                 'charset' => 'utf8',
+                'on afterOpen' => ['humhub\libs\Helpers', 'SqlMode'],
             ];
 
 

--- a/protected/humhub/modules/installer/forms/SecurityForm.php
+++ b/protected/humhub/modules/installer/forms/SecurityForm.php
@@ -61,7 +61,7 @@ class SecurityForm extends \yii\base\Model
         return array(
             'allowGuestAccess' => Yii::t('InstallerModule.forms_SecurityForm', 'Allow access for non-registered users to public content (guest access)'),
             'internalRequireApprovalAfterRegistration' => Yii::t('InstallerModule.forms_SecurityForm', 'Newly registered users have to be activated by an admin first'),
-            'internalAllowAnonymousRegistration' => Yii::t('InstallerModule.forms_SecurityForm', 'External user can register (The registration form will be displayed at Login))'),
+            'internalAllowAnonymousRegistration' => Yii::t('InstallerModule.forms_SecurityForm', 'External users can register (show registration form on login)'),
             'canInviteExternalUsersByEmail' => Yii::t('InstallerModule.forms_SecurityForm', 'Registered members can invite new users via email'),
             'enableFriendshipModule' => Yii::t('InstallerModule.forms_SecurityForm', 'Allow friendships between members'),
         );

--- a/protected/humhub/modules/installer/messages/an/forms_SecurityForm.php
+++ b/protected/humhub/modules/installer/messages/an/forms_SecurityForm.php
@@ -19,7 +19,7 @@
 return [
     'Allow access for non-registered users to public content (guest access)' => '',
     'Allow friendships between members' => '',
-    'External user can register (The registration form will be displayed at Login))' => '',
+    'External users can register (show registration form on login)' => '',
     'Newly registered users have to be activated by an admin first' => '',
     'Registered members can invite new users via email' => '',
 ];

--- a/protected/humhub/modules/installer/messages/ar/forms_SecurityForm.php
+++ b/protected/humhub/modules/installer/messages/ar/forms_SecurityForm.php
@@ -19,7 +19,7 @@
 return [
     'Allow access for non-registered users to public content (guest access)' => '',
     'Allow friendships between members' => '',
-    'External user can register (The registration form will be displayed at Login))' => '',
+    'External users can register (show registration form on login)' => '',
     'Newly registered users have to be activated by an admin first' => '',
     'Registered members can invite new users via email' => '',
 ];

--- a/protected/humhub/modules/installer/messages/bg/forms_SecurityForm.php
+++ b/protected/humhub/modules/installer/messages/bg/forms_SecurityForm.php
@@ -19,7 +19,7 @@
 return [
     'Allow access for non-registered users to public content (guest access)' => '',
     'Allow friendships between members' => '',
-    'External user can register (The registration form will be displayed at Login))' => '',
+    'External users can register (show registration form on login)' => '',
     'Newly registered users have to be activated by an admin first' => '',
     'Registered members can invite new users via email' => '',
 ];

--- a/protected/humhub/modules/installer/messages/ca/forms_SecurityForm.php
+++ b/protected/humhub/modules/installer/messages/ca/forms_SecurityForm.php
@@ -19,7 +19,7 @@
 return [
     'Allow access for non-registered users to public content (guest access)' => '',
     'Allow friendships between members' => '',
-    'External user can register (The registration form will be displayed at Login))' => '',
+    'External users can register (show registration form on login)' => '',
     'Newly registered users have to be activated by an admin first' => '',
     'Registered members can invite new users via email' => '',
 ];

--- a/protected/humhub/modules/installer/messages/cs/forms_SecurityForm.php
+++ b/protected/humhub/modules/installer/messages/cs/forms_SecurityForm.php
@@ -19,7 +19,7 @@
 return [
     'Allow friendships between members' => '',
     'Allow access for non-registered users to public content (guest access)' => 'Povolit přístup nepřihlášeným uživatelům k veřejným příspěvkům',
-    'External user can register (The registration form will be displayed at Login))' => 'Povolit registraci novým uživatelům (bude se zobrazovat formulář registrace)',
+    'External users can register (show registration form on login)' => 'Povolit registraci novým uživatelům (bude se zobrazovat formulář registrace)',
     'Newly registered users have to be activated by an admin first' => 'Noví uživatelé musí být nejdříve schválení administrátorem',
     'Registered members can invite new users via email' => 'Registrovaní uživatelé mohou zvát další',
 ];

--- a/protected/humhub/modules/installer/messages/da/forms_SecurityForm.php
+++ b/protected/humhub/modules/installer/messages/da/forms_SecurityForm.php
@@ -19,7 +19,7 @@
 return [
     'Allow friendships between members' => '',
     'Allow access for non-registered users to public content (guest access)' => 'Tillad adgang for ikke-registrerede bruger til offentligt indhold (gæste adgang)',
-    'External user can register (The registration form will be displayed at Login))' => 'Ekstern bruger kan registrere sig (Registreringen formularen vil blive vist på login siden)',
+    'External users can register (show registration form on login)' => 'Ekstern bruger kan registrere sig (Registreringen formularen vil blive vist på login siden)',
     'Newly registered users have to be activated by an admin first' => 'Nylig registrerede brugere skal aktiveres af en admin først',
     'Registered members can invite new users via email' => 'Registrerede brugere kan invitere nye brugere via email',
 ];

--- a/protected/humhub/modules/installer/messages/de/forms_SecurityForm.php
+++ b/protected/humhub/modules/installer/messages/de/forms_SecurityForm.php
@@ -2,7 +2,7 @@
 return array (
   'Allow access for non-registered users to public content (guest access)' => 'Erlaube Zugriff auf öffentliche Inhalte für nicht registrierte Benutzer  (Gastzugriff)',
   'Allow friendships between members' => 'Freundschaften zwischen Mitgliedern erlauben',
-  'External user can register (The registration form will be displayed at Login))' => 'Externe Benutzer können sich registrieren (Das Registrierungsformular wird auf der Login-Seite angezeigt)',
+  'External users can register (show registration form on login)' => 'Externe Benutzer können sich registrieren (Registrierungsformular auf der Login-Seite anzeigen)',
   'Newly registered users have to be activated by an admin first' => 'Neu registrierte Benutzer müssen durch den Administrator freigeschaltet werden',
   'Registered members can invite new users via email' => 'Registrierte Benutzer können neue Benutzer per E-Mail einladen',
 );

--- a/protected/humhub/modules/installer/messages/el/forms_SecurityForm.php
+++ b/protected/humhub/modules/installer/messages/el/forms_SecurityForm.php
@@ -19,7 +19,7 @@
 return [
     'Allow access for non-registered users to public content (guest access)' => '',
     'Allow friendships between members' => '',
-    'External user can register (The registration form will be displayed at Login))' => '',
+    'External users can register (show registration form on login)' => '',
     'Newly registered users have to be activated by an admin first' => '',
     'Registered members can invite new users via email' => '',
 ];

--- a/protected/humhub/modules/installer/messages/es/forms_SecurityForm.php
+++ b/protected/humhub/modules/installer/messages/es/forms_SecurityForm.php
@@ -19,7 +19,7 @@
 return [
     'Allow access for non-registered users to public content (guest access)' => '',
     'Allow friendships between members' => '',
-    'External user can register (The registration form will be displayed at Login))' => '',
+    'External users can register (show registration form on login)' => '',
     'Newly registered users have to be activated by an admin first' => '',
     'Registered members can invite new users via email' => '',
 ];

--- a/protected/humhub/modules/installer/messages/fa_ir/forms_SecurityForm.php
+++ b/protected/humhub/modules/installer/messages/fa_ir/forms_SecurityForm.php
@@ -2,7 +2,7 @@
 return array (
   'Allow access for non-registered users to public content (guest access)' => 'اجازه دادن به افراد عضو نشده به مطالب عمومي',
   'Allow friendships between members' => 'اجازه دادن به امكان دوستي بين اعضا',
-  'External user can register (The registration form will be displayed at Login))' => 'اعضاي خارج از شبكه هم بتوانند عضو شوند',
+  'External users can register (show registration form on login)' => 'اعضاي خارج از شبكه هم بتوانند عضو شوند',
   'Newly registered users have to be activated by an admin first' => 'اعضاي جديد بايد توسط مدير تاييد شوند',
   'Registered members can invite new users via email' => 'اعضاي حاضر مي توانند با ايميل ديگران را به سايت دعوت كنند',
 );

--- a/protected/humhub/modules/installer/messages/fr/forms_SecurityForm.php
+++ b/protected/humhub/modules/installer/messages/fr/forms_SecurityForm.php
@@ -2,7 +2,7 @@
 return array (
   'Allow access for non-registered users to public content (guest access)' => 'Autoriser l\'accès aux contenus publics pour les utilisateurs non inscrits (accès invité)',
   'Allow friendships between members' => 'Autoriser l\'amitié entre les membres',
-  'External user can register (The registration form will be displayed at Login))' => 'Les utilisateurs externes peuvent s\'inscrire (le formulaire d\'inscription sera affiché lors de la connexion)',
+  'External users can register (show registration form on login)' => 'Les utilisateurs externes peuvent s\'inscrire (le formulaire d\'inscription sera affiché lors de la connexion)',
   'Newly registered users have to be activated by an admin first' => 'Les nouveaux utilisateurs inscrits doivent être préalablement activés par un administrateur',
   'Registered members can invite new users via email' => 'Les membres inscrits peuvent inviter de nouveaux utilisateurs par e-mail',
 );

--- a/protected/humhub/modules/installer/messages/hr/forms_SecurityForm.php
+++ b/protected/humhub/modules/installer/messages/hr/forms_SecurityForm.php
@@ -19,7 +19,7 @@
 return [
     'Allow access for non-registered users to public content (guest access)' => '',
     'Allow friendships between members' => '',
-    'External user can register (The registration form will be displayed at Login))' => '',
+    'External users can register (show registration form on login)' => '',
     'Newly registered users have to be activated by an admin first' => '',
     'Registered members can invite new users via email' => '',
 ];

--- a/protected/humhub/modules/installer/messages/ht/forms_SecurityForm.php
+++ b/protected/humhub/modules/installer/messages/ht/forms_SecurityForm.php
@@ -19,7 +19,7 @@
 return [
     'Allow access for non-registered users to public content (guest access)' => '',
     'Allow friendships between members' => '',
-    'External user can register (The registration form will be displayed at Login))' => '',
+    'External users can register (show registration form on login)' => '',
     'Newly registered users have to be activated by an admin first' => '',
     'Registered members can invite new users via email' => '',
 ];

--- a/protected/humhub/modules/installer/messages/hu/forms_SecurityForm.php
+++ b/protected/humhub/modules/installer/messages/hu/forms_SecurityForm.php
@@ -19,7 +19,7 @@
 return [
     'Allow access for non-registered users to public content (guest access)' => '',
     'Allow friendships between members' => '',
-    'External user can register (The registration form will be displayed at Login))' => '',
+    'External users can register (show registration form on login)' => '',
     'Newly registered users have to be activated by an admin first' => '',
     'Registered members can invite new users via email' => '',
 ];

--- a/protected/humhub/modules/installer/messages/id/forms_SecurityForm.php
+++ b/protected/humhub/modules/installer/messages/id/forms_SecurityForm.php
@@ -19,7 +19,7 @@
 return [
     'Allow access for non-registered users to public content (guest access)' => '',
     'Allow friendships between members' => '',
-    'External user can register (The registration form will be displayed at Login))' => '',
+    'External users can register (show registration form on login)' => '',
     'Newly registered users have to be activated by an admin first' => '',
     'Registered members can invite new users via email' => '',
 ];

--- a/protected/humhub/modules/installer/messages/it/forms_SecurityForm.php
+++ b/protected/humhub/modules/installer/messages/it/forms_SecurityForm.php
@@ -19,7 +19,7 @@
 return [
     'Allow access for non-registered users to public content (guest access)' => '',
     'Allow friendships between members' => '',
-    'External user can register (The registration form will be displayed at Login))' => '',
+    'External users can register (show registration form on login)' => '',
     'Newly registered users have to be activated by an admin first' => '',
     'Registered members can invite new users via email' => '',
 ];

--- a/protected/humhub/modules/installer/messages/ja/forms_SecurityForm.php
+++ b/protected/humhub/modules/installer/messages/ja/forms_SecurityForm.php
@@ -19,7 +19,7 @@
 return [
     'Allow access for non-registered users to public content (guest access)' => '',
     'Allow friendships between members' => '',
-    'External user can register (The registration form will be displayed at Login))' => '',
+    'External users can register (show registration form on login)' => '',
     'Newly registered users have to be activated by an admin first' => '',
     'Registered members can invite new users via email' => '',
 ];

--- a/protected/humhub/modules/installer/messages/ko/forms_SecurityForm.php
+++ b/protected/humhub/modules/installer/messages/ko/forms_SecurityForm.php
@@ -19,7 +19,7 @@
 return [
     'Allow access for non-registered users to public content (guest access)' => '',
     'Allow friendships between members' => '',
-    'External user can register (The registration form will be displayed at Login))' => '',
+    'External users can register (show registration form on login)' => '',
     'Newly registered users have to be activated by an admin first' => '',
     'Registered members can invite new users via email' => '',
 ];

--- a/protected/humhub/modules/installer/messages/lt/forms_SecurityForm.php
+++ b/protected/humhub/modules/installer/messages/lt/forms_SecurityForm.php
@@ -19,7 +19,7 @@
 return [
     'Allow access for non-registered users to public content (guest access)' => '',
     'Allow friendships between members' => '',
-    'External user can register (The registration form will be displayed at Login))' => '',
+    'External users can register (show registration form on login)' => '',
     'Newly registered users have to be activated by an admin first' => '',
     'Registered members can invite new users via email' => '',
 ];

--- a/protected/humhub/modules/installer/messages/nb_no/forms_SecurityForm.php
+++ b/protected/humhub/modules/installer/messages/nb_no/forms_SecurityForm.php
@@ -19,7 +19,7 @@
 return [
     'Allow access for non-registered users to public content (guest access)' => '',
     'Allow friendships between members' => '',
-    'External user can register (The registration form will be displayed at Login))' => '',
+    'External users can register (show registration form on login)' => '',
     'Newly registered users have to be activated by an admin first' => '',
     'Registered members can invite new users via email' => '',
 ];

--- a/protected/humhub/modules/installer/messages/nl/forms_SecurityForm.php
+++ b/protected/humhub/modules/installer/messages/nl/forms_SecurityForm.php
@@ -19,7 +19,7 @@
 return [
     'Allow access for non-registered users to public content (guest access)' => '',
     'Allow friendships between members' => '',
-    'External user can register (The registration form will be displayed at Login))' => '',
+    'External users can register (show registration form on login)' => '',
     'Newly registered users have to be activated by an admin first' => '',
     'Registered members can invite new users via email' => '',
 ];

--- a/protected/humhub/modules/installer/messages/pl/forms_SecurityForm.php
+++ b/protected/humhub/modules/installer/messages/pl/forms_SecurityForm.php
@@ -19,7 +19,7 @@
 return [
     'Allow friendships between members' => '',
     'Allow access for non-registered users to public content (guest access)' => 'Zezwalaj na dostęp niezarejestrowanych użytkowników do treści publicznych (dostęp dla gości)',
-    'External user can register (The registration form will be displayed at Login))' => 'Zewnętrzny użytkownik może się zarejestrować (Formularz rejestracyjny będzie wyświetlany przy logowaniu)',
+    'External users can register (show registration form on login)' => 'Zewnętrzny użytkownik może się zarejestrować (Formularz rejestracyjny będzie wyświetlany przy logowaniu)',
     'Newly registered users have to be activated by an admin first' => 'Nowo zarejestrowani użytkownicy muszą zostać aktywowani przez administratora',
     'Registered members can invite new users via email' => 'Zarejestrowani użytkownicy mogą zapraszać nowych poprzez email',
 ];

--- a/protected/humhub/modules/installer/messages/pt/forms_SecurityForm.php
+++ b/protected/humhub/modules/installer/messages/pt/forms_SecurityForm.php
@@ -19,7 +19,7 @@
 return [
     'Allow access for non-registered users to public content (guest access)' => '',
     'Allow friendships between members' => '',
-    'External user can register (The registration form will be displayed at Login))' => '',
+    'External users can register (show registration form on login)' => '',
     'Newly registered users have to be activated by an admin first' => '',
     'Registered members can invite new users via email' => '',
 ];

--- a/protected/humhub/modules/installer/messages/pt_br/forms_SecurityForm.php
+++ b/protected/humhub/modules/installer/messages/pt_br/forms_SecurityForm.php
@@ -2,7 +2,7 @@
 return array (
   'Allow access for non-registered users to public content (guest access)' => 'Permitir o acesso de usuários não registrados ao conteúdo público (acesso de convidado)',
   'Allow friendships between members' => 'Permitir amizades entre membros',
-  'External user can register (The registration form will be displayed at Login))' => 'O usuário externo pode se inscrever (O formulário de registro será exibido no Login)',
+  'External users can register (show registration form on login)' => 'O usuário externo pode se inscrever (O formulário de registro será exibido no Login)',
   'Newly registered users have to be activated by an admin first' => 'Usuários recém-registrados precisam ser ativados por um administrador primeiro',
   'Registered members can invite new users via email' => 'Os membros registrados podem convidar novos usuários por e-mail',
 );

--- a/protected/humhub/modules/installer/messages/ro/forms_SecurityForm.php
+++ b/protected/humhub/modules/installer/messages/ro/forms_SecurityForm.php
@@ -19,7 +19,7 @@
 return [
     'Allow access for non-registered users to public content (guest access)' => '',
     'Allow friendships between members' => '',
-    'External user can register (The registration form will be displayed at Login))' => '',
+    'External users can register (show registration form on login)' => '',
     'Newly registered users have to be activated by an admin first' => '',
     'Registered members can invite new users via email' => '',
 ];

--- a/protected/humhub/modules/installer/messages/ru/forms_SecurityForm.php
+++ b/protected/humhub/modules/installer/messages/ru/forms_SecurityForm.php
@@ -19,7 +19,7 @@
 return [
     'Allow friendships between members' => 'Разрешить дружбу между пользователями',
     'Allow access for non-registered users to public content (guest access)' => 'Разрешить доступ для незарегистрированных пользователей к содержанию сайта (гостевой доступ)',
-    'External user can register (The registration form will be displayed at Login))' => 'Вошедший пользователь может зарегистрироваться (Регистрационная форма будет отображаться при входе)',
+    'External users can register (show registration form on login)' => 'Вошедший пользователь может зарегистрироваться (Регистрационная форма будет отображаться при входе)',
     'Newly registered users have to be activated by an admin first' => 'Новые пользователи должны быть сначала проверены администратором',
     'Registered members can invite new users via email' => 'Зарегистрированные участники могут приглашать новых пользователей по e-mail',
 ];

--- a/protected/humhub/modules/installer/messages/sk/forms_SecurityForm.php
+++ b/protected/humhub/modules/installer/messages/sk/forms_SecurityForm.php
@@ -19,7 +19,7 @@
 return [
     'Allow access for non-registered users to public content (guest access)' => '',
     'Allow friendships between members' => '',
-    'External user can register (The registration form will be displayed at Login))' => '',
+    'External users can register (show registration form on login)' => '',
     'Newly registered users have to be activated by an admin first' => '',
     'Registered members can invite new users via email' => '',
 ];

--- a/protected/humhub/modules/installer/messages/sv/forms_SecurityForm.php
+++ b/protected/humhub/modules/installer/messages/sv/forms_SecurityForm.php
@@ -19,7 +19,7 @@
 return [
     'Allow access for non-registered users to public content (guest access)' => '',
     'Allow friendships between members' => '',
-    'External user can register (The registration form will be displayed at Login))' => '',
+    'External users can register (show registration form on login)' => '',
     'Newly registered users have to be activated by an admin first' => '',
     'Registered members can invite new users via email' => '',
 ];

--- a/protected/humhub/modules/installer/messages/th/forms_SecurityForm.php
+++ b/protected/humhub/modules/installer/messages/th/forms_SecurityForm.php
@@ -19,7 +19,7 @@
 return [
     'Allow access for non-registered users to public content (guest access)' => '',
     'Allow friendships between members' => '',
-    'External user can register (The registration form will be displayed at Login))' => '',
+    'External users can register (show registration form on login)' => '',
     'Newly registered users have to be activated by an admin first' => '',
     'Registered members can invite new users via email' => '',
 ];

--- a/protected/humhub/modules/installer/messages/tr/forms_SecurityForm.php
+++ b/protected/humhub/modules/installer/messages/tr/forms_SecurityForm.php
@@ -2,7 +2,7 @@
 return array (
   'Allow access for non-registered users to public content (guest access)' => 'Kayıtlı olmayan kullanıcılar için erişim izni. (Misafir erişimi)',
   'Allow friendships between members' => 'Üyeler arasında arkadaşlık',
-  'External user can register (The registration form will be displayed at Login))' => 'Harici kullanıcı kayıt olabilir. (Girişte kayıt formu gösterilecek)',
+  'External users can register (show registration form on login)' => 'Harici kullanıcı kayıt olabilir. (Girişte kayıt formu gösterilecek)',
   'Newly registered users have to be activated by an admin first' => 'Yeni kayıt olan kullanıcılar ilk olarak yönetici tarafından aktive edilecek.',
   'Registered members can invite new users via email' => 'Kayıtlı üyeler e-posta yoluyla yeni kullanıcıları davet edebilir',
 );

--- a/protected/humhub/modules/installer/messages/uk/forms_SecurityForm.php
+++ b/protected/humhub/modules/installer/messages/uk/forms_SecurityForm.php
@@ -19,7 +19,7 @@
 return [
     'Allow access for non-registered users to public content (guest access)' => '',
     'Allow friendships between members' => '',
-    'External user can register (The registration form will be displayed at Login))' => '',
+    'External users can register (show registration form on login)' => '',
     'Newly registered users have to be activated by an admin first' => '',
     'Registered members can invite new users via email' => '',
 ];

--- a/protected/humhub/modules/installer/messages/uz/forms_SecurityForm.php
+++ b/protected/humhub/modules/installer/messages/uz/forms_SecurityForm.php
@@ -19,7 +19,7 @@
 return [
     'Allow access for non-registered users to public content (guest access)' => '',
     'Allow friendships between members' => '',
-    'External user can register (The registration form will be displayed at Login))' => '',
+    'External users can register (show registration form on login)' => '',
     'Newly registered users have to be activated by an admin first' => '',
     'Registered members can invite new users via email' => '',
 ];

--- a/protected/humhub/modules/installer/messages/vi/forms_SecurityForm.php
+++ b/protected/humhub/modules/installer/messages/vi/forms_SecurityForm.php
@@ -19,7 +19,7 @@
 return [
     'Allow access for non-registered users to public content (guest access)' => '',
     'Allow friendships between members' => '',
-    'External user can register (The registration form will be displayed at Login))' => '',
+    'External users can register (show registration form on login)' => '',
     'Newly registered users have to be activated by an admin first' => '',
     'Registered members can invite new users via email' => '',
 ];

--- a/protected/humhub/modules/installer/messages/zh_cn/forms_SecurityForm.php
+++ b/protected/humhub/modules/installer/messages/zh_cn/forms_SecurityForm.php
@@ -19,7 +19,7 @@
 return [
     'Allow access for non-registered users to public content (guest access)' => '允许非注册用户访问公开内容（访客访问）',
     'Allow friendships between members' => '允许成员之间',
-    'External user can register (The registration form will be displayed at Login))' => '外部用户可以注册（注册表单将显示在登录页）',
+    'External users can register (show registration form on login)' => '外部用户可以注册（注册表单将显示在登录页）',
     'Newly registered users have to be activated by an admin first' => '新注册的用户必须由管理员激活',
     'Registered members can invite new users via email' => '注册会员可以通过电子邮件邀请新用户',
 ];

--- a/protected/humhub/modules/installer/messages/zh_tw/forms_SecurityForm.php
+++ b/protected/humhub/modules/installer/messages/zh_tw/forms_SecurityForm.php
@@ -19,7 +19,7 @@
 return [
     'Allow access for non-registered users to public content (guest access)' => '',
     'Allow friendships between members' => '',
-    'External user can register (The registration form will be displayed at Login))' => '',
+    'External users can register (show registration form on login)' => '',
     'Newly registered users have to be activated by an admin first' => '',
     'Registered members can invite new users via email' => '',
 ];


### PR DESCRIPTION
Removed the double )) at the end of the original string. Updated wording in german (see screenshot attached)
![humhub_installer_longtext](https://cloud.githubusercontent.com/assets/3902676/22618891/d3c556ea-eae8-11e6-9949-7acf788b5cfa.PNG)
![humhub_installer_longtext2](https://cloud.githubusercontent.com/assets/3902676/22618892/d6754a08-eae8-11e6-8e5e-a2a43d8cdde8.PNG)

