### PR TITLE
Fix height of <select> under Firefox

### DIFF
--- a/static/less/form.less
+++ b/static/less/form.less
@@ -15,6 +15,7 @@
 .form-control {
     border: 2px solid @background-color-page;
     box-shadow: none;
+    min-height: 35px;
     &:focus {
         border: 2px solid @info;
         outline: 0;


### PR DESCRIPTION
To avoid this (very) small issue of letters not being displayed entirely.

![image](https://cloud.githubusercontent.com/assets/12234510/23837272/d5609d7a-0785-11e7-9040-cfee1cb017ed.png)

