### PR TITLE
Fix #2921

### DIFF
--- a/protected/humhub/modules/user/components/PermissionManager.php
+++ b/protected/humhub/modules/user/components/PermissionManager.php
@@ -12,6 +12,7 @@ use humhub\libs\BasePermission;
 use humhub\modules\user\models\GroupPermission;
 use Yii;
 use yii\base\Component;
+use yii\base\Module as BaseModule;
 
 /**
  * Description of PermissionManager
@@ -294,7 +295,7 @@ class PermissionManager extends Component
      * @return array of BasePermissions
      * @throws \yii\base\InvalidConfigException
      */
-    protected function getModulePermissions(Module $module)
+    protected function getModulePermissions(BaseModule $module)
     {
         $result = [];
         if ($module instanceof Module) {

--- a/protected/humhub/modules/user/components/PermissionManager.php
+++ b/protected/humhub/modules/user/components/PermissionManager.php
@@ -291,7 +291,7 @@ class PermissionManager extends Component
     /**
      * Returns permissions provided by a module
      *
-     * @param Module $module
+     * @param BaseModule $module
      * @return array of BasePermissions
      * @throws \yii\base\InvalidConfigException
      */


### PR DESCRIPTION
Fix #2921

> Declaration of `humhub\modules\content\components\ContentContainerPermissionManager::getModulePermissions(yii\base\Module $module)` should be compatible with `humhub\modules\user\components\PermissionManager::getModulePermissions(humhub\components\Module $module)`

@luke- @danielkesselberg 