### PR TITLE
Fix Overflow on long filenames

### DIFF
--- a/static/less/stream.less
+++ b/static/less/stream.less
@@ -44,6 +44,7 @@
             overflow:hidden;
             text-overflow:ellipsis;
             max-width: 100%;
+            display: inline-block;
         }
 
         img {


### PR DESCRIPTION
Should fix these overflows:
![image](https://user-images.githubusercontent.com/12234510/45587721-02a55000-b90a-11e8-94ae-0fd1d60005b9.png)
