### PR TITLE
workaround for #1777 and #1786

### DIFF
--- a/protected/humhub/libs/Helpers.php
+++ b/protected/humhub/libs/Helpers.php
@@ -213,7 +213,7 @@ class Helpers
     {
         /* set sql_mode only for mysql */
         if ($event->sender->driverName == 'mysql') {
-            $event->sender->createCommand('SET sql_mode="TRADITIONAL"')->execute();
+            $event->sender->createCommand('SET SESSION sql_mode=""; SET SESSION sql_mode="NO_ENGINE_SUBSTITUTION"')->execute();
         }
     }
 

--- a/protected/humhub/libs/Helpers.php
+++ b/protected/humhub/libs/Helpers.php
@@ -201,4 +201,20 @@ class Helpers
         return $check === 0;
     }
 
+    /**
+     * Set sql_mode=TRADITIONAL for mysql server.
+     *
+     * This static function is intended as closure for on afterOpen raised by yii\db\Connection and
+     * should be configured in dynamic.php like this: 'on afterOpen' => ['humhub\libs\Helpers', 'SqlMode'],
+     *
+     * @param $event
+     */
+    public static function SqlMode($event)
+    {
+        /* set sql_mode only for mysql */
+        if ($event->sender->driverName == 'mysql') {
+            $event->sender->createCommand('SET sql_mode="TRADITIONAL"')->execute();
+        }
+    }
+
 }

--- a/protected/humhub/modules/installer/controllers/SetupController.php
+++ b/protected/humhub/modules/installer/controllers/SetupController.php
@@ -80,6 +80,7 @@ class SetupController extends Controller
                 'username' => $model->username,
                 'password' => $password,
                 'charset' => 'utf8',
+                'on afterOpen' => ['humhub\libs\Helpers', 'SqlMode'],
             ];
 
 


### PR DESCRIPTION
I setup a local humhub copy today on my vagrant box (ubuntu 16.04, php7, mysql5.7). The initial setup was a bit frustrating ;-) First setup crashed when task-module enabled (#1786) and later with (#1777).  

Both problems may solved if mysql is running with sql_mode traditional. I can change this on my vagrant box but not on a shared hosting. 

I ended up with adding a small helper function which changes the sql_mode for the current session. Then changed the db configuration to run this callback after a successfull mysql connection.

This is not a real solution for the issues but a neat workaround until all sql strict mode related issues are solved.