### PR TITLE
Enhancement HumHubDbTestCase

### DIFF
--- a/protected/humhub/tests/codeception/_support/HumHubDbTestCase.php
+++ b/protected/humhub/tests/codeception/_support/HumHubDbTestCase.php
@@ -190,11 +190,10 @@ class HumHubDbTestCase extends Unit
 
     public function allowGuestAccess($allow = true)
     {
-        if ($allow) {
-            Yii::$app->getModule('user')->settings->set('auth.allowGuestAccess', 1);
-        } else {
-            Yii::$app->getModule('user')->settings->set('auth.allowGuestAccess', 0);
-        }
+        Yii::$app
+            ->getModule('user')
+            ->settings
+            ->set('auth.allowGuestAccess', (int)$allow);
     }
 
     public function setGroupPermission($groupId, $permission, $state = BasePermission::STATE_ALLOW)

--- a/protected/humhub/tests/codeception/_support/HumHubDbTestCase.php
+++ b/protected/humhub/tests/codeception/_support/HumHubDbTestCase.php
@@ -188,6 +188,9 @@ class HumHubDbTestCase extends Unit
         $this->assertEquals($subject, str_replace(["\n", "\r"], '', $message->getSubject()));
     }
 
+    /**
+     * @param bool $allow
+     */
     public function allowGuestAccess($allow = true)
     {
         Yii::$app


### PR DESCRIPTION
- deprecated `Codeception\TestCase\Test` replaced to `Codeception\Test\Unit`
Note: now you can mark file as text `protected/vendor/codeception/codeception/shim.php`

- optimize imports for default fixture. All fixtures with fullpath you can see in
`HumHubDbTestCase::getDefaultFixtures()`

- fix for `HumHubDbTestCase::assertHasNotification()`.
Method `Notification::find($conditions)` hasn't any arguments. Replaced to
`Notification::find()->where($conditions)`

- To autocomplete IDE added new `HumHubDbTestCase:getYiiModule()`
  instead `HumHubDbTestCase::getModule('Yii2')`

- `HumHubDbTestCase::assertMailSent` becomes deprecated.
Use `HumHubDbTestCase::assertSentEmail` instead