### PR TITLE
Fix profile Friends panel collapsibility

### DIFF
--- a/protected/humhub/modules/friendship/widgets/views/friendsPanel.php
+++ b/protected/humhub/modules/friendship/widgets/views/friendsPanel.php
@@ -3,7 +3,7 @@
 use yii\helpers\Html;
 ?>
 <?php if (count($friends) > 0) { ?>
-    <div class="panel panel-default follower" id="profile-follower-panel">
+    <div class="panel panel-default follower" id="profile-friends-panel">
         <?php echo \humhub\widgets\PanelMenu::widget(['id' => 'profile-friends-panel']); ?>
 
         <div class="panel-heading"><strong><?php echo Yii::t('FriendshipModule.base', 'Friends'); ?></strong> (<?php echo $totalCount; ?>)</div>


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included
- [ ] Changelog was modified

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

The profile Friends panel was using the same div id as the Followers panel, causing it to collapse at the same time as the Followers panel, and preventing it from collapsing from its own widget panel menu. Fix this by correcting the div id to match the panel widget configuration.
