### PR TITLE
Add custom phpcs configuration

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -7,7 +7,7 @@ engines:
  phpcodesniffer:
    enabled: true
    config:
-    standard: "PSR1,PSR2"
+    standard: "ruleset.xml"
 
 ratings:
  paths:

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<ruleset name="HumHub">
+    <description>HumHub coding standard.</description>
+
+    <!-- Include PSR-1 -->
+    <rule ref="PSR1"/>
+
+    <!-- Include PSR-2 -->
+    <rule ref="PSR2"/>
+
+    <!-- Prefer [] instead array() -->
+    <rule ref="Generic.Arrays.DisallowLongArraySyntax.Found">
+        <type>warning</type>
+    </rule>
+
+</ruleset>


### PR DESCRIPTION
@Felli told me that [] is preferred over array(). This pr adds a custom phpcs ruleset (based on PSR-1 & PSR-2) with Short-Array-Syntax preferred.