### PR TITLE
[Search] Do not store comments with search index

### DIFF
--- a/protected/humhub/modules/search/engine/ZendLuceneSearch.php
+++ b/protected/humhub/modules/search/engine/ZendLuceneSearch.php
@@ -59,7 +59,7 @@ class ZendLuceneSearch extends Search
             foreach (Comment::findAll(['object_id' => $obj->getPrimaryKey(), 'object_model' => $obj->className()]) as $comment) {
                 $comments .= ' ' . $comment->user->displayName . ' ' . $comment->message;
             }
-            $doc->addField(\ZendSearch\Lucene\Document\Field::Text('comments', $comments, 'UTF-8'));
+            $doc->addField(\ZendSearch\Lucene\Document\Field::unStored('comments', $comments, 'UTF-8'));
         }
 
         if (\Yii::$app->request->isConsoleRequest) {


### PR DESCRIPTION
I don't think there is a need to store the comments text blob in the index, tokenizing and indexing should be enough for searching.

So we can use the unStored Field factory function instead.

```php
    /**
     * Constructs a String-valued Field that is tokenized and indexed,
     * but that is not stored in the index.
     *
     * @param string $name
     * @param string $value
     * @param string $encoding
     * @return \ZendSearch\Lucene\Document\Field
     */
    public static function unStored($name, $value, $encoding = 'UTF-8')
```