### PR TITLE
improve composer-asset-plugin config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,18 @@
     },
     "config": {
         "process-timeout": 1800,
-        "vendor-dir": "protected/vendor"
+        "vendor-dir": "protected/vendor",
+        "fxp-asset":{
+            "installer-paths": {
+                "npm-asset-library": "protected/vendor/npm",
+                "bower-asset-library": "protected/vendor/bower"
+            },
+            "vcs-driver-options": {
+                "github-no-api": true
+            },
+            "git-skip-update": "2 days",
+            "pattern-skip-version": "(-build|-patch)"
+        }
     },
     "scripts": {
         "post-create-project-cmd": [


### PR DESCRIPTION
- Make sure to be compatible with newer versions of the plugin

  > The "extra.asset-installer-paths" option is deprecated, use the
  > "config.fxp-asset.installer-paths" option

- Improve performance of dependency resolution:
  https://github.com/yiisoft/yii2-app-basic/commit/120d35506e411e575ee07aac900d7394b5b7386c#diff-b5d0ee8c97c7abd7e3fa29b9a27d1780