### PR TITLE
CodeClimate does not pickup phpcs.xml.dist

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,17 +1,15 @@
 engines:
- duplication:
-   enabled: true
-   config:
-     languages:
-     - php
- phpcodesniffer:
-   enabled: true
-
+    duplication:
+        enabled: true
+        config:
+            languages: [php]
+    phpcodesniffer:
+        enabled: true
+        standard: phpcs.xml.dist
 ratings:
- paths:
- - "**.php"
-
+    paths:
+        - '**.php'
 exclude_paths:
-- "**/messages/"
-- "**/codeception/_support/_generated/"
-- "static/assets/"
+    - '**/messages/'
+    - '**/codeception/_support/_generated/'
+    - static/assets/

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,15 +1,14 @@
-engines:
+version: '2'
+plugins:
     duplication:
         enabled: true
         config:
             languages: [php]
     phpcodesniffer:
         enabled: true
-        standard: phpcs.xml.dist
-ratings:
-    paths:
-        - '**.php'
-exclude_paths:
+        config:
+            standard: phpcs.xml.dist
+exclude_patterns:
     - '**/messages/'
     - '**/codeception/_support/_generated/'
     - static/assets/


### PR DESCRIPTION
CodeClimate does not pickup our custom phpcs standard. Caused by bug in outdated phpcodesniffer.