### PR TITLE
Add restriction on Username and password (settings can be defined)

### DIFF
--- a/protected/humhub/modules/admin/models/forms/AuthenticationSettingsForm.php
+++ b/protected/humhub/modules/admin/models/forms/AuthenticationSettingsForm.php
@@ -23,6 +23,9 @@ class AuthenticationSettingsForm extends \yii\base\Model
     public $internalRequireApprovalAfterRegistration;
     public $internalUsersCanInvite;
     public $defaultUserGroup;
+    public $MinUserNameLength;
+    public $MinPasswordLength;
+    public $activePasswordSecurity;
     public $defaultUserIdleTimeoutSec;
     public $allowGuestAccess;
     public $defaultUserProfileVisibility;
@@ -40,6 +43,9 @@ class AuthenticationSettingsForm extends \yii\base\Model
         $this->internalRequireApprovalAfterRegistration = $settingsManager->get('auth.needApproval');
         $this->internalAllowAnonymousRegistration = $settingsManager->get('auth.anonymousRegistration');
         $this->defaultUserGroup = $settingsManager->get('auth.defaultUserGroup');
+        $this->MinUserNameLength = $settingsManager->get('auth.MinUserNameLength');
+        $this->MinPasswordLength = $settingsManager->get('auth.MinPasswordLength');
+        $this->activePasswordSecurity = $settingsManager->get('auth.activePasswordSecurity');
         $this->defaultUserIdleTimeoutSec = $settingsManager->get('auth.defaultUserIdleTimeoutSec');
         $this->allowGuestAccess = $settingsManager->get('auth.allowGuestAccess');
         $this->defaultUserProfileVisibility = $settingsManager->get('auth.defaultUserProfileVisibility');
@@ -54,6 +60,9 @@ class AuthenticationSettingsForm extends \yii\base\Model
             [['internalUsersCanInvite', 'internalAllowAnonymousRegistration', 'internalRequireApprovalAfterRegistration', 'allowGuestAccess'], 'boolean'],
             ['defaultUserGroup', 'exist', 'targetAttribute' => 'id', 'targetClass' => \humhub\modules\user\models\Group::className()],
             ['defaultUserProfileVisibility', 'in', 'range' => [1, 2]],
+            ['MinUserNameLength', 'integer', 'min' => 4],
+            ['MinPasswordLength', 'integer', 'min' => 5],
+            ['activePasswordSecurity', 'boolean'],
             ['defaultUserIdleTimeoutSec', 'integer', 'min' => 20],
         ];
     }
@@ -68,6 +77,9 @@ class AuthenticationSettingsForm extends \yii\base\Model
             'internalAllowAnonymousRegistration' => Yii::t('AdminModule.forms_AuthenticationSettingsForm', 'Anonymous users can register'),
             'internalUsersCanInvite' => Yii::t('AdminModule.forms_AuthenticationSettingsForm', 'Members can invite external users by email'),
             'defaultUserGroup' => Yii::t('AdminModule.forms_AuthenticationSettingsForm', 'Default user group for new users'),
+            'MinUserNameLength' => Yii::t('AdminModule.forms_AuthenticationSettingsForm', 'Minimum UserName Length'),
+            'MinPasswordLength' => Yii::t('AdminModule.forms_AuthenticationSettingsForm', 'Minimum Password Length'),
+            'activePasswordSecurity' => Yii::t('AdminModule.forms_AuthenticationSettingsForm', 'Password Complexity Force'),
             'defaultUserIdleTimeoutSec' => Yii::t('AdminModule.forms_AuthenticationSettingsForm', 'Default user idle timeout, auto-logout (in seconds, optional)'),
             'allowGuestAccess' => Yii::t('AdminModule.forms_AuthenticationSettingsForm', 'Allow limited access for non-authenticated users (guests)'),
             'defaultUserProfileVisibility' => Yii::t('AdminModule.forms_AuthenticationSettingsForm', 'Default user profile visibility'),
@@ -87,6 +99,9 @@ class AuthenticationSettingsForm extends \yii\base\Model
         $settingsManager->set('auth.needApproval', $this->internalRequireApprovalAfterRegistration);
         $settingsManager->set('auth.anonymousRegistration', $this->internalAllowAnonymousRegistration);
         $settingsManager->set('auth.defaultUserGroup', $this->defaultUserGroup);
+        $settingsManager->set('auth.MinUserNameLength', $this->MinUserNameLength);
+        $settingsManager->set('auth.MinPasswordLength', $this->MinPasswordLength);
+        $settingsManager->set('auth.activePasswordSecurity', $this->activePasswordSecurity);
         $settingsManager->set('auth.defaultUserIdleTimeoutSec', $this->defaultUserIdleTimeoutSec);
         $settingsManager->set('auth.allowGuestAccess', $this->allowGuestAccess);
 

--- a/protected/humhub/modules/admin/views/authentication/authentication.php
+++ b/protected/humhub/modules/admin/views/authentication/authentication.php
@@ -21,6 +21,15 @@ use humhub\models\Setting;
 
     <?= $form->field($model, 'defaultUserGroup')->dropDownList($groups, ['readonly' => Setting::IsFixed('auth.defaultUserGroup', 'user')]); ?>
 
+    <?= $form->field($model, 'MinUserNameLength')->textInput(['readonly' => Setting::IsFixed('auth.MinUserNameLength', 'user')]); ?>
+    <p class="help-block"><?= Yii::t('AdminModule.views_setting_authentication', 'Min value is 4. If not set, Minimum Username Length is 4'); ?></p>
+
+    <?= $form->field($model, 'MinPasswordLength')->textInput(['readonly' => Setting::IsFixed('auth.MinPasswordLength', 'user')]); ?>
+    <p class="help-block"><?= Yii::t('AdminModule.views_setting_authentication', 'Min value is 5. If not set, Minimum Password Length is 5'); ?></p>
+
+    <?= $form->field($model, 'activePasswordSecurity')->checkbox(); ?>
+    <p class="help-block"><?= Yii::t('AdminModule.views_setting_authentication', 'The password must contains characters from all of the following categories : Uppercase, Lowercase, Number and Special'); ?></p>
+
     <?= $form->field($model, 'defaultUserIdleTimeoutSec')->textInput(['readonly' => Setting::IsFixed('auth.defaultUserIdleTimeoutSec', 'user')]); ?>
     <p class="help-block"><?= Yii::t('AdminModule.views_setting_authentication', 'Min value is 20 seconds. If not set, session will timeout after 1400 seconds (24 minutes) regardless of activity (default session timeout)'); ?></p>
 

--- a/protected/humhub/modules/user/controllers/PasswordSecurityValidator.php
+++ b/protected/humhub/modules/user/controllers/PasswordSecurityValidator.php
@@ -1,0 +1,126 @@
+<?php
+namespace humhub\modules\user\controllers;
+
+use yii\validators\Validator;
+
+class PasswordSecurityValidator extends Validator
+{
+    public $low = 0;
+    public $up = 0;
+    public $spec = 0;
+    public $digit = 0;
+    public $max;
+
+    /**
+     * Validation
+     *
+     * Function checks whether fulfill this requirements  :
+     * <ul>
+     *  <li>is a string</li>
+     *  <li>has the minimal number of lower case characters</li>
+     *  <li>has the minimal number of upper case characters</li>
+     *  <li>has the minimal number of digit characters </li>
+     *  <li>has the minimal number of special characters </li>
+     *  <li>has the minimal length is respected</li>
+     * </ul>
+     * @param CModel $object
+     * @param string $attribute
+     */
+    public function validateAttribute($object, $attribute)
+    {
+        $this->checkParams();
+
+        $value = $object->$attribute;
+
+        // is a string
+        if (!is_string($value))
+        {
+            $this->addError($object, 
+                            $attribute, 
+                            ":attribute is a :type and is must be a string.", 
+                            array(':attribute' => $attribute, ':type' => gettype($value))
+            );
+            return; // other checks will throw errors or exception, so end validation here.
+        }
+
+        // number of lower case characters
+        $found = preg_match_all('![a-z]!', $value, $whatever);
+        if ($found < $this->low)
+        {
+            $this->addErrorInternal($object, 
+                            $attribute, 
+                           'Minuscule',
+                            array('found' => $found, 'required' => $this->low)
+            );            
+        }
+
+        // number of upper case characters
+        $found = preg_match_all('![A-Z]!', $value, $whatever);
+        if ($found < $this->up)
+        {
+            $this->addErrorInternal($object, 
+                            $attribute, 
+                            'Majuscule',
+                            array('found' => $found, 'required' => $this->up)
+            );
+        }
+        
+        // special characters
+        $found = preg_match_all('![\W]!', $value, $whatever);
+        if ($found < $this->spec)
+        {
+            $this->addErrorInternal($object, 
+                            $attribute, 
+                            'caractère special', 
+                            array('found' => $found, 'required' => $this->spec)
+            );
+        }
+
+        // digit characters
+        $found = preg_match_all('![\d]!', $value, $whatever);
+        if ($found < $this->digit)
+        {
+            $this->addErrorInternal($object, 
+                            $attribute, 
+                            'Chiffre', 
+                            array('found' => $found, 'required' => $this->digit)
+            );
+        }
+
+    }
+
+    /**
+    * Checks the provided parameters
+    * Checks if sum of required params values is greater than max
+    * @throw CException if more than max
+    */
+    private function checkParams()
+    {
+        $this->max = (int) $this->max;
+        if($this->max && ($this->up + $this->digit + $this->low + $this->spec) > $this->max)
+	    throw new CException('Total number of required characters is greater than max : Validation is impossible !');
+    }
+
+    /**
+    * Adds an error about the specified attribute to the active record.
+    * This is a helper method that call addError which performs message selection and internationalization.
+    *
+    * Construct the message and the params array to call addError().
+    *
+    * @param CModel $object the data object being validated
+    * @param string $attribute the attribute being validated
+    * @param string $tested_param the tested property (eg 'upper case') for generating the error message
+    * @param array $values values for the placeholders :is and :should in the error message - array(['found'] => <int>, ['required'] => <int>)
+    *
+    * @todo change message for correct message with 'max' param
+    */
+    private function addErrorInternal($object, $attribute,$tested_param, array $values)
+    {
+        $message = "Le :attribute ne contient pas assez de caractère(s) :tested_param. Trouvé :found alors qu'il doit en contenir au moins :required."; 
+        //$message .= "  !!! RAPPEL SECURITE !!! Le :attribute doit faire au minimum 8 caractères et contenir au moins 1 caractère de chacun des types suivants : Majuscule / Minuscule / Chiffre / Caractère Spécial"; 
+        $params = array(':attribute' => $attribute, ':tested_param' => $tested_param, ':found' => $values['found'], ':required' => $values['required']);
+        parent::addError($object, $attribute, $message, $params);
+    }
+
+}
+

--- a/protected/humhub/modules/user/controllers/PasswordSecurityValidator.php
+++ b/protected/humhub/modules/user/controllers/PasswordSecurityValidator.php
@@ -117,7 +117,6 @@ class PasswordSecurityValidator extends Validator
     private function addErrorInternal($object, $attribute,$tested_param, array $values)
     {
         $message = "Le :attribute ne contient pas assez de caractère(s) :tested_param. Trouvé :found alors qu'il doit en contenir au moins :required."; 
-        //$message .= "  !!! RAPPEL SECURITE !!! Le :attribute doit faire au minimum 8 caractères et contenir au moins 1 caractère de chacun des types suivants : Majuscule / Minuscule / Chiffre / Caractère Spécial"; 
         $params = array(':attribute' => $attribute, ':tested_param' => $tested_param, ':found' => $values['found'], ':required' => $values['required']);
         parent::addError($object, $attribute, $message, $params);
     }

--- a/protected/humhub/modules/user/models/Password.php
+++ b/protected/humhub/modules/user/models/Password.php
@@ -10,6 +10,7 @@ namespace humhub\modules\user\models;
 
 use Yii;
 use humhub\modules\user\components\CheckPasswordValidator;
+use humhub\modules\user\controllers\PasswordSecurityValidator;
 
 /**
  * This is the model class for table "user_password".
@@ -67,6 +68,7 @@ class Password extends \yii\db\ActiveRecord
      */
     public function rules()
     {
+	if(Yii::$app->getModule('user')->settings->get('auth.activePasswordSecurity') === '1') {
         return [
             [['newPassword', 'newPasswordConfirm'], 'required', 'on' => 'registration'],
             [['newPassword', 'newPasswordConfirm'], 'trim'],
@@ -80,7 +82,29 @@ class Password extends \yii\db\ActiveRecord
             [['newPassword'], 'unequalsCurrentPassword', 'on' => 'changePassword'],
             [['newPasswordConfirm'], 'compare', 'compareAttribute' => 'newPassword', 'on' => 'changePassword'],
             [['newPasswordConfirm'], 'compare', 'compareAttribute' => 'newPassword', 'on' => 'registration'],
+			[['newPassword', 'newPasswordConfirm'], 'string', 'min' => Yii::$app->getModule('user')->settings->get('auth.MinPasswordLength'), 'max' => 255],
+			[['newPassword', 'newPasswordConfirm'], 'string', 'min' => 5, 'max' => 255],
+			[['newPassword'], PasswordSecurityValidator::className(), 'up' => 1, 'low' => 1, 'digit' => 1, 'spec' => 1],
         ];
+	}
+	else {
+        return [
+            [['newPassword', 'newPasswordConfirm'], 'required', 'on' => 'registration'],
+            [['newPassword', 'newPasswordConfirm'], 'trim'],
+            [['user_id'], 'integer'],
+            [['password', 'salt'], 'string'],
+            [['created_at'], 'safe'],
+            [['algorithm'], 'string', 'max' => 20],
+            [['currentPassword'], CheckPasswordValidator::className(), 'on' => 'changePassword'],
+            [['newPassword', 'newPasswordConfirm', 'currentPassword'], 'required', 'on' => 'changePassword'],
+            [['newPassword', 'newPasswordConfirm'], 'string', 'min' => 5, 'max' => 255, 'on' => 'changePassword'],
+            [['newPassword'], 'unequalsCurrentPassword', 'on' => 'changePassword'],
+            [['newPasswordConfirm'], 'compare', 'compareAttribute' => 'newPassword', 'on' => 'changePassword'],
+            [['newPasswordConfirm'], 'compare', 'compareAttribute' => 'newPassword', 'on' => 'registration'],
+			[['newPassword', 'newPasswordConfirm'], 'string', 'min' => Yii::$app->getModule('user')->settings->get('auth.MinPasswordLength'), 'max' => 255],
+			[['newPassword', 'newPasswordConfirm'], 'string', 'min' => 5, 'max' => 255],
+        ];
+    }
     }
     
     /**

--- a/protected/humhub/modules/user/models/User.php
+++ b/protected/humhub/modules/user/models/User.php
@@ -90,6 +90,7 @@ class User extends ContentContainerActiveRecord implements \yii\web\IdentityInte
             [['status', 'visibility'], 'integer'],
             [['tags'], 'string'],
             [['guid'], 'string', 'max' => 45],
+			[['username'], 'string', 'max' => 50, 'min' => Yii::$app->getModule('user')->settings->get('auth.MinUserNameLength')],
             [['username'], 'string', 'max' => 50, 'min' => Yii::$app->getModule('user')->minimumUsernameLength],
             [['time_zone'], 'in', 'range' => \DateTimeZone::listIdentifiers()],
             [['auth_mode'], 'string', 'max' => 10],


### PR DESCRIPTION
Add 3 settings in User Settings General:

Minimum UserName Length
(Min value is 4. If not set, Minimum Username Length is 4)
Minimum Password Length
(Min value is 5. If not set, Minimum Password Length is 5)
Password Complexity Force
(The password must contains characters from all of the following categories : Uppercase, Lowercase, Number and Special)

Settings are saved in database (settings)

Attention : PasswordSecurityValidator.php is based on https://github.com/SebSept/YiiPasswordValidator
