### PR TITLE
Yii 2.0.11 added Init-Event for Widget.

### DIFF
--- a/protected/humhub/widgets/GridView.php
+++ b/protected/humhub/widgets/GridView.php
@@ -1,8 +1,7 @@
 <?php
-
 /**
  * @link https://www.humhub.org/
- * @copyright Copyright (c) 2015 HumHub GmbH & Co. KG
+ * @copyright Copyright (c) 2018 HumHub GmbH & Co. KG
  * @license https://www.humhub.com/licences
  */
 
@@ -13,18 +12,6 @@ namespace humhub\widgets;
  */
 class GridView extends \yii\grid\GridView
 {
-
-    const EVENT_INIT = 'init';
-
-    /**
-     * @inheritdoc
-     */
-    public function init()
-    {
-        $this->trigger(self::EVENT_INIT);
-        parent::init();
-    }
-
     /**
      * @inheritdoc
      */
@@ -45,5 +32,4 @@ class GridView extends \yii\grid\GridView
 
         return parent::run();
     }
-
 }


### PR DESCRIPTION
Yii 2.0.11 [see this commit](https://github.com/yiisoft/yii2/commit/7c1693479fbc8441d1565958942aeb7490872cb6) added Init-Event for Widgets.

I guess its required to remove the Init-Event from humhub\widgets\GridView because the event is trigger twice at the moment.

@acs-ferreira @githubjeka 