### PR TITLE
Apply Yii security patch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": ">=5.6.0",
-        "yiisoft/yii2": "2.0.14.*",
+        "yiisoft/yii2": "2.0.15.*",
         "yiisoft/yii2-bootstrap": "~2.0.0",
         "yiisoft/yii2-swiftmailer": "~2.0.0",
         "yiisoft/yii2-authclient": "~2.1.0",


### PR DESCRIPTION
See http://www.yiiframework.com/news/168/releasing-yii-2-0-15-and-database-extensions-with-security-fixes/

> Upgrading Yii addresses the SQL injection but doesn't make findOne() and findAll() safe in general. Check all usages of findOne() and findAll() in your application. Also note, that where() and filterWhere() never escape column names, so if you need to pass a variable as a column name, make sure it is safe.