### PR TITLE
Enh #4061: Improved post context menu order

### DIFF
--- a/protected/humhub/docs/CHANGELOG.md
+++ b/protected/humhub/docs/CHANGELOG.md
@@ -18,6 +18,7 @@ HumHub Change Log
 - Fix #4096: Missing CreatePost permission check in post model canMove
 - Fix #4098: Space setting edit fails due to unique name validation
 - Fix #4100: Empty message validation errors on post and comment edit broken
+- Enh #4061: Improved post context menu order
 
 
 1.5.1 (April 19, 2020)

--- a/protected/humhub/modules/content/widgets/WallEntry.php
+++ b/protected/humhub/modules/content/widgets/WallEntry.php
@@ -187,13 +187,14 @@ class WallEntry extends Widget
     {
         $result = [];
 
-        $this->addControl($result, [DeleteLink::class, ['content' => $this->contentObject], ['sortOrder' => 100]]);
-
         if (!empty($this->getEditUrl())) {
-            $this->addControl($result, [EditLink::class, ['model' => $this->contentObject, 'mode' => $this->editMode, 'url' => $this->getEditUrl()], ['sortOrder' => 200]]);
+            $this->addControl($result, [EditLink::class, ['model' => $this->contentObject, 'mode' => $this->editMode, 'url' => $this->getEditUrl()], ['sortOrder' => 100]]);
         }
 
-        $this->addControl($result, [PermaLink::class, ['content' => $this->contentObject], ['sortOrder' => 300]]);
+        $this->addControl($result, [PermaLink::class, ['content' => $this->contentObject], ['sortOrder' => 200]]);
+
+        $this->addControl($result, [DeleteLink::class, ['content' => $this->contentObject], ['sortOrder' => 300]]);
+
         $this->addControl($result, new DropdownDivider(['sortOrder' => 350]));
         $this->addControl($result, [VisibilityLink::class, ['contentRecord' => $this->contentObject], ['sortOrder' => 400]]);
         $this->addControl($result, [NotificationSwitchLink::class, ['content' => $this->contentObject], ['sortOrder' => 500]]);


### PR DESCRIPTION
Implements #4061: Improved post context menu order:

 - Edit
 - Permalink
 - Delete

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No