### PR TITLE
Fix Exception 'ReflectionException'

### DIFF
--- a/protected/humhub/tests/config/common.php
+++ b/protected/humhub/tests/config/common.php
@@ -19,11 +19,10 @@ return [
             ],
         ],
         'queue' => [
-            'class' => 'humhub\components\queue\driver\Instant',
+            'class' => 'humhub\modules\queue\driver\Instant',
         ],
     ],
     'params' => [
         'installed' => true,
-        'moduleAutoloadPaths' => ['/home/travis/build/humhub'],
     ]
 ];


### PR DESCRIPTION
Fixes for travis ci Exception 'ReflectionException' with message 'Class humhub\components\queue\driver\Instant does not exist' 

https://travis-ci.org/humhub/humhub/jobs/340865331#L544

Also, need to merge 1.3-dev with the lasted master branch to fix next others tests problems...