### PR TITLE
Change isolated to isolate

### DIFF
--- a/protected/humhub/docs/guide/admin/installation-configuration.md
+++ b/protected/humhub/docs/guide/admin/installation-configuration.md
@@ -42,7 +42,7 @@ The asynchronous job-runner can also be executed manually as follows:
 > /usr/bin/php /path/to/humhub/protected/yii queue/run
 ```
 
-> Note: If you're on a **shared hosting environment**, you may need to add the `--isolated=0` option to the `queue/run`. e.g. `/usr/bin/php /path/to/humhub/protected/yii queue/run --isolated=0`
+> Note: If you're on a **shared hosting environment**, you may need to add the `--isolate=0` option to the `queue/run`. e.g. `/usr/bin/php /path/to/humhub/protected/yii queue/run --isolate=0`
 
 **Example CronTab configuration:**
 


### PR DESCRIPTION
@mk314 suggested https://github.com/humhub/humhub/issues/3308#issuecomment-423819238 that `isolated` should be `isolate`. 

Looks correct for me when i look at yii2-queue: https://github.com/yiisoft/yii2-queue/blob/d291834dc3df44dd2f17b4222a3172102eb16a4a/src/cli/Command.php#L48-L51