### PR TITLE
Enh: Disable close modal by click on backdrop or escape by default.

### DIFF
--- a/protected/humhub/widgets/Modal.php
+++ b/protected/humhub/widgets/Modal.php
@@ -14,7 +14,7 @@ namespace humhub\widgets;
  * @author luke
  */
 class Modal extends JsWidget
-{   
+{
     /**
      * @inheritdoc
      */
@@ -73,19 +73,19 @@ class Modal extends JsWidget
      *
      * @var bool
      */
-    public $closable = true;
+    public $closable = false;
 
     /**
      * Defines if a click on the modal background should close the modal
      * @var boolean
      */
-    public $backdrop = true;
+    public $backdrop = false;
 
     /**
      * Defines if the modal can be closed by pressing escape
      * @var boolean
      */
-    public $keyboard = true;
+    public $keyboard = false;
 
     /**
      * Defines if the modal should be shown at startup

--- a/protected/humhub/widgets/Modal.php
+++ b/protected/humhub/widgets/Modal.php
@@ -79,13 +79,13 @@ class Modal extends JsWidget
      * Defines if a click on the modal background should close the modal
      * @var boolean
      */
-    public $backdrop = false;
+    public $backdrop = true;
 
     /**
      * Defines if the modal can be closed by pressing escape
      * @var boolean
      */
-    public $keyboard = false;
+    public $keyboard = true;
 
     /**
      * Defines if the modal should be shown at startup

--- a/protected/humhub/widgets/ModalDialog.php
+++ b/protected/humhub/widgets/ModalDialog.php
@@ -8,7 +8,7 @@ namespace humhub\widgets;
  */
 class ModalDialog extends Modal
 {
-    
+
     public $dialogContent;
 
     private $dialogClass;
@@ -35,7 +35,7 @@ class ModalDialog extends Modal
         if(!$this->body && !$this->footer) {
             $this->dialogContent = ob_get_clean();
         }
-        
+
         //The x close button is rendered by default either if forced by showClose or a headertext is given
         $showClose = $this->showClose ?: ($this->header !== null);
 
@@ -43,7 +43,7 @@ class ModalDialog extends Modal
         $bodyClass .= $this->centerText ? ' text-center' : '';
 
         $this->initialLoader = ($this->initialLoader ==! null) ? $this->initialLoader : ($this->body === null);
-        
+
         return $this->render('modalDialog', [
             'header' => $this->header,
             'options' => $this->getOptions(),
@@ -70,7 +70,7 @@ class ModalDialog extends Modal
     public function getData()
     {
         return [
-            'backdrop' => (!$this->closable || $this->backdrop === false) ? 'static' : $this->backdrop,
+            'backdrop' => (!$this->closable || $this->backdrop === false) ? 'static' : 'true',
             'keyboard' => (!$this->closable || !$this->keyboard) ? 'false' : 'true',
         ];
     }

--- a/protected/humhub/widgets/ModalDialog.php
+++ b/protected/humhub/widgets/ModalDialog.php
@@ -9,11 +9,15 @@ namespace humhub\widgets;
 class ModalDialog extends Modal
 {
 
+    /**
+     * @var
+     */
     public $dialogContent;
 
+    /**
+     * @var
+     */
     private $dialogClass;
-
-    public $closable = false;
 
     /**
      * @inheritdoc

--- a/static/js/humhub/humhub.ui.modal.js
+++ b/static/js/humhub/humhub.ui.modal.js
@@ -393,8 +393,8 @@ humhub.module('ui.modal', function (module, require, $) {
             this.getDialog().addClass('modal-dialog-'+this.options.size);
         }
 
-        this.options.backdrop = object.defaultValue(options.backdrop, true);
-        this.options.keyboard = object.defaultValue(options.keyboard, true);
+        this.options.backdrop = object.defaultValue(options.backdrop, 'static');
+        this.options.keyboard = object.defaultValue(options.keyboard, false);
 
         if (this.$.data('bs.modal')) {
             this.$.data('bs.modal').options = this.options;
@@ -453,9 +453,6 @@ humhub.module('ui.modal', function (module, require, $) {
     };
 
     Modal.prototype.updateDialogOptions = function() {
-        var test = this.getDialog();
-        var test2 = this.getDialog().data('backdrop');
-        var test3 = this.getDialog().data('keyboard');
         this.set({
             backdrop : this.getDialog().data('backdrop'),
             keyboard : this.getDialog().data('keyboard')


### PR DESCRIPTION
This change will by default prevent modals from beeing closed by clicking on the modal backdrop or by escape. This will prevent accidental loss of form or other data.

One question is should we allow closing by escape by default. I think it would be better to block escape, since a modal
may include features as for example special richtext features which may suggest pressing escape will only affect this feature but eventually will close the modal. A modal is always closable by `x` button and should ideally inclue a `Cancel` button instead.

After this PR, closable Modals can be created by:

```php
<?php ModalDialog::begin(['closable' => false]) ?>
 ...
<?php ModalDialog::end() ?>
```

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [x] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [x] All tests are passing
- [ ] New/updated tests are included
- [ ] Changelog was modified