### PR TITLE
Fix bug on grunt build-assets

### DIFF
--- a/protected/humhub/assets/JqueryWidgetAsset.php
+++ b/protected/humhub/assets/JqueryWidgetAsset.php
@@ -26,6 +26,6 @@ class JqueryWidgetAsset extends AssetBundle
     /**
      * @inheritdoc
      */
-    public $js = ['ui/minified/widget.min.js'];
+    public $js = ['ui/minified/widget.js'];
 
 }


### PR DESCRIPTION
````PHP Warning 'yii\base\ErrorException' with message 'file_get_contents(/static/assets/956b8bf1/ui/minified/widget.min.js): failed to open stream: No such file or directory'````