### PR TITLE
Exclude folder static/assets for codeclimate.

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -15,3 +15,4 @@ ratings:
 
 exclude_paths:
 - "**/messages/"
+- "static/assets/"


### PR DESCRIPTION
These files generated by yii.