### PR TITLE
fix error

### DIFF
--- a/protected/humhub/config/common.php
+++ b/protected/humhub/config/common.php
@@ -119,7 +119,9 @@ $config = [
             'password' => '',
             'charset' => 'utf8',
             'enableSchemaCache' => true,
-            'on afterOpen' => ['humhub\libs\Helpers', 'SqlMode'],
+            'on afterOpen' => function ($event) {
+                humhub\libs\Helpers::SqlMode($event);
+            },
         ],
         'authClientCollection' => [
             'class' => 'humhub\modules\user\authclient\Collection',


### PR DESCRIPTION
```
PHP Warning 'yii\base\ErrorException' with message 'call_user_func() expects parameter 1 to be a valid callback, array must have exactly two members'

in \humhub\protected\vendor\yiisoft\yii2\base\Component.php:547
```

https://github.com/humhub/humhub/commit/83f69c8b0972bb2ed098a7ed1c4fccdff5f0faf2#commitcomment-23435580