### PR TITLE
Fix #2851: getting model attribute value using Html::getAttributeValue()

### DIFF
--- a/protected/humhub/widgets/BasePickerField.php
+++ b/protected/humhub/widgets/BasePickerField.php
@@ -244,7 +244,7 @@ abstract class BasePickerField extends InputWidget
         if (!$this->selection && $this->model != null) {
             $attribute = $this->attribute;
 
-            $this->selection = $this->loadItems($this->model->$attribute);
+            $this->selection = $this->loadItems(Html::getAttributeValue($this->model, $attribute));
         }
 
         if (!$this->selection) {


### PR DESCRIPTION
Using of Html::getAttributeValue() for parsing model attribute name resolve this issue.