### PR TITLE
Fix #4031: Notifications with non existing base model breaks notifications

### DIFF
--- a/protected/humhub/docs/CHANGELOG.md
+++ b/protected/humhub/docs/CHANGELOG.md
@@ -1,6 +1,11 @@
 HumHub Change Log
 =================
 
+1.5.2 (Unreleased)
+----------------------
+
+- Fix #4031: Notifications with non existing base model breaks notification list
+
 
 1.5.1 (April 18, 2020)
 ----------------------

--- a/protected/humhub/modules/notification/controllers/ListController.php
+++ b/protected/humhub/modules/notification/controllers/ListController.php
@@ -47,7 +47,7 @@ class ListController extends Controller
             try {
                 $baseModel = $notification->getBaseModel();
 
-                if (!$baseModel->validate()) {
+                if (!$baseModel || !$baseModel->validate()) {
                     throw new IntegrityException('Invalid base model found for notification');
                 }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No