### PR TITLE
Fix #2456: Only display list of relevant modules on space creation

### DIFF
--- a/protected/humhub/modules/content/components/behaviors/CompatModuleManager.php
+++ b/protected/humhub/modules/content/components/behaviors/CompatModuleManager.php
@@ -47,6 +47,11 @@ class CompatModuleManager extends Behavior
         return $this->moduleManager->isEnabled($moduleId);
     }
 
+    public function canEnableModule($id)
+    {
+        return $this->moduleManager->canEnable($id);
+    }
+
     public function enableModule($moduleId)
     {
         return $this->moduleManager->enable($moduleId);

--- a/protected/humhub/modules/space/views/create/modules.php
+++ b/protected/humhub/modules/space/views/create/modules.php
@@ -19,7 +19,13 @@ SpaceAsset::register($this);
 
             <div class="row">
 
-                <?php foreach ($availableModules as $moduleId => $module) : ?>
+                <?php foreach ($availableModules as $moduleId => $module) :
+
+                    if (($space->isModuleEnabled($moduleId) && !$space->canDisableModule($moduleId)) ||
+                        (!$space->isModuleEnabled($moduleId) && !$space->canEnableModule($moduleId))) {
+                        continue;
+                    }
+                    ?>
                     <div class="col-md-6">
                         <div class="media well well-small ">
                             <img class="media-object img-rounded pull-left" data-src="holder.js/64x64" alt="64x64"
@@ -45,19 +51,18 @@ SpaceAsset::register($this);
                                     }
                                 }
                                 ?>
-                                <a href="#" class="btn btn-sm btn-primary enable" 
-                                    data-action-click="content.container.enableModule" 
-                                    data-ui-loader
-                                    data-action-url="<?= $space->createUrl('/space/manage/module/enable', ['moduleId' => $moduleId]); ?>">
-                                        <?= Yii::t('SpaceModule.manage', 'Enable'); ?>
+                                <a href="#" class="btn btn-sm btn-primary <?= $enable ?>"
+                                   data-action-click="content.container.enableModule"
+                                   data-ui-loader
+                                   data-action-url="<?= $space->createUrl('/space/manage/module/enable', ['moduleId' => $moduleId]); ?>">
+                                    <?= Yii::t('SpaceModule.manage', 'Enable'); ?>
                                 </a>
-                                
-                                <a href="#" class="btn btn-sm btn-primary disable" 
-                                   style="display:none"
-                                    data-action-click="content.container.disableModule" 
-                                    data-ui-loader
-                                    data-action-url="<?= $space->createUrl('/space/manage/module/disable', ['moduleId' => $moduleId]); ?>">
-                                        <?= Yii::t('SpaceModule.manage', 'Disable'); ?>
+
+                                <a href="#" class="btn btn-sm btn-primary <?= $disable ?>"
+                                   data-action-click="content.container.disableModule"
+                                   data-ui-loader
+                                   data-action-url="<?= $space->createUrl('/space/manage/module/disable', ['moduleId' => $moduleId]); ?>">
+                                    <?= Yii::t('SpaceModule.manage', 'Disable'); ?>
                                 </a>
                             </div>
                         </div>
@@ -68,11 +73,11 @@ SpaceAsset::register($this);
         </div>
 
         <div class="modal-footer">
-            <a href="#" class="btn btn-primary" 
-               data-action-click="ui.modal.post" 
+            <a href="#" class="btn btn-primary"
+               data-action-click="ui.modal.post"
                data-ui-loader
                data-action-url="<?= Url::to(['/space/create/invite', 'spaceId' => $space->id]); ?>">
-                   <?= Yii::t('SpaceModule.manage', 'Next'); ?>
+                <?= Yii::t('SpaceModule.manage', 'Next'); ?>
             </a>
         </div>
     </div>


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [x] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [x] All tests are passing
- [ ] New/updated tests are included
- [ ] Changelog was modified

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
_On space creation, only display those modules which:_
- is enabled and can be disabled
OR
- is disabled and can be enabled

Fixes #2456
