### PR TITLE
Fix #4140: Profile field hint is double encoded

### DIFF
--- a/protected/humhub/compat/HForm.php
+++ b/protected/humhub/compat/HForm.php
@@ -343,7 +343,7 @@ class HForm extends \yii\base\Component
                 }
 
                 if(!empty($definition['hint'])  && $field instanceof ActiveField) {
-                    $field->hint(Html::encode($definition['hint']));
+                    $field->hint(Html::encode($definition['hint'], false));
                 }
 
                 return $field;

--- a/protected/humhub/docs/CHANGELOG.md
+++ b/protected/humhub/docs/CHANGELOG.md
@@ -6,6 +6,7 @@ HumHub Change Log
 - Fix #4168: Erroneous pagination in notification overview 
 - Fix #4060: Profile description and text regex error message not translatable
 - Fix #4153: Administration: Email transport configuration 'Save & Test' Gives No Result
+- Fix #4140: Profile field hint is double encoded
 
 1.5.2 (May 20, 2020)
 --------------------


### PR DESCRIPTION
Fixes https://github.com/humhub/humhub/issues/4140

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No