### PR TITLE
Update dev grunt dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,14 +1,18 @@
 {
   "name": "humhub",
-  "license" : "AGPL V3",
+  "license": "AGPL-3.0",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/humhub/humhub.git"
+  },
   "devDependencies": {
     "grunt": "^1.0.1",
-    "grunt-contrib-clean": "^1.0.0",
-    "grunt-contrib-concat": "^1.0.0",
+    "grunt-contrib-clean": "^1.1.0",
+    "grunt-contrib-concat": "^1.0.1",
     "grunt-contrib-copy": "*",
-    "grunt-contrib-cssmin": "^1.0.1",
-    "grunt-contrib-less": "^1.3.0",
-    "grunt-contrib-uglify": "^1.0.1",
+    "grunt-contrib-cssmin": "^2.1.0",
+    "grunt-contrib-less": "^1.4.1",
+    "grunt-contrib-uglify": "^2.3.0",
     "grunt-contrib-watch": "^1.0.0",
     "grunt-shell": "^2.1.0"
   }


### PR DESCRIPTION
- Update dependencies
- Fix warnings on build

```
npm WARN humhub@ No repository field.
npm WARN humhub@ license should be a valid SPDX license expression
```