### PR TITLE
Expose signingOptions and extraCerts params

### DIFF
--- a/protected/humhub/components/mail/Mailer.php
+++ b/protected/humhub/components/mail/Mailer.php
@@ -41,6 +41,17 @@ class Mailer extends \yii\swiftmailer\Mailer
      * @var string|null Path for the sigining certificate private key. If provided emails will be digitally signed before sending.
      */
     public $signingPrivateKeyPath = null;
+    
+    /**
+     * @var string|null Path for extra sigining certificates (i.e. intermidiate certificates).
+     */
+    public $signingExtraCertsPath = null;
+
+    /**
+     * @var int Bitwise operator options for openssl_pkcs7_sign()     
+    */
+    public $signingOptions = PKCS7_DETACHED;
+
 
     /**
      * Creates a new message instance and optionally composes its body content via view rendering.
@@ -72,7 +83,8 @@ class Mailer extends \yii\swiftmailer\Mailer
         }
 
         if ($this->signingCertificatePath !== null && $this->signingPrivateKeyPath !== null) {
-            $message->setSmimeSigner($this->signingCertificatePath, $this->signingPrivateKeyPath);
+            $message->setSmimeSigner($this->signingCertificatePath, $this->signingPrivateKeyPath, $this->signingOptions, $this->signingExtraCertsPath);
+
         }
 
         return $message;

--- a/protected/humhub/components/mail/Message.php
+++ b/protected/humhub/components/mail/Message.php
@@ -16,11 +16,11 @@ namespace humhub\components\mail;
  */
 class Message extends \yii\swiftmailer\Message
 {
-    public function setSmimeSigner($signingCertificatePath, $signingPrivateKeyPath) 
+    public function setSmimeSigner($signingCertificatePath, $signingPrivateKeyPath, $signingOptions = PKCS7_DETACHED, $extraCerts = null)
 	{
 		$signer = \Swift_Signers_SMimeSigner::newInstance();
 
-		$signer->setSignCertificate($signingCertificatePath, $signingPrivateKeyPath);
+		$signer->setSignCertificate($signingCertificatePath, $signingPrivateKeyPath, $signingOptions, $extraCerts);
 
 		$this->getSwiftMessage()->attachSigner($signer);
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [X] Other, please describe: Enhancement

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [X] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included
- [ ] Changelog was modified

If adding a **new feature**, the PR's description includes:
- [X] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Some certificate providers may have a long list of intermediate certificates that must be included in the signing process. Without these certificates, some email clients may fail to verify the signature of the email.

The two additional Module params relating to this would be:

- signingExtraCertsPath: Path to PEM file containing chain of Certificates 

- signingOptions: Bitwise operator options for openssl_pkcs7_sign

Issue: #3649
Based on PR: #3651