### PR TITLE
add a link to the permalink from the ago text

### DIFF
--- a/protected/humhub/modules/content/widgets/views/wallEntry.php
+++ b/protected/humhub/modules/content/widgets/views/wallEntry.php
@@ -8,6 +8,7 @@ use humhub\modules\content\widgets\WallEntryControls;
 use humhub\modules\space\widgets\Image as SpaceImage;
 use humhub\modules\content\widgets\WallEntryAddons;
 use humhub\modules\content\widgets\WallEntryLabels;
+use yii\helpers\Url;
 
 /* @var $object \humhub\modules\content\components\ContentContainerActiveRecord */
 /* @var $renderControls boolean */
@@ -77,7 +78,9 @@ use humhub\modules\content\widgets\WallEntryLabels;
                     </div>
                 </div>
                 <div class="media-subheading">
-                    <?= TimeAgo::widget(['timestamp' => $createdAt]); ?>
+                    <a href="<?= Url::to(['/content/perma', 'id' => $object->content->id], true) ?>">
+                        <?= TimeAgo::widget(['timestamp' => $createdAt]); ?>
+                    </a>
                     <?php if ($updatedAt !== null) : ?>
                         &middot;
                         <span class="tt" title="<?= Yii::$app->formatter->asDateTime($updatedAt); ?>"><?= Yii::t('ContentModule.base', 'Updated'); ?></span>


### PR DESCRIPTION
This PR adds a link on the 'ago' text to the permalink for a post. the point of this is to make it easier to refer back to conversations by link by providing a much quicker way to get that link (right click, copy link) instead of needing to click into a context menu, find the permalink entry, and then copy it from the dialog.