### PR TITLE
Fix #4086: Maximum call stack size exceeded thrown on ActivityStreamEntry.remove

### DIFF
--- a/protected/humhub/docs/CHANGELOG.md
+++ b/protected/humhub/docs/CHANGELOG.md
@@ -11,6 +11,7 @@ HumHub Change Log
 - Fix #4078: Richtext linkextension pattern fails on link extensions with containing `)` in link title
 - Fix #4080: Invalid absolute urls created in acceptance tests
 - Fix #4030: #search-menu-nav required in theme view layout main
+- Fix #4086: Maximum call stack size exceeded thrown on ActivityStreamEntry.remove
 
 1.5.1 (April 19, 2020)
 ----------------------

--- a/protected/humhub/modules/stream/resources/js/humhub.stream.StreamEntry.js
+++ b/protected/humhub/modules/stream/resources/js/humhub.stream.StreamEntry.js
@@ -384,7 +384,7 @@ humhub.module('stream.StreamEntry', function (module, require, $) {
      */
     StreamEntry.prototype.remove = function () {
         var stream = this.stream();
-        return this.super('remove').then($.proxy(stream.onChange, stream));
+        return Content.prototype.remove.call(this).then($.proxy(stream.onChange, stream));
     };
 
     module.export = StreamEntry;


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No
