### PR TITLE
remove reinitialize stream

### DIFF
--- a/protected/humhub/modules/stream/actions/Stream.php
+++ b/protected/humhub/modules/stream/actions/Stream.php
@@ -147,7 +147,7 @@ abstract class Stream extends Action
     public $streamQueryClass = 'humhub\modules\stream\models\StreamSuppressQuery';
 
     /**
-     * @inheritdocs
+     * @inheritdoc
      */
     public function init()
     {
@@ -223,8 +223,6 @@ abstract class Stream extends Action
     {
         Yii::$app->response->format = \yii\web\Response::FORMAT_JSON;
         $output = [];
-
-        $this->init();
 
         $output['content'] = [];
 


### PR DESCRIPTION
INIT called in the constructor.
```php
//from yii code of controller
$action = $this->createAction($id); // this INIT by default
$result = $action->runWithParams($params); // This you again call INIT. Why?
```
