### PR TITLE
Enh #3990: Use StrictAccess by default in humhub\components\Controller

### DIFF
--- a/protected/humhub/components/Controller.php
+++ b/protected/humhub/components/Controller.php
@@ -9,6 +9,7 @@
 namespace humhub\components;
 
 use humhub\components\access\ControllerAccess;
+use humhub\components\access\StrictAccess;
 use humhub\components\behaviors\AccessControl;
 use Yii;
 use yii\helpers\Url;
@@ -56,7 +57,7 @@ class Controller extends \yii\web\Controller
      * @var string defines the ControllerAccess class for this controller responsible for managing access rules
      * @see self::getAccess()
      */
-    protected $access = ControllerAccess::class;
+    protected $access = StrictAccess::class;
 
     /**
      * Returns access rules for the standard access control behavior.
@@ -70,7 +71,7 @@ class Controller extends \yii\web\Controller
     }
 
     /**
-     * @return null|ControllerAccess returns an ControllerAccess instance
+     * @return null|ControllerAccess returns a ControllerAccess instance
      */
     public function getAccess()
     {

--- a/protected/humhub/modules/activity/controllers/LinkController.php
+++ b/protected/humhub/modules/activity/controllers/LinkController.php
@@ -9,7 +9,6 @@
 namespace humhub\modules\activity\controllers;
 
 use Yii;
-use humhub\components\access\StrictAccess;
 use humhub\components\Controller;
 use humhub\modules\activity\models\Activity;
 use yii\web\HttpException;
@@ -21,11 +20,6 @@ use yii\web\HttpException;
  */
 class LinkController extends Controller
 {
-
-    /**
-     * @inheritdoc
-     */
-    public $access = StrictAccess::class;
 
     /**
      * Returns the link for the given activity.

--- a/protected/humhub/modules/installer/controllers/ConfigController.php
+++ b/protected/humhub/modules/installer/controllers/ConfigController.php
@@ -8,6 +8,7 @@
 
 namespace humhub\modules\installer\controllers;
 
+use humhub\components\access\ControllerAccess;
 use humhub\components\Controller;
 use humhub\modules\marketplace\Module;
 use humhub\modules\queue\driver\Sync;
@@ -29,6 +30,12 @@ use yii\base\InvalidConfigException;
  */
 class ConfigController extends Controller
 {
+    /**
+     * Allow guest access independently from guest mode setting.
+     *
+     * @var string
+     */
+    public $access = ControllerAccess::class;
 
     const EVENT_INSTALL_SAMPLE_DATA = 'install_sample_data';
 

--- a/protected/humhub/modules/installer/controllers/IndexController.php
+++ b/protected/humhub/modules/installer/controllers/IndexController.php
@@ -9,6 +9,7 @@
 namespace humhub\modules\installer\controllers;
 
 
+use humhub\components\access\ControllerAccess;
 use humhub\components\Controller;
 
 
@@ -19,6 +20,12 @@ use humhub\components\Controller;
  */
 class IndexController extends Controller
 {
+    /**
+     * Allow guest access independently from guest mode setting.
+     *
+     * @var string
+     */
+    public $access = ControllerAccess::class;
 
     /**
      * Index View just provides a welcome page

--- a/protected/humhub/modules/installer/controllers/SetupController.php
+++ b/protected/humhub/modules/installer/controllers/SetupController.php
@@ -8,6 +8,7 @@
 
 namespace humhub\modules\installer\controllers;
 
+use humhub\components\access\ControllerAccess;
 use Yii;
 use humhub\components\Controller;
 use humhub\modules\installer\forms\DatabaseForm;
@@ -22,6 +23,13 @@ use humhub\modules\admin\widgets\PrerequisitesList;
  */
 class SetupController extends Controller
 {
+    /**
+     * Allow guest access independently from guest mode setting.
+     *
+     * @var string
+     */
+    public $access = ControllerAccess::class;
+
 
     const PASSWORD_PLACEHOLDER = 'n0thingToSeeHere!';
 

--- a/protected/humhub/modules/user/controllers/AuthController.php
+++ b/protected/humhub/modules/user/controllers/AuthController.php
@@ -8,6 +8,7 @@
 
 namespace humhub\modules\user\controllers;
 
+use humhub\components\access\ControllerAccess;
 use humhub\components\Controller;
 use humhub\modules\user\models\User;
 use humhub\modules\user\authclient\AuthAction;
@@ -39,6 +40,13 @@ class AuthController extends Controller
      * @inheritdoc
      */
     public $layout = '@humhub/modules/user/views/layouts/main';
+
+    /**
+     * Allow guest access independently from guest mode setting.
+     *
+     * @var string
+     */
+    public $access = ControllerAccess::class;
 
     /**
      * @inheritdoc

--- a/protected/humhub/modules/user/controllers/PasswordRecoveryController.php
+++ b/protected/humhub/modules/user/controllers/PasswordRecoveryController.php
@@ -8,6 +8,7 @@
 
 namespace humhub\modules\user\controllers;
 
+use humhub\components\access\ControllerAccess;
 use Yii;
 use yii\web\HttpException;
 use humhub\components\Controller;
@@ -27,6 +28,13 @@ class PasswordRecoveryController extends Controller
      * @inheritdoc
      */
     public $layout = "@humhub/modules/user/views/layouts/main";
+
+    /**
+     * Allow guest access independently from guest mode setting.
+     *
+     * @var string
+     */
+    public $access = ControllerAccess::class;
 
     /**
      * @inheritdoc

--- a/protected/humhub/modules/user/controllers/RegistrationController.php
+++ b/protected/humhub/modules/user/controllers/RegistrationController.php
@@ -8,6 +8,7 @@
 
 namespace humhub\modules\user\controllers;
 
+use humhub\components\access\ControllerAccess;
 use Yii;
 use yii\base\Exception;
 use yii\web\HttpException;
@@ -30,6 +31,13 @@ class RegistrationController extends Controller
      * @inheritdoc
      */
     public $layout = "@humhub/modules/user/views/layouts/main";
+
+    /**
+     * Allow guest access independently from guest mode setting.
+     *
+     * @var string
+     */
+    public $access = ControllerAccess::class;
 
     /**
      * @inheritdoc

--- a/protected/humhub/modules/web/pwa/controllers/ManifestController.php
+++ b/protected/humhub/modules/web/pwa/controllers/ManifestController.php
@@ -8,6 +8,7 @@
 
 namespace humhub\modules\web\pwa\controllers;
 
+use humhub\components\access\ControllerAccess;
 use humhub\components\Controller;
 use humhub\modules\web\pwa\widgets\SiteIcon;
 use humhub\modules\web\Module;
@@ -24,6 +25,12 @@ use yii\helpers\Url;
  */
 class ManifestController extends Controller
 {
+    /**
+     * Allow guest access independently from guest mode setting.
+     *
+     * @var string
+     */
+    public $access = ControllerAccess::class;
 
     /**
      * @var array the manifest

--- a/protected/humhub/modules/web/pwa/controllers/OfflineController.php
+++ b/protected/humhub/modules/web/pwa/controllers/OfflineController.php
@@ -8,6 +8,7 @@
 
 namespace humhub\modules\web\pwa\controllers;
 
+use humhub\components\access\ControllerAccess;
 use humhub\components\Controller;
 use humhub\modules\ui\Module;
 
@@ -20,6 +21,13 @@ use humhub\modules\ui\Module;
  */
 class OfflineController extends Controller
 {
+    /**
+     * Allow guest access independently from guest mode setting.
+     *
+     * @var string
+     */
+    public $access = ControllerAccess::class;
+
     public function actionIndex()
     {
         return $this->renderPartial('@humhub/modules/web/pwa/views/offline/index');

--- a/protected/humhub/modules/web/pwa/controllers/ServiceWorkerController.php
+++ b/protected/humhub/modules/web/pwa/controllers/ServiceWorkerController.php
@@ -8,6 +8,7 @@
 
 namespace humhub\modules\web\pwa\controllers;
 
+use humhub\components\access\ControllerAccess;
 use humhub\components\Controller;
 use humhub\modules\ui\Module;
 use Yii;
@@ -23,7 +24,12 @@ use yii\helpers\Url;
  */
 class ServiceWorkerController extends Controller
 {
-
+    /**
+     * Allow guest access independently from guest mode setting.
+     *
+     * @var string
+     */
+    public $access = ControllerAccess::class;
     public $baseJs;
     public $additionalJs;
 


### PR DESCRIPTION
Implements: https://github.com/humhub/humhub/issues/3990

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

Controllers requiring guest access even though guest mode is not active need to explicitly configure:

```
public $access = ControllerAccess::class;
```

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [x] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [x] All tests are passing
- [x] New/updated tests are included
- [x] Changelog was modified
