### PR TITLE
autocomplete PHPStorm for behaviors for Content's models [skip ci]

### DIFF
--- a/protected/humhub/modules/content/components/ContentActiveRecord.php
+++ b/protected/humhub/modules/content/components/ContentActiveRecord.php
@@ -45,6 +45,7 @@ use humhub\modules\content\interfaces\ContentOwner;
  * Note: If the underlying Content record cannot be saved or validated an Exception will thrown.
  *
  * @property Content $content
+ * @mixin \humhub\modules\user\behaviors\Followable
  * @author Luke
  */
 class ContentActiveRecord extends ActiveRecord implements ContentOwner

--- a/protected/humhub/modules/content/models/Content.php
+++ b/protected/humhub/modules/content/models/Content.php
@@ -41,7 +41,8 @@ use yii\rbac\Permission;
  * @property string $stream_channel
  * @property integer $contentcontainer_id;
  * @property ContentContainerActiveRecord $container
- *
+ * @mixin \humhub\components\behaviors\PolymorphicRelation
+ * @mixin \humhub\components\behaviors\GUID
  * @since 0.5
  */
 class Content extends ContentDeprecated
@@ -73,7 +74,7 @@ class Content extends ContentDeprecated
      * @var ContentContainerActiveRecord the Container (e.g. Space or User) where this content belongs to.
      */
     protected $_container = null;
-    
+
     /**
      * @var bool flag to disable the creation of default social activities like activity and notifications in afterSave() at content creation.
      * @deprecated since v1.2.3 use ContentActiveRecord::silentContentCreation instead.
@@ -87,8 +88,8 @@ class Content extends ContentDeprecated
     {
         return [
             [
-                'class' => \humhub\components\behaviors\PolymorphicRelation::className(),
-                'mustBeInstanceOf' => array(ContentActiveRecord::className()),
+                'class' => \humhub\components\behaviors\PolymorphicRelation::class,
+                'mustBeInstanceOf' => [ContentActiveRecord::class],
             ],
             [
                 'class' => \humhub\components\behaviors\GUID::className(),
@@ -594,7 +595,7 @@ class Content extends ContentDeprecated
         if ($user->isSystemAdmin() && Yii::$app->getModule('content')->adminCanViewAllContent) {
             return true;
         }
-        
+
         if ($this->isPrivate() && $this->getContainer() !== null && $this->getContainer()->canAccessPrivateContent($user)) {
             return true;
         }

--- a/protected/humhub/modules/content/models/ContentContainer.php
+++ b/protected/humhub/modules/content/models/ContentContainer.php
@@ -20,6 +20,7 @@ use humhub\modules\content\components\ContentContainerActiveRecord;
  * @property string $class
  * @property integer $pk
  * @property integer $owner_user_id
+ * @mixin PolymorphicRelation
  */
 class ContentContainer extends \yii\db\ActiveRecord
 {


### PR DESCRIPTION
For more info see https://blog.jetbrains.com/phpstorm/2013/11/phpstorm-7-1-eap-133-51/

> A way to document mixins: now PhpStorm interprets @mixin regardless of PHP version just the same way it interprets “use trait” (see WI-1730 for details)