### PR TITLE
fix assertEqualsLastEmailSubject in tests

### DIFF
--- a/protected/humhub/tests/codeception/_support/HumHubDbTestCase.php
+++ b/protected/humhub/tests/codeception/_support/HumHubDbTestCase.php
@@ -159,7 +159,7 @@ class HumHubDbTestCase extends Test
     public function assertEqualsLastEmailSubject($subject)
     {
         $message = $this->getModule('Yii2')->grabLastSentEmail();
-        $this->assertEquals($subject, $message->getSubject());
+        $this->assertEquals($subject, str_replace(["\n", "\r"], '', $message->getSubject()));
     }
 
     public function allowGuestAccess($allow = true)


### PR DESCRIPTION
Fix tests like this https://travis-ci.org/humhub/humhub/jobs/342250980#L2106

![image](https://user-images.githubusercontent.com/874234/36307412-1af7bee6-132d-11e8-8746-ac9966bb7292.png)
