### PR TITLE
Added missed id attribute to the widget

### DIFF
--- a/protected/humhub/modules/space/widgets/Menu.php
+++ b/protected/humhub/modules/space/widgets/Menu.php
@@ -29,6 +29,8 @@ class Menu extends \humhub\widgets\BaseMenu
         if ($this->space === null) {
             throw new \yii\base\Exception("Could not instance space menu without space!");
         }
+        
+        $this->id = 'navigation-menu-space-' . $this->space->getUniqueId();
 
         $this->addItemGroup(array(
             'id' => 'modules',


### PR DESCRIPTION
An ID must not be the empty string in view of this widget:

```html
<div id="<?= $this->context->id; ?>" class="panel panel-default">
```
[protected/humhub/widgets/views/leftNavigation.php:11](https://github.com/humhub/humhub/blob/master/protected/humhub/widgets/views/leftNavigation.php#L11)

