### PR TITLE
[BUGFIX] remove `debugger;` in javascript from spaces tour

### DIFF
--- a/protected/humhub/modules/tour/widgets/views/guide_spaces.php
+++ b/protected/humhub/modules/tour/widgets/views/guide_spaces.php
@@ -9,7 +9,6 @@ $this->context->loadResources($this);
     var gotoProfile = false;
     $(document).on('ready', function () {
         // Create a new tour
-        debugger;
         var spacesTour = new Tour({
             storage: false,
             template: '<div class="popover tour"> <div class="arrow"></div> <h3 class="popover-title"></h3> <div class="popover-content"></div> <div class="popover-navigation"> <div class="btn-group"> <button class="btn btn-sm btn-default" data-role="prev"><?php echo Yii::t('TourModule.base', '« Prev'); ?></button> <button class="btn btn-sm btn-default" data-role="next"><?php echo Yii::t('TourModule.base', 'Next »'); ?></button>  </div> <button class="btn btn-sm btn-default" data-role="end"><?php echo Yii::t('TourModule.base', 'End guide'); ?></button> </div> </div>',


### PR DESCRIPTION
This PR removes the `debugger;` to prevent the starting of the dev tools then viewing the tour.

Closes #3182 