### PR TITLE
Switch from mkdir() to FileHelper::createDirectory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,9 @@ matrix:
 
 dist: trusty
 
+sudo: required
 addons:
   chrome: stable
-
-# faster builds on new travis setup not using sudo
-sudo: false
 
 # cache vendor dirs
 cache:

--- a/protected/humhub/commands/MessageController.php
+++ b/protected/humhub/commands/MessageController.php
@@ -11,6 +11,8 @@ namespace humhub\commands;
 use Yii;
 use yii\helpers\Console;
 use yii\helpers\FileHelper;
+use yii\helpers\Json;
+use yii\base\Exception;
 
 /**
  * Extracts messages to be translated from source files.
@@ -42,9 +44,7 @@ class MessageController extends \yii\console\controllers\MessageController
 
         $config['sourcePath'] = $module->getBasePath();
 
-        if (!is_dir($config['sourcePath'] . '/messages')) {
-            @mkdir($config['sourcePath'] . '/messages');
-        }
+        FileHelper::createDirectory($config['sourcePath'] . '/messages');
 
         $files = FileHelper::findFiles(realpath($config['sourcePath']), $config);
 
@@ -63,9 +63,7 @@ class MessageController extends \yii\console\controllers\MessageController
 
         foreach ($config['languages'] as $language) {
             $dir = $config['sourcePath'] . DIRECTORY_SEPARATOR . 'messages' . DIRECTORY_SEPARATOR . $language;
-            if (!is_dir($dir)) {
-                @mkdir($dir);
-            }
+            FileHelper::createDirectory($dir);
 
             $this->saveMessagesToPHP($messages, $dir, $config['overwrite'], $config['removeUnused'], $config['sort'], false);
         }
@@ -122,7 +120,7 @@ class MessageController extends \yii\console\controllers\MessageController
                 $moduleId = strtolower(preg_replace("/([A-Z])/", '_\1', lcfirst($result[1])));
                 try {
                     return Yii::$app->moduleManager->getModule($moduleId, true);
-                } catch (\yii\base\Exception $ex) {
+                } catch (Exception $ex) {
                     // Module not found, try again with dash syntax
                     $moduleId = strtolower(preg_replace("/([A-Z])/", '-\1', lcfirst($result[1])));
                     return Yii::$app->moduleManager->getModule($moduleId, true);
@@ -156,7 +154,7 @@ class MessageController extends \yii\console\controllers\MessageController
             $archive = [];
             $archiveFile = Yii::getAlias('@humhub/messages/' . $language . '/archive.json');
             if (file_exists($archiveFile)) {
-                $archive = \yii\helpers\Json::decode(file_get_contents($archiveFile));
+                $archive = Json::decode(file_get_contents($archiveFile));
             }
 
             // Loop overall messages
@@ -172,7 +170,7 @@ class MessageController extends \yii\console\controllers\MessageController
                                 $translated = preg_replace('/@@$/', '', $translated);
                             }
 
-                            if ($translated != "") {
+                            if ($translated != '') {
                                 if (isset($archive[$original]) && !in_array($translated, $archive[$original])) {
                                     $archive[$original][] = $translated;
                                 } else {
@@ -185,7 +183,7 @@ class MessageController extends \yii\console\controllers\MessageController
             }
 
             // Save
-            file_put_contents($archiveFile, \yii\helpers\Json::encode($archive));
+            file_put_contents($archiveFile, Json::encode($archive));
 
             print "Saved!\n";
         }

--- a/protected/humhub/components/ModuleManager.php
+++ b/protected/humhub/components/ModuleManager.php
@@ -9,10 +9,12 @@
 namespace humhub\components;
 
 use Yii;
+use yii\base\Component;
 use yii\base\Exception;
 use yii\base\Event;
 use yii\base\InvalidConfigException;
 use yii\helpers\FileHelper;
+use yii\helpers\ArrayHelper;
 use humhub\components\bootstrap\ModuleAutoLoader;
 use humhub\models\ModuleEnabled;
 
@@ -21,7 +23,7 @@ use humhub\models\ModuleEnabled;
  *
  * @author luke
  */
-class ModuleManager extends \yii\base\Component
+class ModuleManager extends Component
 {
 
     /**
@@ -82,7 +84,7 @@ class ModuleManager extends \yii\base\Component
 
      * @throws Exception
      */
-    public function registerBulk(Array $configs)
+    public function registerBulk(array $configs)
     {
         foreach ($configs as $basePath => $config) {
             $this->register($basePath, $config);
@@ -104,7 +106,7 @@ class ModuleManager extends \yii\base\Component
 
         // Check mandatory config options
         if (!isset($config['class']) || !isset($config['id'])) {
-            throw new InvalidConfigException("Module configuration requires an id and class attribute!");
+            throw new InvalidConfigException('Module configuration requires an id and class attribute!');
         }
 
         $isCoreModule = (isset($config['isCoreModule']) && $config['isCoreModule']);
@@ -134,7 +136,7 @@ class ModuleManager extends \yii\base\Component
 
         // Handle Submodules
         if (!isset($config['modules'])) {
-            $config['modules'] = array();
+            $config['modules'] = [];
         }
 
         if ($isCoreModule) {
@@ -153,7 +155,7 @@ class ModuleManager extends \yii\base\Component
 
         // Add config file values to module
         if (isset(Yii::$app->modules[$config['id']]) && is_array(Yii::$app->modules[$config['id']])) {
-            $moduleConfig = \yii\helpers\ArrayHelper::merge($moduleConfig, Yii::$app->modules[$config['id']]);
+            $moduleConfig = ArrayHelper::merge($moduleConfig, Yii::$app->modules[$config['id']]);
         }
 
         // Register Yii Module
@@ -240,7 +242,7 @@ class ModuleManager extends \yii\base\Component
             return Yii::createObject($class, [$id, Yii::$app]);
         }
 
-        throw new Exception("Could not find/load requested module: " . $id);
+        throw new Exception('Could not find/load requested module: ' . $id);
     }
 
     /**
@@ -282,7 +284,7 @@ class ModuleManager extends \yii\base\Component
         $module = $this->getModule($moduleId);
 
         if ($module == null) {
-            throw new Exception("Could not load module to remove!");
+            throw new Exception('Could not load module to remove!');
         }
 
         /**
@@ -296,14 +298,10 @@ class ModuleManager extends \yii\base\Component
          * Remove Folder
          */
         if ($this->createBackup) {
-            $moduleBackupFolder = Yii::getAlias("@runtime/module_backups");
-            if (!is_dir($moduleBackupFolder)) {
-                if (!@mkdir($moduleBackupFolder)) {
-                    throw new Exception("Could not create module backup folder!");
-                }
-            }
+            $moduleBackupFolder = Yii::getAlias('@runtime/module_backups');
+            FileHelper::createDirectory($moduleBackupFolder);
 
-            $backupFolderName = $moduleBackupFolder . DIRECTORY_SEPARATOR . $moduleId . "_" . time();
+            $backupFolderName = $moduleBackupFolder . DIRECTORY_SEPARATOR . $moduleId . '_' . time();
             $moduleBasePath = $module->getBasePath();
             FileHelper::copyDirectory($moduleBasePath, $backupFolderName);
             FileHelper::removeDirectory($moduleBasePath);
@@ -367,7 +365,7 @@ class ModuleManager extends \yii\base\Component
     {
         foreach ($modules as $module) {
             $module = ($module instanceof Module) ? $module : $this->getModule($module);
-            if($module != null) {
+            if ($module != null) {
                 $module->disable();
             }
         }

--- a/protected/humhub/libs/LogoImage.php
+++ b/protected/humhub/libs/LogoImage.php
@@ -8,10 +8,11 @@
 
 namespace humhub\libs;
 
+use humhub\modules\file\libs\ImageConverter;
 use Yii;
 use yii\web\UploadedFile;
 use yii\helpers\Url;
-use humhub\modules\file\libs\ImageConverter;
+use yii\helpers\FileHelper;
 
 /**
  * LogoImage

--- a/protected/humhub/libs/LogoImage.php
+++ b/protected/humhub/libs/LogoImage.php
@@ -93,8 +93,8 @@ class LogoImage
             'height' => $this->height,
             'width' => 0,
             'mode' => 'max',
-            'transparent' => ($file->getExtension() == 'png' && ImageConverter::checkTransparent($this->getPath())))
-        ];
+            'transparent' => ($file->getExtension() == 'png' && ImageConverter::checkTransparent($this->getPath()))
+        ]);
     }
 
     /**

--- a/protected/humhub/libs/LogoImage.php
+++ b/protected/humhub/libs/LogoImage.php
@@ -70,10 +70,9 @@ class LogoImage
      */
     public function getPath()
     {
-        $path = \Yii::getAlias("@webroot") . DIRECTORY_SEPARATOR . "uploads" . DIRECTORY_SEPARATOR . $this->folder_images . DIRECTORY_SEPARATOR;
+        $path = Yii::getAlias('@webroot') . DIRECTORY_SEPARATOR . 'uploads' . DIRECTORY_SEPARATOR . $this->folder_images . DIRECTORY_SEPARATOR;
 
-        if (!is_dir($path))
-            mkdir($path);
+        FileHelper::createDirectory($path);
 
         $path .= 'logo.png';
 
@@ -90,12 +89,12 @@ class LogoImage
         $this->delete();
         move_uploaded_file($file->tempName, $this->getPath());
 
-        ImageConverter::Resize($this->getPath(), $this->getPath(), array(
+        ImageConverter::Resize($this->getPath(), $this->getPath(), [
             'height' => $this->height,
             'width' => 0,
             'mode' => 'max',
             'transparent' => ($file->getExtension() == 'png' && ImageConverter::checkTransparent($this->getPath())))
-        );
+        ];
     }
 
     /**

--- a/protected/humhub/libs/ProfileImage.php
+++ b/protected/humhub/libs/ProfileImage.php
@@ -10,6 +10,8 @@ namespace humhub\libs;
 
 use Yii;
 use yii\helpers\Url;
+use yii\helpers\FileHelper;
+use yii\web\UploadedFile;
 use humhub\modules\file\libs\ImageConverter;
 
 /**
@@ -31,7 +33,7 @@ class ProfileImage
     /**
      * @var String is the guid of user or space
      */
-    protected $guid = "";
+    protected $guid = '';
 
     /**
      * @var Integer width of the Image
@@ -46,7 +48,7 @@ class ProfileImage
     /**
      * @var String folder name inside the uploads directory
      */
-    protected $folder_images = "profile_image";
+    protected $folder_images = 'profile_image';
 
     /**
      * @var String name of the default image
@@ -73,7 +75,7 @@ class ProfileImage
      * @param boolean $scheme URL Scheme
      * @return String Url of the profile image
      */
-    public function getUrl($prefix = "", $scheme = false)
+    public function getUrl($prefix = '', $scheme = false)
     {
         if (file_exists($this->getPath($prefix))) {
             $path = '@web/uploads/' . $this->folder_images . '/';
@@ -95,7 +97,7 @@ class ProfileImage
      */
     public function hasImage()
     {
-        return file_exists($this->getPath("_org"));
+        return file_exists($this->getPath('_org'));
     }
 
     /**
@@ -104,16 +106,15 @@ class ProfileImage
      * @param String $prefix for the profile image
      * @return String Path to the profile image
      */
-    public function getPath($prefix = "")
+    public function getPath($prefix = '')
     {
         $path = Yii::getAlias('@webroot/uploads/' . $this->folder_images . '/');
 
-        if (!is_dir($path))
-            mkdir($path);
+        FileHelper::createDirectory($path, 0775, true);
 
         $path .= $this->guid;
         $path .= $prefix;
-        $path .= ".jpg";
+        $path .= '.jpg';
 
         return $path;
     }
@@ -138,7 +139,7 @@ class ProfileImage
             return false;
         }
 
-        unlink($this->getPath(''));
+        @unlink($this->getPath(''));
         imagejpeg($destImage, $this->getPath(''), 100);
     }
 
@@ -149,7 +150,7 @@ class ProfileImage
      */
     public function setNew($file)
     {
-        if ($file instanceof \yii\web\UploadedFile) {
+        if ($file instanceof UploadedFile) {
             $file = $file->tempName;
         }
 

--- a/protected/humhub/libs/ProfileImage.php
+++ b/protected/humhub/libs/ProfileImage.php
@@ -110,7 +110,7 @@ class ProfileImage
     {
         $path = Yii::getAlias('@webroot/uploads/' . $this->folder_images . '/');
 
-        FileHelper::createDirectory($path, 0775, true);
+        FileHelper::createDirectory($path);
 
         $path .= $this->guid;
         $path .= $prefix;

--- a/protected/humhub/modules/admin/libs/OnlineModuleManager.php
+++ b/protected/humhub/modules/admin/libs/OnlineModuleManager.php
@@ -2,7 +2,7 @@
 
 /**
  * @link https://www.humhub.org/
- * @copyright Copyright (c) 2017 HumHub GmbH & Co. KG
+ * @copyright Copyright (c) 2018 HumHub GmbH & Co. KG
  * @license https://www.humhub.com/licences
  */
 
@@ -11,6 +11,7 @@ namespace humhub\modules\admin\libs;
 use Yii;
 use yii\web\HttpException;
 use yii\base\Exception;
+use yii\helpers\FileHelper;
 use humhub\libs\CURLHelper;
 use ZipArchive;
 
@@ -40,14 +41,13 @@ class OnlineModuleManager
         $moduleInfo = $this->getModuleInfo($moduleId);
 
         if (!isset($moduleInfo['latestCompatibleVersion'])) {
-            throw new Exception(Yii::t('AdminModule.libs_OnlineModuleManager', "No compatible module version found!"));
+            throw new Exception(Yii::t('AdminModule.libs_OnlineModuleManager', 'No compatible module version found!'));
         }
-
 
         $moduleDir = $modulePath . DIRECTORY_SEPARATOR . $moduleId;
         if (is_dir($moduleDir)) {
             $files = new \RecursiveIteratorIterator(
-                    new \RecursiveDirectoryIterator($moduleDir, \RecursiveDirectoryIterator::SKIP_DOTS), \RecursiveIteratorIterator::CHILD_FIRST
+                     new \RecursiveDirectoryIterator($moduleDir, \RecursiveDirectoryIterator::SKIP_DOTS), \RecursiveIteratorIterator::CHILD_FIRST
             );
 
             foreach ($files as $fileinfo) {
@@ -55,17 +55,12 @@ class OnlineModuleManager
                 $todo($fileinfo->getRealPath());
             }
 
-            rmdir($moduleDir);
-            #throw new HttpException(500, Yii::t('AdminModule.libs_OnlineModuleManager', 'Module directory for module %moduleId% already exists!', array('%moduleId%' => $moduleId)));
+            FileHelper::removeDirectory($moduleDir);
         }
 
         // Check Module Folder exists
-        $moduleDownloadFolder = Yii::getAlias("@runtime/module_downloads");
-        if (!is_dir($moduleDownloadFolder)) {
-            if (!@mkdir($moduleDownloadFolder)) {
-                throw new Exception("Could not create module download folder!");
-            }
-        }
+        $moduleDownloadFolder = Yii::getAlias('@runtime/module_downloads');
+        FileHelper::createDirectory($moduleDownloadFolder);
 
         $version = $moduleInfo['latestCompatibleVersion'];
 
@@ -171,7 +166,7 @@ class OnlineModuleManager
                         $updates[$moduleId] = $moduleInfo;
                     }
                 } else {
-                    Yii::error("Could not load module: " . $moduleId . " to get updates");
+                    Yii::error('Could not load module: ' . $moduleId . ' to get updates');
                 }
             }
         }

--- a/protected/humhub/modules/file/components/StorageManager.php
+++ b/protected/humhub/modules/file/components/StorageManager.php
@@ -115,7 +115,7 @@ class StorageManager extends Component implements StorageManagerInterface
                         unlink($file);
                     }
                 }
-                rmdir($path);
+                FileHelper::removeDirectory($path);
             }
         } elseif (is_file($this->get($variant))) {
             unlink($this->get($variant));

--- a/protected/humhub/modules/search/engine/ZendLuceneSearch.php
+++ b/protected/humhub/modules/search/engine/ZendLuceneSearch.php
@@ -8,14 +8,26 @@
 
 namespace humhub\modules\search\engine;
 
-use Yii;
 use humhub\modules\search\interfaces\Searchable;
 use humhub\modules\search\libs\SearchResult;
 use humhub\modules\search\libs\SearchResultSet;
 use humhub\modules\space\models\Space;
+use humhub\modules\space\models\Membership;
+use ZendSearch\Lucene\Document;
 use ZendSearch\Lucene\Document\Field;
-use yii\helpers\VarDumper;
 use ZendSearch\Lucene\Lucene;
+use ZendSearch\Lucene\Search\Query\MultiTerm;
+use ZendSearch\Lucene\Index\Term;
+use ZendSearch\Lucene\Search\Query\Term as QueryTerm;
+use ZendSearch\Lucene\Search\Query\Wildcard;
+use ZendSearch\Lucene\Search\Query\Boolean;
+use ZendSearch\Lucene\Search\QueryParser;
+use ZendSearch\Lucene\Exception\RuntimeException;
+use ZendSearch\Lucene\Analysis\Analyzer\Analyzer;
+use ZendSearch\Lucene\Analysis\Analyzer\Common\Utf8Num\CaseInsensitive;
+use Yii;
+use yii\helpers\VarDumper;
+use yii\helpers\FileHelper;
 
 /**
  * ZendLucenceSearch Engine
@@ -59,7 +71,7 @@ class ZendLuceneSearch extends Search
 
         $index = $this->getIndex();
 
-        $doc = new \ZendSearch\Lucene\Document();
+        $doc = new Document();
 
         // Add Meta Data fields
         foreach ($this->getMetaInfoArray($obj) as $fieldName => $fieldValue) {
@@ -69,7 +81,7 @@ class ZendLuceneSearch extends Search
         // Add provided search infos
         foreach ($attributes as $key => $val) {
             if (is_array($val)) {
-                $val = implode(" ", $val);
+                $val = implode(' ', $val);
             }
 
             $doc->addField(Field::Text($key, $val, 'UTF-8'));
@@ -82,7 +94,7 @@ class ZendLuceneSearch extends Search
         }
 
         if (Yii::$app->request->isConsoleRequest) {
-            print ".";
+            print '.';
         }
 
         $index->addDocument($doc);
@@ -99,9 +111,9 @@ class ZendLuceneSearch extends Search
     {
         $index = $this->getIndex();
 
-        $query = new \ZendSearch\Lucene\Search\Query\MultiTerm();
-        $query->addTerm(new \ZendSearch\Lucene\Index\Term($obj->className(), 'model'), true);
-        $query->addTerm(new \ZendSearch\Lucene\Index\Term($obj->getPrimaryKey(), 'pk'), true);
+        $query = new MultiTerm();
+        $query->addTerm(new Term($obj->className(), 'model'), true);
+        $query->addTerm(new Term($obj->getPrimaryKey(), 'pk'), true);
 
         $hits = $index->find($query);
         foreach ($hits as $hit) {
@@ -123,19 +135,19 @@ class ZendLuceneSearch extends Search
         $this->index = null;
     }
 
-    public function find($keyword, Array $options)
+    public function find($keyword, array $options)
     {
         $options = $this->setDefaultFindOptions($options);
 
         $index = $this->getIndex();
-        $keyword = str_replace(array('*', '?', '_', '$', '-', '.'), ' ', mb_strtolower($keyword, 'utf-8'));
+        $keyword = str_replace(['*', '?', '_', '$', '-', '.'], ' ', mb_strtolower($keyword, 'utf-8'));
 
         $query = $this->buildQuery($keyword, $options);
         if ($query === null) {
             return new SearchResultSet();
         }
 
-        if (!isset($options['sortField']) || $options['sortField'] == "") {
+        if (!isset($options['sortField']) || $options['sortField'] == '') {
             $hits = new \ArrayObject($index->find($query));
         } else {
             $hits = new \ArrayObject($index->find($query, $options['sortField']));
@@ -171,16 +183,16 @@ class ZendLuceneSearch extends Search
     protected function buildQuery($keyword, $options)
     {
         // Allow *Token*
-        \ZendSearch\Lucene\Search\Query\Wildcard::setMinPrefixLength(0);
+        Wildcard::setMinPrefixLength(0);
 
-        $query = new \ZendSearch\Lucene\Search\Query\Boolean();
+        $query = new Boolean();
 
         $emptyQuery = true;
-        foreach (explode(" ", $keyword) as $k) {
+        foreach (explode(' ', $keyword) as $k) {
             // Require a minimum of non-wildcard characters
             if (mb_strlen($k, Yii::$app->charset) >= $this->minQueryTokenLength) {
-                $term = new \ZendSearch\Lucene\Index\Term("*$k*");
-                $query->addSubquery(new \ZendSearch\Lucene\Search\Query\Wildcard($term), true);
+                $term = new Term('*$k*');
+                $query->addSubquery(new Wildcard($term), true);
                 $emptyQuery = false;
             }
         }
@@ -192,79 +204,79 @@ class ZendLuceneSearch extends Search
         }
 
         // Add model filter
-        if (isset($options['model']) && $options['model'] != "") {
+        if (isset($options['model']) && $options['model'] != '') {
             if (is_array($options['model'])) {
-                $boolQuery = new \ZendSearch\Lucene\Search\Query\MultiTerm();
+                $boolQuery = new MultiTerm();
                 foreach ($options['model'] as $model) {
-                    $boolQuery->addTerm(new \ZendSearch\Lucene\Index\Term($model, 'model'));
+                    $boolQuery->addTerm(new Term($model, 'model'));
                 }
                 $query->addSubquery($boolQuery, true);
             } else {
-                $term = new \ZendSearch\Lucene\Index\Term($options['model'], 'model');
-                $query->addSubquery(new \ZendSearch\Lucene\Search\Query\Term($term), true);
+                $term = new Term($options['model'], 'model');
+                $query->addSubquery(new QueryTerm($term), true);
             }
         }
 
         // Add type filter
-        if (isset($options['type']) && $options['type'] != "") {
+        if (isset($options['type']) && $options['type'] != '') {
             if (is_array($options['type'])) {
-                $boolQuery = new \ZendSearch\Lucene\Search\Query\MultiTerm();
+                $boolQuery = new MultiTerm();
                 foreach ($options['type'] as $model) {
-                    $boolQuery->addTerm(new \ZendSearch\Lucene\Index\Term($type), 'type');
+                    $boolQuery->addTerm(new Term($type), 'type');
                 }
                 $query->addSubquery($boolQuery, true);
             } else {
-                $term = new \ZendSearch\Lucene\Index\Term($options['type'], 'type');
-                $query->addSubquery(new \ZendSearch\Lucene\Search\Query\Term($term), true);
+                $term = new Term($options['type'], 'type');
+                $query->addSubquery(new QueryTerm($term), true);
             }
         }
 
         // Add custom filters
         if (isset($options['filters']) && is_array($options['filters'])) {
             foreach ($options['filters'] as $field => $value) {
-                $term = new \ZendSearch\Lucene\Index\Term($value, $field);
-                $query->addSubquery(new \ZendSearch\Lucene\Search\Query\Term($term), true);
+                $term = new Term($value, $field);
+                $query->addSubquery(new QueryTerm($term), true);
             }
         }
 
 
         if ($options['checkPermissions'] && !Yii::$app->request->isConsoleRequest) {
 
-            $permissionQuery = new \ZendSearch\Lucene\Search\Query\Boolean();
+            $permissionQuery = new Boolean();
 
             if (Yii::$app->user->isGuest) {
 
                 // Guest Content
-                $guestContentQuery = new \ZendSearch\Lucene\Search\Query\Boolean();
-                $guestContentQuery->addSubquery(new \ZendSearch\Lucene\Search\Query\Term(new \ZendSearch\Lucene\Index\Term(self::DOCUMENT_VISIBILITY_PUBLIC, 'visibility')), true);
-                $guestContentQuery->addSubquery(new \ZendSearch\Lucene\Search\Query\Term(new \ZendSearch\Lucene\Index\Term(self::DOCUMENT_TYPE_CONTENT, 'type')), true);
-                $guestContentQuery->addSubquery(new \ZendSearch\Lucene\Search\Query\Term(new \ZendSearch\Lucene\Index\Term(Space::className(), 'containerModel')), true);
-                $guestSpaceListQuery = new \ZendSearch\Lucene\Search\Query\MultiTerm();
+                $guestContentQuery = new Boolean();
+                $guestContentQuery->addSubquery(new QueryTerm(new Term(self::DOCUMENT_VISIBILITY_PUBLIC, 'visibility')), true);
+                $guestContentQuery->addSubquery(new QueryTerm(new Term(self::DOCUMENT_TYPE_CONTENT, 'type')), true);
+                $guestContentQuery->addSubquery(new QueryTerm(new Term(Space::className(), 'containerModel')), true);
+                $guestSpaceListQuery = new MultiTerm();
                 foreach (Space::find()->where(['visibility' => Space::VISIBILITY_ALL])->all() as $space) {
-                    $guestSpaceListQuery->addTerm(new \ZendSearch\Lucene\Index\Term($space->id, 'containerPk'));
+                    $guestSpaceListQuery->addTerm(new Term($space->id, 'containerPk'));
                 }
                 $guestContentQuery->addSubquery($guestSpaceListQuery, true);
                 $permissionQuery->addSubquery($guestContentQuery);
 
                 // Guest Spaces
-                $guestSpacesQuery = new \ZendSearch\Lucene\Search\Query\Boolean();
-                $guestSpacesQuery->addSubquery(new \ZendSearch\Lucene\Search\Query\Term(new \ZendSearch\Lucene\Index\Term(self::DOCUMENT_TYPE_SPACE, 'type')), true);
-                $guestSpacesQuery->addSubquery(new \ZendSearch\Lucene\Search\Query\Term(new \ZendSearch\Lucene\Index\Term(self::DOCUMENT_VISIBILITY_PUBLIC, 'visibility')), true);
+                $guestSpacesQuery = new Boolean();
+                $guestSpacesQuery->addSubquery(new QueryTerm(new Term(self::DOCUMENT_TYPE_SPACE, 'type')), true);
+                $guestSpacesQuery->addSubquery(new QueryTerm(new Term(self::DOCUMENT_VISIBILITY_PUBLIC, 'visibility')), true);
                 $permissionQuery->addSubquery($guestSpacesQuery);
 
-                $permissionQuery->addSubquery(new \ZendSearch\Lucene\Search\Query\Term(new \ZendSearch\Lucene\Index\Term(self::DOCUMENT_TYPE_USER, 'type')));
+                $permissionQuery->addSubquery(new QueryTerm(new Term(self::DOCUMENT_TYPE_USER, 'type')));
             } else {
                 //--- Public Content
-                $permissionQuery->addSubquery(new \ZendSearch\Lucene\Search\Query\Term(new \ZendSearch\Lucene\Index\Term(self::DOCUMENT_VISIBILITY_PUBLIC, 'visibility')));
+                $permissionQuery->addSubquery(new QueryTerm(new Term(self::DOCUMENT_VISIBILITY_PUBLIC, 'visibility')));
 
                 //--- Private Space Content
-                $privateSpaceContentQuery = new \ZendSearch\Lucene\Search\Query\Boolean();
-                $privateSpaceContentQuery->addSubquery(new \ZendSearch\Lucene\Search\Query\Term(new \ZendSearch\Lucene\Index\Term(self::DOCUMENT_VISIBILITY_PRIVATE, 'visibility')), true);
-                $privateSpaceContentQuery->addSubquery(new \ZendSearch\Lucene\Search\Query\Term(new \ZendSearch\Lucene\Index\Term(Space::className(), 'containerModel')), true);
-                $privateSpacesListQuery = new \ZendSearch\Lucene\Search\Query\MultiTerm();
+                $privateSpaceContentQuery = new Boolean();
+                $privateSpaceContentQuery->addSubquery(new QueryTerm(new Term(self::DOCUMENT_VISIBILITY_PRIVATE, 'visibility')), true);
+                $privateSpaceContentQuery->addSubquery(new QueryTerm(new Term(Space::className(), 'containerModel')), true);
+                $privateSpacesListQuery = new MultiTerm();
 
-                foreach (\humhub\modules\space\models\Membership::GetUserSpaces() as $space) {
-                    $privateSpacesListQuery->addTerm(new \ZendSearch\Lucene\Index\Term($space->id, 'containerPk'));
+                foreach (Membership::GetUserSpaces() as $space) {
+                    $privateSpacesListQuery->addTerm(new Term($space->id, 'containerPk'));
                 }
 
                 $privateSpaceContentQuery->addSubquery($privateSpacesListQuery, true);
@@ -275,11 +287,11 @@ class ZendLuceneSearch extends Search
 
         if (count($options['limitSpaces']) > 0) {
 
-            $spaceBaseQuery = new \ZendSearch\Lucene\Search\Query\Boolean();
-            $spaceBaseQuery->addSubquery(new \ZendSearch\Lucene\Search\Query\Term(new \ZendSearch\Lucene\Index\Term(Space::className(), 'containerModel')), true);
-            $spaceIdQuery = new \ZendSearch\Lucene\Search\Query\MultiTerm();
+            $spaceBaseQuery = new Boolean();
+            $spaceBaseQuery->addSubquery(new QueryTerm(new Term(Space::className(), 'containerModel')), true);
+            $spaceIdQuery = new MultiTerm();
             foreach ($options['limitSpaces'] as $space) {
-                $spaceIdQuery->addTerm(new \ZendSearch\Lucene\Index\Term($space->id, 'containerPk'));
+                $spaceIdQuery->addTerm(new Term($space->id, 'containerPk'));
             }
             $spaceBaseQuery->addSubquery($spaceIdQuery, true);
             $query->addSubquery($spaceBaseQuery, true);
@@ -297,19 +309,20 @@ class ZendLuceneSearch extends Search
     protected function getIndex()
     {
 
-        if ($this->index != null)
+        if ($this->index != null) {
             return $this->index;
+        }
 
-        \ZendSearch\Lucene\Search\QueryParser::setDefaultEncoding('utf-8');
-        \ZendSearch\Lucene\Analysis\Analyzer\Analyzer::setDefault(new \ZendSearch\Lucene\Analysis\Analyzer\Common\Utf8Num\CaseInsensitive());
-        \ZendSearch\Lucene\Search\QueryParser::setDefaultOperator(\ZendSearch\Lucene\Search\QueryParser::B_AND);
+        QueryParser::setDefaultEncoding('utf-8');
+        Analyzer::setDefault(new CaseInsensitive());
+        QueryParser::setDefaultOperator(QueryParser::B_AND);
 
-        \ZendSearch\Lucene\Lucene::setTermsPerQueryLimit($this->searchItemLimit);
+        Lucene::setTermsPerQueryLimit($this->searchItemLimit);
 
         try {
-            $index = \ZendSearch\Lucene\Lucene::open($this->getIndexPath());
-        } catch (\ZendSearch\Lucene\Exception\RuntimeException $ex) {
-            $index = \ZendSearch\Lucene\Lucene::create($this->getIndexPath());
+            $index = Lucene::open($this->getIndexPath());
+        } catch (RuntimeException $ex) {
+            $index = Lucene::create($this->getIndexPath());
         }
 
         $this->index = $index;
@@ -319,10 +332,7 @@ class ZendLuceneSearch extends Search
     protected function getIndexPath()
     {
         $path = Yii::getAlias(Yii::$app->params['search']['zendLucenceDataDir']);
-
-        if (!is_dir($path)) {
-            mkdir($path);
-        }
+        FileHelper::removeDirectory($path);
 
         return $path;
     }

--- a/protected/humhub/modules/search/engine/ZendLuceneSearch.php
+++ b/protected/humhub/modules/search/engine/ZendLuceneSearch.php
@@ -332,7 +332,7 @@ class ZendLuceneSearch extends Search
     protected function getIndexPath()
     {
         $path = Yii::getAlias(Yii::$app->params['search']['zendLucenceDataDir']);
-        FileHelper::removeDirectory($path);
+        FileHelper::createDirectory($path);
 
         return $path;
     }


### PR DESCRIPTION
ToDo : switch `unlink()` to `FileHelper::unlink` (globaly), when ready to upgrade to **Yii 2.0.14**
This will be done in a separate PR (in the v1.3-dev branch)

https://github.com/yiisoft/yii2/blob/313be2a5d75951e48273c6dae04eba2ab879fba9/framework/helpers/BaseFileHelper.php#L402

**=>The latest commit https://github.com/humhub/humhub/pull/3041/commits/b9e11ec6bc12a116bdd966f88eb66adf730aca02 should fix Travis tests.**

Reviews welcome @danielkesselberg @buddh4 