### PR TITLE
Fix search index containing index for select fields

### DIFF
--- a/protected/humhub/modules/user/models/User.php
+++ b/protected/humhub/modules/user/models/User.php
@@ -565,7 +565,7 @@ class User extends ContentContainerActiveRecord implements \yii\web\IdentityInte
         if (!$this->profile->isNewRecord) {
             foreach ($this->profile->getProfileFields() as $profileField) {
                 if ($profileField->searchable) {
-                    $attributes['profile_' . $profileField->internal_name] = $profileField->getUserValue($this, true);
+                    $attributes['profile_' . $profileField->internal_name] = $profileField->getUserValue($this, false);
                 }
             }
         }


### PR DESCRIPTION
If I create a custom field with the Select type, what was indexed was the index number (for exemple 1) instead of the value, so the choice wasn't searchable.
Fix by setting false to the raw parameter of getUserValue.