### PR TITLE
Limit spaces in space chooser to make it scale

### DIFF
--- a/protected/humhub/components/bootstrap/ModuleAutoLoader.php
+++ b/protected/humhub/components/bootstrap/ModuleAutoLoader.php
@@ -30,8 +30,9 @@ class ModuleAutoLoader implements BootstrapInterface
             foreach (Yii::$app->params['moduleAutoloadPaths'] as $modulePath) {
                 $modulePath = Yii::getAlias($modulePath);
                 foreach (scandir($modulePath) as $moduleId) {
-                    if ($moduleId == '.' || $moduleId == '..')
+                    if ($moduleId === '.' || $moduleId === '..') {
                         continue;
+                    }
 
                     $moduleDir = $modulePath . DIRECTORY_SEPARATOR . $moduleId;
                     if (is_dir($moduleDir) && is_file($moduleDir . DIRECTORY_SEPARATOR . 'config.php')) {

--- a/protected/humhub/modules/activity/resources/js/humhub.activity.js
+++ b/protected/humhub/modules/activity/resources/js/humhub.activity.js
@@ -10,7 +10,7 @@ humhub.module('activity', function (module, require, $) {
     var loader = require('ui.loader');
 
     /**
-     * Number of initial stream enteis loaded when stream is initialized.
+     * Number of initial stream entries loaded when stream is initialized.
      * @type Number
      */
     var STREAM_INIT_COUNT = 10;

--- a/protected/humhub/modules/space/controllers/BrowseController.php
+++ b/protected/humhub/modules/space/controllers/BrowseController.php
@@ -8,8 +8,12 @@
 
 namespace humhub\modules\space\controllers;
 
+use humhub\components\access\ControllerAccess;
+use humhub\modules\space\models\Membership;
+use humhub\modules\space\widgets\Chooser;
 use Yii;
 use humhub\components\Controller;
+use yii\data\Pagination;
 
 /**
  * BrowseController
@@ -29,7 +33,10 @@ class BrowseController extends Controller
         return [
             'acl' => [
                 'class' => \humhub\components\behaviors\AccessControl::className(),
-                'guestAllowedActions' => ['search-json']
+                'guestAllowedActions' => ['search-json'],
+                'rules' => [
+                    [ControllerAccess::RULE_LOGGED_IN_ONLY => ['chooser-json']],
+                ],
             ]
         ];
     }
@@ -54,6 +61,31 @@ class BrowseController extends Controller
         ]);
 
         return $this->prepareResult($searchResultSet);
+    }
+
+    /**
+     * Returns a workspace list by json, implements pagination for the space chooser.
+     */
+    public function actionChooserJson()
+    {
+        \Yii::$app->response->format = 'json';
+
+        // paginates the result based on 'page' query parameter
+        $pagination = new Pagination([
+            'pageSize' => Chooser::SPACE_BATCH_SIZE,
+            'totalCount' => Membership::findByUser(Yii::$app->user->getIdentity())->count(),
+        ]);
+        $memberships = Membership::findByUser(Yii::$app->user->getIdentity())->limit($pagination->limit)->offset($pagination->offset)->all();
+
+        $items = [];
+        foreach ($memberships as $membership) {
+            $items[] = \humhub\modules\space\widgets\Chooser::getSpaceResult($membership->space, true, ['isMember' => true]);
+        }
+        return [
+            'items' => $items,
+            'page' => $pagination->page + 1,
+            'lastPage' => $pagination->page + 1 >= $pagination->pageCount,
+        ];
     }
 
     protected function prepareResult($searchResultSet)

--- a/protected/humhub/modules/space/widgets/Chooser.php
+++ b/protected/humhub/modules/space/widgets/Chooser.php
@@ -16,6 +16,11 @@ use yii\helpers\Html;
  */
 class Chooser extends Widget
 {
+    /**
+     * Maximum number of spaces to load per request.
+     */
+    const SPACE_BATCH_SIZE = 100;
+
 
     public static function getSpaceResult($space, $withChooserItem = true, $options = [])
     {
@@ -61,7 +66,7 @@ class Chooser extends Widget
     protected function getMemberships()
     {
         if (!Yii::$app->user->isGuest) {
-            return Membership::findByUser(Yii::$app->user->getIdentity())->all();
+            return Membership::findByUser(Yii::$app->user->getIdentity())->limit(static::SPACE_BATCH_SIZE)->all();
         }
     }
 
@@ -104,5 +109,3 @@ class Chooser extends Widget
     }
 
 }
-
-?>

--- a/protected/humhub/modules/space/widgets/Chooser.php
+++ b/protected/humhub/modules/space/widgets/Chooser.php
@@ -19,7 +19,7 @@ class Chooser extends Widget
     /**
      * Maximum number of spaces to load per request.
      */
-    const SPACE_BATCH_SIZE = 100;
+    const SPACE_BATCH_SIZE = 25;
 
 
     public static function getSpaceResult($space, $withChooserItem = true, $options = [])

--- a/protected/humhub/modules/space/widgets/views/spaceChooser.php
+++ b/protected/humhub/modules/space/widgets/views/spaceChooser.php
@@ -12,6 +12,7 @@ $noSpaceView = '<div class="no-space"><i class="fa fa-dot-circle-o"></i><br>' . 
 
 $this->registerJsConfig('space.chooser', [
     'noSpace' => $noSpaceView,
+    'loadEntriesUrl' => Url::to(['/space/browse/chooser-json']),
     'remoteSearchUrl' =>  Url::to(['/space/browse/search-json']),
     'text' => [
         'info.remoteAtLeastInput' => Yii::t('SpaceModule.widgets_views_spaceChooser', 'To search for other spaces, type at least {count} characters.', ['count' => 2]),


### PR DESCRIPTION
- limit the number of items initially loaded for the space chooser to 100.
- implemenated loading on scroll to load items when needed (inspired by
  the implementation of the latest activity widget)
- tested this with a setup with 20000 spaces.
- fixes #2835

By setting the batch size to 100 there should be no difference in
behavior for normal use cases but it would still work in large setups.