### PR TITLE
Fix: #3665 oEmbeds don't load properly a second time with pjax

### DIFF
--- a/protected/humhub/docs/CHANGELOG_DEV.md
+++ b/protected/humhub/docs/CHANGELOG_DEV.md
@@ -67,3 +67,4 @@ HumHub Change Log (DEVELOP)
 - Enh: Added `grunt test --debug` option
 - Fix #3653: Add PHP LibXML requirement
 - Enh: Added show password feature for password form elements
+- Fix: #3665 oEmbeds don't load properly a second time with pjax

--- a/protected/humhub/modules/stream/resources/js/humhub.stream.Stream.js
+++ b/protected/humhub/modules/stream/resources/js/humhub.stream.Stream.js
@@ -262,10 +262,18 @@ humhub.module('stream.Stream', function (module, require, $) {
     Stream.prototype.addResponseEntries = function (request, options) {
         options = $.extend(request.options, options || {});
         var that = this;
-        var result = '';
 
         this.removeResponseEntries(request);
         var $result = $(request.getResultHtml());
+        $result.find('script[src]').each(function(){
+            var cacheBusterPrefix;
+            if(/\?/.test(this.src)) {
+                cacheBusterPrefix = '&_=';
+            } else {
+                cacheBusterPrefix = '?_=';
+            }
+            this.src += cacheBusterPrefix + Date.now();
+        });
 
         this.$.trigger('humhub:stream:beforeAddEntries', [request.response, request, $result]);
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->
Fix: #3665 oEmbeds don't load properly a second time with pjax

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [x] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included
- [x] Changelog was modified