### PR TITLE
improve performance for search (avoid memory issues)

### DIFF
--- a/protected/humhub/modules/admin/controllers/UserController.php
+++ b/protected/humhub/modules/admin/controllers/UserController.php
@@ -238,7 +238,7 @@ class UserController extends Controller
         if ($doit == 2) {
             $this->forcePostRequest();
 
-            foreach (Membership::GetUserSpaces($user->id) as $space) {
+            foreach (Membership::getUserSpaces($user->id) as $space) {
                 if ($space->isSpaceOwner($user->id)) {
                     $space->addMember(Yii::$app->user->id);
                     $space->setSpaceOwner(Yii::$app->user->id);

--- a/protected/humhub/modules/live/Module.php
+++ b/protected/humhub/modules/live/Module.php
@@ -13,6 +13,7 @@ use humhub\modules\content\models\Content;
 use humhub\modules\user\models\User;
 use humhub\modules\user\models\Follow;
 use humhub\modules\friendship\models\Friendship;
+use humhub\modules\space\models\Membership;
 
 /**
  * Live module provides a live channel to the users browser.
@@ -85,7 +86,7 @@ class Module extends \humhub\components\Module
             $legitimation[Content::VISIBILITY_OWNER][] = $user->contentContainerRecord->id;
 
             // Collect user space membership with private content visibility
-            $spaces = \humhub\modules\space\models\Membership::GetUserSpaces($user->id);
+            $spaces = Membership::getUserSpaces($user->id);
             foreach ($spaces as $space) {
                 $legitimation[Content::VISIBILITY_PRIVATE][] = $space->contentContainerRecord->id;
             }

--- a/protected/humhub/modules/search/engine/ZendLuceneSearch.php
+++ b/protected/humhub/modules/search/engine/ZendLuceneSearch.php
@@ -275,7 +275,7 @@ class ZendLuceneSearch extends Search
                 $privateSpaceContentQuery->addSubquery(new QueryTerm(new Term(Space::className(), 'containerModel')), true);
                 $privateSpacesListQuery = new MultiTerm();
 
-                foreach (Membership::GetUserSpaceIds() as $spaceId) {
+                foreach (Membership::getUserSpaceIds() as $spaceId) {
                     $privateSpacesListQuery->addTerm(new Term($spaceId, 'containerPk'));
                 }
 

--- a/protected/humhub/modules/search/engine/ZendLuceneSearch.php
+++ b/protected/humhub/modules/search/engine/ZendLuceneSearch.php
@@ -275,8 +275,8 @@ class ZendLuceneSearch extends Search
                 $privateSpaceContentQuery->addSubquery(new QueryTerm(new Term(Space::className(), 'containerModel')), true);
                 $privateSpacesListQuery = new MultiTerm();
 
-                foreach (Membership::GetUserSpaces() as $space) {
-                    $privateSpacesListQuery->addTerm(new Term($space->id, 'containerPk'));
+                foreach (Membership::GetUserSpaceIds() as $spaceId) {
+                    $privateSpacesListQuery->addTerm(new Term($spaceId, 'containerPk'));
                 }
 
                 $privateSpaceContentQuery->addSubquery($privateSpacesListQuery, true);

--- a/protected/humhub/modules/space/Events.php
+++ b/protected/humhub/modules/space/Events.php
@@ -44,7 +44,7 @@ class Events extends \yii\base\Object
         $user = $event->sender;
 
         // Check if the user owns some spaces
-        foreach (Membership::GetUserSpaces($user->id) as $space) {
+        foreach (Membership::getUserSpaces($user->id) as $space) {
             if ($space->isSpaceOwner($user->id)) {
                 throw new HttpException(500, Yii::t('SpaceModule.base', 'Could not delete user who is a space owner! Name of Space: {spaceName}', array('spaceName' => $space->name)));
             }

--- a/protected/humhub/modules/space/models/Membership.php
+++ b/protected/humhub/modules/space/models/Membership.php
@@ -52,6 +52,10 @@ class Membership extends \yii\db\ActiveRecord
     const STATUS_APPLICANT = 2;
     const STATUS_MEMBER = 3;
 
+    const USER_SPACES_CACHE_KEY = 'userSpaces_';
+    const USER_SPACEIDS_CACHE_KEY = 'userSpaceIds_';
+
+
     /**
      * @inheritdoc
      */
@@ -121,13 +125,15 @@ class Membership extends \yii\db\ActiveRecord
 
     public function beforeSave($insert)
     {
-        Yii::$app->cache->delete('userSpaces_' . $this->user_id);
+        Yii::$app->cache->delete(self::USER_SPACES_CACHE_KEY . $this->user_id);
+        Yii::$app->cache->delete(self::USER_SPACEIDS_CACHE_KEY . $this->user_id);
         return parent::beforeSave($insert);
     }
 
     public function beforeDelete()
     {
-        Yii::$app->cache->delete('userSpaces_' . $this->user_id);
+        Yii::$app->cache->delete(self::USER_SPACES_CACHE_KEY . $this->user_id);
+        Yii::$app->cache->delete(self::USER_SPACEIDS_CACHE_KEY . $this->user_id);
         return parent::beforeDelete();
     }
 
@@ -159,17 +165,16 @@ class Membership extends \yii\db\ActiveRecord
      * @param boolean $cached use cached result if available
      * @return Space[] an array of spaces
      */
-    public static function GetUserSpaces($userId = "", $cached = true)
+    public static function getUserSpaces($userId = '', $cached = true)
     {
-        if ($userId == "") {
+        if ($userId === '') {
             $userId = Yii::$app->user->id;
         }
 
-        $cacheId = "userSpaces_" . $userId;
+        $cacheId = self::USER_SPACES_CACHE_KEY . $userId;
 
         $spaces = Yii::$app->cache->get($cacheId);
         if ($spaces === false || !$cached) {
-
             $spaces = [];
             foreach (static::getMembershipQuery($userId)->all() as $membership) {
                 $spaces[] = $membership->space;
@@ -185,19 +190,17 @@ class Membership extends \yii\db\ActiveRecord
      * @param integer $userId
      * @since 1.2.5
      */
-    public static function GetUserSpaceIds($userId = "")
+    public static function getUserSpaceIds($userId = '')
     {
-        if ($userId == "") {
+        if ($userId === '') {
             $userId = Yii::$app->user->id;
         }
 
-        $cacheId = "userSpaceIds_" . $userId;
+        $cacheId = self::USER_SPACEIDS_CACHE_KEY . $userId;
 
         $spaceIds = Yii::$app->cache->get($cacheId);
         if ($spaceIds === false) {
-
             $spaceIds = static::getMembershipQuery($userId)->select('space_id')->column();
-
             Yii::$app->cache->set($cacheId, $spaceIds);
         }
         return $spaceIds;

--- a/protected/humhub/modules/tour/controllers/TourController.php
+++ b/protected/humhub/modules/tour/controllers/TourController.php
@@ -70,7 +70,7 @@ class TourController extends \humhub\components\Controller
         $space = null;
 
         // Loop over all spaces where the user is member
-        foreach (\humhub\modules\space\models\Membership::GetUserSpaces() as $space) {
+        foreach (\humhub\modules\space\models\Membership::getUserSpaces() as $space) {
             if ($space->isAdmin() && !$space->isArchived()) {
                 // If user is admin on this space, it´s the perfect match
                 break;

--- a/protected/humhub/modules/user/controllers/AccountController.php
+++ b/protected/humhub/modules/user/controllers/AccountController.php
@@ -14,6 +14,7 @@ use humhub\modules\user\components\BaseAccountController;
 use humhub\modules\user\models\User;
 use humhub\modules\notification\models\forms\NotificationSettings;
 use humhub\modules\user\controllers\ImageController;
+use humhub\modules\space\models\Membership;
 
 /**
  * AccountController provides all standard actions for the current logged in
@@ -270,7 +271,7 @@ class AccountController extends BaseAccountController
             throw new HttpException(500, 'Account deletion not allowed');
         }
 
-        foreach (\humhub\modules\space\models\Membership::GetUserSpaces() as $space) {
+        foreach (Membership::getUserSpaces() as $space) {
             if ($space->isSpaceOwner($user->id)) {
                 $isSpaceOwner = true;
             }

--- a/protected/humhub/modules/user/models/User.php
+++ b/protected/humhub/modules/user/models/User.php
@@ -340,7 +340,7 @@ class User extends ContentContainerActiveRecord implements \yii\web\IdentityInte
     public function beforeDelete()
     {
         // We don't allow deletion of users who owns a space - validate that
-        foreach (Membership::GetUserSpaces($this->id, false) as $space) {
+        foreach (Membership::getUserSpaces($this->id, false) as $space) {
             if ($space->isSpaceOwner($this->id)) {
                 throw new Exception('Tried to delete a user (' . $this->id . ') which is owner of a space (' . $space->id . ')!');
             }


### PR DESCRIPTION
when limiting a search query to spaces, only the space IDs are necessary.
When a user is member in many spaces, loading all the spaces objects
consumes a lot of memory and in extreme cases can cause Humhub to crash
with out of memory error.

This problem is fixed by adding a new method
`Membership::GetUserSpaceIds()` a new private method is added to ensure
the query is the same for `GetUserSpaceIds()` and `GetUserSpaces()`.