### PR TITLE
TryToFix #2357: length of primary key is too long

### DIFF
--- a/protected/humhub/migrations/m131203_110444_oembed.php
+++ b/protected/humhub/migrations/m131203_110444_oembed.php
@@ -9,7 +9,7 @@ class m131203_110444_oembed extends Migration
     public function up()
     {
         $this->createTable('url_oembed', array(
-            'url' => 'varchar(255) NOT NULL',
+            'url' => 'varchar(180) NOT NULL',
             'preview' => 'text NOT NULL',
             'PRIMARY KEY (`url`)'
         ));


### PR DESCRIPTION
IMO 180 chars are enough for `url` column and it needs to allow for 4 bytes per character with `utf8mb4`, but `255*4 = 1020 bytes` wich is `>767 bytes` allowed by the database configuration.