### PR TITLE
Exclude codeception generated

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -15,5 +15,5 @@ ratings:
 
 exclude_paths:
 - "**/messages/"
-- "**/_generated/"
+- "**/codeception/_support/_generated/"
 - "static/assets/"

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -15,4 +15,5 @@ ratings:
 
 exclude_paths:
 - "**/messages/"
+- "**_generated/"
 - "static/assets/"

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -15,5 +15,5 @@ ratings:
 
 exclude_paths:
 - "**/messages/"
-- "**_generated/"
+- "**/_generate/"
 - "static/assets/"

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -15,5 +15,5 @@ ratings:
 
 exclude_paths:
 - "**/messages/"
-- "**/_generate/"
+- "**/_generated/"
 - "static/assets/"


### PR DESCRIPTION
Files inside codeception/_support/_generate could be ignored by codeclimate