### PR TITLE
Avoid HTML tags on Page Titles

### DIFF
--- a/protected/humhub/views/layouts/main.php
+++ b/protected/humhub/views/layouts/main.php
@@ -8,7 +8,7 @@
 <!DOCTYPE html>
 <html lang="<?= Yii::$app->language ?>">
     <head>
-        <title><?= $this->pageTitle; ?></title>
+        <title><?= strip_tags($this->pageTitle); ?></title>
         <meta charset="<?= Yii::$app->charset ?>">
         <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no">
         <?php $this->head() ?>


### PR DESCRIPTION
Like `<title><strong>Search</strong></title>` that becomes `<title>Search</title>`