### PR TITLE
BC break for itemKey of UserPickerField

### DIFF
--- a/protected/humhub/modules/user/tests/codeception/unit/UserPickerFieldTest.php
+++ b/protected/humhub/modules/user/tests/codeception/unit/UserPickerFieldTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace tests\codeception\unit;
+
+use humhub\modules\user\widgets\UserPickerField;
+use tests\codeception\_support\HumHubDbTestCase;
+
+class UserPickerFieldTest extends HumHubDbTestCase
+{
+    public function testItemKey()
+    {
+        $picker = new UserPickerField();
+        $this->assertEquals('guid', $picker->itemKey);
+
+        $picker = new UserPickerField(['itemKey' => 'id']);
+        $this->assertEquals('id', $picker->itemKey);
+    }
+}

--- a/protected/humhub/modules/user/widgets/UserPickerField.php
+++ b/protected/humhub/modules/user/widgets/UserPickerField.php
@@ -2,11 +2,11 @@
 
 namespace humhub\modules\user\widgets;
 
-use Yii;
 use humhub\modules\user\models\User;
-use yii\helpers\Html;
-use \yii\helpers\Url;
 use humhub\widgets\BasePickerField;
+use Yii;
+use yii\helpers\Html;
+use yii\helpers\Url;
 
 /**
  *
@@ -16,27 +16,33 @@ use humhub\widgets\BasePickerField;
  */
 class UserPickerField extends BasePickerField
 {
-
     /**
-     * @inheritdoc 
+     * @inheritdoc
      */
     public $defaultRoute = '/user/search/json';
-    
+
     /**
-     * @inheritdoc 
+     * @inheritdoc
      */
     public $jsWidget = 'user.picker.UserPicker';
 
     /**
-     * @inheritdoc 
+     * @inheritdoc
+     * The 'guid' value is default for UserPickerField
      */
-    public function init() {
+    public $itemKey = 'guid';
+
+    /**
+     * @inheritdoc
+     */
+    public function init()
+    {
         $this->itemClass = User::className();
-        if(!$this->itemKey) {
+        if (empty($this->itemKey)) {
             $this->itemKey = 'guid';
         }
     }
-    
+
     /**
      * @inheritdoc
      */
@@ -55,30 +61,36 @@ class UserPickerField extends BasePickerField
     }
 
     /**
-     * @inheritdoc 
+     * @inheritdoc
      */
     protected function getData()
     {
         $result = parent::getData();
         $allowMultiple = $this->maxSelection !== 1;
-        $result['placeholder'] = ($this->placeholder != null) ? $this->placeholder : Yii::t('UserModule.widgets_UserPickerField', 'Select {n,plural,=1{user} other{users}}', ['n' => ($allowMultiple) ? 2 : 1]);
-        
-        if($this->placeholder && !$this->placeholderMore) {
+        $result['placeholder'] = ($this->placeholder != null)
+            ? $this->placeholder
+            : Yii::t('UserModule.widgets_UserPickerField', 'Select {n,plural,=1{user} other{users}}',
+                ['n' => ($allowMultiple) ? 2 : 1]);
+
+        if ($this->placeholder && !$this->placeholderMore) {
             $result['placeholder-more'] = $this->placeholder;
         } else {
-            $result['placeholder-more'] = ($this->placeholderMore) ? $this->placeholderMore : Yii::t('UserModule.widgets_UserPickerField', 'Add more...');
+            $result['placeholder-more'] = ($this->placeholderMore) ? $this->placeholderMore
+                : Yii::t('UserModule.widgets_UserPickerField', 'Add more...');
         }
-        
+
         $result['no-result'] = Yii::t('UserModule.widgets_UserPickerField', 'No users found for the given query.');
 
         if ($this->maxSelection) {
-            $result['maximum-selected'] = Yii::t('UserModule.widgets_UserPickerField', 'This field only allows a maximum of {n,plural,=1{# user} other{# users}}.', ['n' => $this->maxSelection]);
+            $result['maximum-selected'] = Yii::t('UserModule.widgets_UserPickerField',
+                'This field only allows a maximum of {n,plural,=1{# user} other{# users}}.',
+                ['n' => $this->maxSelection]);
         }
         return $result;
     }
 
     /**
-     * @inheritdoc 
+     * @inheritdoc
      */
     protected function getItemText($item)
     {
@@ -86,7 +98,7 @@ class UserPickerField extends BasePickerField
     }
 
     /**
-     * @inheritdoc 
+     * @inheritdoc
      */
     protected function getItemImage($item)
     {


### PR DESCRIPTION
My code

```php
<?= $form->field($model, 'attribute')
          ->widget(\humhub\modules\user\widgets\UserPickerField::class); ?>
```

Before 1.3 , input value is `$model->attribute`

After 1.3 input value always null. Bug in https://github.com/humhub/humhub/commit/af85d33f5faf70c77f7f808d5ee89d2478dcd077#diff-b7487eb0708eec7dc191a72a89c1c131

