### PR TITLE
Added a "Interlink wiki page" toolbar-button

### DIFF
--- a/static/js/humhub/humhub.ui.markdown.js
+++ b/static/js/humhub/humhub.ui.markdown.js
@@ -123,9 +123,23 @@ humhub.module('ui.markdown', function (module, require, $) {
                 [{
                     name: "groupCustom",
                     data: [{
+                        name: "cmdInterLinkWiki",
+                        title: "InterlinkWiki",
+                        icon: {glyph: 'glyphicon glyphicon-link', fa: 'fa fa-link', 'fa-3': 'icon-link'},
+                        callback: function (e) {
+
+							vtitle = e.getSelection().text;
+							if (vtitle != "") {
+
+								vLink = '[' + vtitle + '](' +  vtitle + ')';
+								e.replaceSelection(vLink);
+							}
+                        }
+                    },
+                    {
                         name: "cmdLinkWiki",
                         title: "URL/Link",
-                        icon: {glyph: 'glyphicon glyphicon-link', fa: 'fa fa-link', 'fa-3': 'icon-link'},
+	                    icon: {glyph: 'glyphicon glyphicon-link', fa: 'fa fa-external-link', 'fa-3': 'icon-link'},
                         callback: function (e) {
                             var linkModal = modal.get('#markdown-modal-add-link');
                             $titleInput = linkModal.$.find('.linkTitle');

--- a/static/js/humhub/humhub.ui.markdown.js
+++ b/static/js/humhub/humhub.ui.markdown.js
@@ -128,10 +128,10 @@ humhub.module('ui.markdown', function (module, require, $) {
                         icon: {glyph: 'glyphicon glyphicon-link', fa: 'fa fa-link', 'fa-3': 'icon-link'},
                         callback: function (e) {
 
-							vtitle = e.getSelection().text;
+							var vtitle = e.getSelection().text;
 							if (vtitle != "") {
 
-								vLink = '[' + vtitle + '](' +  vtitle + ')';
+								var vLink = '[' + vtitle + '](' +  vtitle + ')';
 								e.replaceSelection(vLink);
 							}
                         }


### PR DESCRIPTION
A simple toolbar-button to convert marked text to link for another wiki
page. "marked text" => [marked text](marked text). + switched icon on
the old link button to "fa-external-link".