### PR TITLE
Update MembershipController:search

### DIFF
--- a/protected/humhub/modules/space/controllers/MembershipController.php
+++ b/protected/humhub/modules/space/controllers/MembershipController.php
@@ -50,8 +50,10 @@ class MembershipController extends \humhub\modules\content\components\ContentCon
         Yii::$app->response->format = 'json';
 
         $space = $this->getSpace();
-
-        if (!$space->isMember()) {
+        $visibility = (int)$space->visibility;
+        if ($visibility === Space::VISIBILITY_NONE && !$space->isMember() ||
+            ($visibility === Space::VISIBILITY_REGISTERED_ONLY && Yii::$app->user->isGuest)
+        ) {
             throw new HttpException(404, Yii::t('SpaceModule.controllers_SpaceController', 'This action is only available for workspace members!'));
         }
 


### PR DESCRIPTION
If a space is public then you can see all members on main-page of the Space. But when I use this code:

```php
 <?= $form->field($documentRequest, 'receivers')
        ->widget(\humhub\modules\user\widgets\UserPickerField::class,
            [
                'url' => $contentContainer->createUrl('/space/membership/search'),
            ]
        ); ?>
```

I get 404 error, because I not a member of this Space. This different behavior for UI and code. 
This Pull Request fixes this case.

