### PR TITLE
Fix #4182: Native edge password reveal icons interferes with custom one

### DIFF
--- a/protected/humhub/docs/CHANGELOG_DEV.md
+++ b/protected/humhub/docs/CHANGELOG_DEV.md
@@ -11,3 +11,4 @@ HumHub Change Log
 - Chg #4170: Updated codeception to v4.1.6
 - Chg #4138: Updated jQuery to v3.5.1
 - Chg #4158: Cleanup post table removed unused column  
+- Fix #4182: Native edge password reveal icons interferes with custom one

--- a/static/less/form.less
+++ b/static/less/form.less
@@ -90,6 +90,12 @@ label.control-label {
     color: @text-color-soft !important;
 }
 
+/* hide native password reveal icons */
+input::-ms-clear, input::-ms-reveal {
+    display: none;
+}
+
+
 /* ie */
 input:-moz-placeholder {
     color: @text-color-soft !important;


### PR DESCRIPTION
Fixes https://github.com/humhub/humhub/issues/4182

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No