### PR TITLE
fix bug: Space picker required  3 char vs 2 min from Space

### DIFF
--- a/protected/humhub/modules/space/widgets/SpacePickerField.php
+++ b/protected/humhub/modules/space/widgets/SpacePickerField.php
@@ -8,23 +8,28 @@ use yii\helpers\Html;
 
 /**
  * Mutliselect input field for selecting space guids.
- * 
+ *
  * @package humhub.modules_core.space.widgets
  * @since 1.2
  * @author buddha
  */
 class SpacePickerField extends BasePickerField
 {
+    /**
+     * @inheritdoc
+     * Min guids string value of Space model equal 2
+     */
+    public $minInput = 2;
 
     /**
-     * @inheritdoc 
+     * @inheritdoc
      */
     public $defaultRoute = '/space/browse/search-json';
     public $itemClass = \humhub\modules\space\models\Space::class;
     public $itemKey = 'guid';
 
     /**
-     * @inheritdoc 
+     * @inheritdoc
      */
     protected function getData()
     {
@@ -41,15 +46,15 @@ class SpacePickerField extends BasePickerField
     }
 
     /**
-     * @inheritdoc 
+     * @inheritdoc
      */
     protected function getItemText($item)
     {
-        return \yii\helpers\Html::encode($item->getDisplayName());
+        return Html::encode($item->getDisplayName());
     }
 
     /**
-     * @inheritdoc 
+     * @inheritdoc
      */
     protected function getItemImage($item)
     {


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/874234/23550649/42df9082-0023-11e7-99cb-c3105efd390d.png)

vs

```php
// from Space
[['guid', 'name', 'url'], 'string', 'max' => 45, 'min' => 2],
```