### PR TITLE
Code of ImageConverter::allocateMemory uses different units of memory

### DIFF
--- a/protected/humhub/docs/CHANGELOG.md
+++ b/protected/humhub/docs/CHANGELOG.md
@@ -86,7 +86,7 @@ HumHub Change Log
 - Enh: Added APCu Support
 - Enh: Added ContentContainer integrity check (Daha62)
 - Fix #2331: Bug image load on PHP 7.1 with dynamic memory alloc (githubjeka)
-- Fix #2366: `ImageConverter::allocateMemory` uses common units(MegaBates) of memory (githubjeka)
+- Fix #2367: `ImageConverter::allocateMemory` uses common units(MegaBates) of memory (githubjeka)
 
 
 1.2.0-beta.2 (February 24, 2017)

--- a/protected/humhub/docs/CHANGELOG.md
+++ b/protected/humhub/docs/CHANGELOG.md
@@ -86,6 +86,7 @@ HumHub Change Log
 - Enh: Added APCu Support
 - Enh: Added ContentContainer integrity check (Daha62)
 - Fix #2331: Bug image load on PHP 7.1 with dynamic memory alloc (githubjeka)
+- Fix #2366: `ImageConverter::allocateMemory` uses common units(MegaBates) of memory (githubjeka)
 
 
 1.2.0-beta.2 (February 24, 2017)

--- a/protected/humhub/modules/file/libs/ImageConverter.php
+++ b/protected/humhub/modules/file/libs/ImageConverter.php
@@ -98,8 +98,13 @@ class ImageConverter
      */
     public static function allocateMemory($sourceFile, $test = false)
     {
-        $width = 0;
-        $height = 0;
+        if (!file_exists($sourceFile)) {
+            return true;
+        }
+
+        // getting the image width and height
+        list($width, $height) = getimagesize($sourceFile);
+
         // buffer for memory needed by other stuff
         $buffer = 10;
         // usually for RGB 3 pixels are used, for CMYK 4 pixels
@@ -107,22 +112,18 @@ class ImageConverter
         // tweak factor, experience value
         $tweakFactor = 2.2;
         // check if the file exists, if not it seems that we do not have to allocate memory and we return true
-        if (!file_exists($sourceFile)) {
-            return true;
-        }
-        // getting the image width and height
-        list ($width, $height) = getimagesize($sourceFile);
+
         // get defined memory limit from php_ini
         $memoryLimit = ini_get('memory_limit');
 
         // No memory limit set
         if ($memoryLimit == -1) {
-            return;
+            return false;
         }
 
-        // calc needed size for processing image dimensions in Bytes. 
-        $memoryLimit = Helpers::getBytesOfIniValue($memoryLimit) * 1048576;
-        // calc needed size for processing image dimensions in Bytes.        
+        // calc needed size for processing image dimensions in MegaBytes.
+        $memoryLimit = Helpers::getBytesOfIniValue($memoryLimit) / 1048576;
+        // calc needed size for processing image dimensions in MegaBytes.
         $neededMemory = floor(($width * $height * $bytesPerPixel * $tweakFactor + 1048576) / 1048576);
         $maxMemoryAllocation = Yii::$app->getModule('file')->settings->get(self::SETTINGS_NAME_MAX_MEMORY_ALLOCATION);
         $maxMemoryAllocation = $maxMemoryAllocation == null ? self::DEFAULT_MAX_ADDITIONAL_MEMORY_ALLOCATION : $maxMemoryAllocation;


### PR DESCRIPTION
Fix #2366 
Fix #1631