### PR TITLE
Detect dataType from server response in AJAX requests

### DIFF
--- a/static/js/humhub/humhub.client.js
+++ b/static/js/humhub/humhub.client.js
@@ -16,15 +16,24 @@ humhub.module('client', function (module, require, $) {
         this.response = xhr.responseJSON || xhr.responseText;
         //Textstatus = "timeout", "error", "abort", "parsererror", "application"
         this.textStatus = textStatus;
-        this.dataType = dataType;
         this.xhr = xhr;
 
-        var responseType = this.header('content-type');
+        if (!dataType) {
+            var responseType = this.header('content-type');
+            if (responseType && responseType.indexOf('json') > -1) {
+                dataType = 'json';
+            } else if (responseType && responseType.indexOf('html') > -1) {
+                dataType = 'html';
+            } else {
+                console.error('unable to determine dataType from response, this may cause problems.');
+            }
+        }
+        this.dataType = dataType;
 
         // If we expect json and received json we merge the json result with our response object.
-        if ((!dataType || dataType === 'json') && responseType && responseType.indexOf('json') > -1) {
+        if (this.dataType === 'json') {
             $.extend(this, this.response);
-        } else if (dataType) {
+        } else if (this.dataType === 'html') {
             this[dataType] = this.response;
         }
     };
@@ -230,9 +239,6 @@ humhub.module('client', function (module, require, $) {
             cfg.success = success;
             cfg.error = error;
             cfg.url = url;
-
-            //Setting some default values
-            cfg.dataType = cfg.dataType || "json";
 
             $.ajax(cfg);
         });

--- a/static/js/humhub/humhub.ui.modal.js
+++ b/static/js/humhub/humhub.ui.modal.js
@@ -190,7 +190,6 @@ humhub.module('ui.modal', function (module, require, $) {
     Modal.prototype.load = function (url, cfg, originalEvent) {
         var that = this;
         var cfg = cfg || {};
-        cfg.dataType = cfg.dataType || 'html';
         return new Promise(function (resolve, reject) {
             if (!that.isVisible()) {
                 that.loader();
@@ -205,7 +204,6 @@ humhub.module('ui.modal', function (module, require, $) {
     Modal.prototype.post = function (url, cfg, originalEvent) {
         var that = this;
         var cfg = cfg || {};
-        cfg.dataType = cfg.dataType || 'html';
         return new Promise(function (resolve, reject) {
             if (!that.isVisible()) {
                 that.loader();
@@ -679,7 +677,6 @@ humhub.module('ui.modal', function (module, require, $) {
 
     var _defaultRequestOptions = function (evt, options) {
         options = options || {};
-        options.dataType = options.dataType || evt.data('data-type', 'html');
         return options;
     };
 


### PR DESCRIPTION
This PR allows us to automatically detect `dataType` based on server response type.

We have a custom fork of the humhub-module-calendar where we'd like to introduce some changes. These involve changing the server response-type from `html` to `json`. Unfortunately, we were forced us to modify all references to `modal.load(...)`, specifying that these were now `dataType = 'json'` requests.

This is sub-optimal, since the `dataType` is already specified in the server response. [`$.ajax`](http://api.jquery.com/jquery.ajax/) already does the right thing:

> If none is specified, jQuery will try to infer [dataType] based on the MIME type of the response

I've attached [our private patch](https://github.com/humhub/humhub/files/1626334/0001-cleanup-major-always-return-json-when-editing-calend.patch.gz) as a demonstration of the "pain that this PR would save us for" :smiley: 