### PR TITLE
Chg: Removed unnecessary ContentActiveRecord:initContent

### DIFF
--- a/protected/humhub/docs/CHANGELOG_DEV.md
+++ b/protected/humhub/docs/CHANGELOG_DEV.md
@@ -21,3 +21,4 @@ HumHub Change Log
 - Enh #4222: Added virtual profile fields to display users e-mail address and username
 - Enh #4194: Increased max pinnable space content
 - Enh #4194: Make max pinnable content configurable on space/profile level
+- Chg #4228: Removed unnecessary `ContentActiveRecord:initContent`

--- a/protected/humhub/modules/content/components/ContentActiveRecord.php
+++ b/protected/humhub/modules/content/components/ContentActiveRecord.php
@@ -108,13 +108,6 @@ class ContentActiveRecord extends ActiveRecord implements ContentOwner, Movable
     public $silentContentCreation = false;
 
     /**
-     * @var Content used to cache the content relation in order to avoid the relation to be overwritten in the insert process
-     * @see https://github.com/humhub/humhub/issues/3110
-     * @since 1.3
-     */
-    protected $initContent;
-
-    /**
      * @var bool|string defines if the Movable behaviour of this ContentContainerActiveRecord type is active.
      * @see Content::move()
      * @since 1.3
@@ -177,15 +170,12 @@ class ContentActiveRecord extends ActiveRecord implements ContentOwner, Movable
          * Ensure there is always a corresponding Content record
          * @see Content
          */
-        if ($name == 'content') {
-            $content = $this->initContent = (empty($this->initContent)) ? parent::__get('content') : $this->initContent;
+        if ($name === 'content') {
+            $content = parent::__get('content');
 
             if(!$content) {
-                $content = $this->initContent =  new Content();
+                $content = new Content();
                 $content->setPolymorphicRelation($this);
-            }
-
-            if(!$this->isRelationPopulated('content')) {
                 $this->populateRelation('content', $content);
             }
 
@@ -206,7 +196,7 @@ class ContentActiveRecord extends ActiveRecord implements ContentOwner, Movable
     }
 
     /**
-     * Can be used to define an icon for this content type e.g.: 'fa-calendar'.
+     * Can be used to define an icon for this content type e.g.: 'calendar'.
      * @return string
      */
     public function getIcon()
@@ -392,7 +382,6 @@ class ContentActiveRecord extends ActiveRecord implements ContentOwner, Movable
 
         // Set polymorphic relation
         if ($insert) {
-            $this->populateRelation('content', $this->initContent);
             $this->content->object_model = static::getObjectModel();
             $this->content->object_id = $this->getPrimaryKey();
         }

--- a/protected/humhub/modules/content/models/ContentContainer.php
+++ b/protected/humhub/modules/content/models/ContentContainer.php
@@ -41,6 +41,7 @@ class ContentContainer extends ActiveRecord
     {
         return [
             [['pk', 'owner_user_id'], 'integer'],
+            [['class', 'pk', 'guid'], 'required'],
             [['guid', 'class'], 'string', 'max' => 255],
             [['class', 'pk'], 'unique', 'targetAttribute' => ['class', 'pk'], 'message' => 'The combination of Class and Pk has already been taken.'],
             [['guid'], 'unique']
@@ -78,16 +79,14 @@ class ContentContainer extends ActiveRecord
 
     /**
      * @param $guid
-     * @return ContentContainerActiveRecord
+     * @return ContentContainerActiveRecord|null
      * @throws \yii\db\IntegrityException
      * @since 1.4
      */
     public static function findRecord($guid)
     {
         $instance = static::findOne(['guid' => $guid]);
-        if($instance) {
-            return $instance->getPolymorphicRelation();
-        }
+        return $instance ? $instance->getPolymorphicRelation() : null;
     }
 
 }

--- a/protected/humhub/modules/content/models/ContentContainerModuleState.php
+++ b/protected/humhub/modules/content/models/ContentContainerModuleState.php
@@ -8,6 +8,8 @@
 
 namespace humhub\modules\content\models;
 
+use yii\db\ActiveRecord;
+
 /**
  * This is the model class for table "contentcontainer_module".
  *
@@ -15,7 +17,7 @@ namespace humhub\modules\content\models;
  * @property string $module_id
  * @property integer $module_state
  */
-class ContentContainerModuleState extends \yii\db\ActiveRecord
+class ContentContainerModuleState extends ActiveRecord
 {
 
     const STATE_DISABLED = 0;

--- a/protected/humhub/modules/content/models/ContentType.php
+++ b/protected/humhub/modules/content/models/ContentType.php
@@ -16,7 +16,19 @@ use yii\base\Model;
 use yii\db\Query;
 
 /**
- * This class can be used to search for existing types of [[\humhub\modules\content\components\ContentActiveRecords]].
+ * The ContentType class serves as meta data class for content types and can be used to
+ * search for existing types of [[\humhub\modules\content\components\ContentActiveRecords]].
+ *
+ * ContentType models are usually used for Picker widgets e.g. ContentType filters in a stream. The [[getContentTypes()]]
+ * and [[getContentTypeSelection()]] function will search for content types with `stream_channel="default"` and an existing
+ * content entry related to a given container or
+ *
+ * ## Usage:
+ *
+ * ```php
+ * // Fetch content types
+ * $spaceContentTypes = ContentType::getContentTypes($space);
+ * ```
  *
  * @since 1.3
  */
@@ -35,7 +47,7 @@ class ContentType extends Model
     /**
      * @var [] caches the result for contentContainer and global requests [$contentContainer->id|'' => ContentType[]]
      */
-    public static $cache = [];
+    private static $cache = [];
 
     /**
      * @inheritdoc
@@ -44,6 +56,11 @@ class ContentType extends Model
     {
         parent::init();
         $this->instance = Yii::createObject($this->typeClass);
+    }
+
+    public static function flush()
+    {
+        static::$cache = [];
     }
 
     /**
@@ -98,18 +115,9 @@ class ContentType extends Model
     }
 
     /**
-     * Returns a description of this particular content.
-     *
-     * This will be used to create a text preview of the content record. (e.g. in Activities or Notifications)
-     * You need to override this method in your content implementation.
-     *
-     * @return string description of this content
+     * Returns a content type related icon
+     * @return string
      */
-    public function getContentDescription()
-    {
-        return $this->instance->getContentDescription();
-    }
-
     public function getIcon()
     {
         return $this->instance->getIcon();

--- a/protected/humhub/modules/content/tests/codeception/_support/ContentModelTest.php
+++ b/protected/humhub/modules/content/tests/codeception/_support/ContentModelTest.php
@@ -1,0 +1,44 @@
+<?php
+
+
+namespace modules\content\tests\codeception\_support;
+
+
+use humhub\modules\content\models\Content;
+use humhub\modules\content\tests\codeception\unit\TestContent;
+use humhub\modules\space\models\Space;
+use tests\codeception\_support\HumHubDbTestCase;
+
+class ContentModelTest extends HumHubDbTestCase
+{
+    /**
+     * @var TestContent
+     */
+    public $testModel;
+
+    /**
+     * @var Content
+     */
+    public $testContent;
+
+    /**
+     * @var Space
+     */
+    public $space;
+
+    public function _before()
+    {
+        parent::_before();
+        $this->becomeUser('User2');
+        $this->space = Space::findOne(['id' => 2]);
+
+        $this->testModel = new TestContent($this->space, Content::VISIBILITY_PUBLIC, [
+            'message' => 'Test'
+        ]);
+
+        $this->assertTrue($this->testModel->save());
+
+        $this->testContent = $this->testModel->content;
+    }
+
+}

--- a/protected/humhub/modules/content/tests/codeception/unit/TestContent.php
+++ b/protected/humhub/modules/content/tests/codeception/unit/TestContent.php
@@ -29,4 +29,8 @@ class TestContent extends Post
         $this->managePermission = $managePermission;
     }
 
+    public function getContentName()
+    {
+        return 'TestContent';
+    }
 }

--- a/protected/humhub/modules/content/tests/codeception/unit/models/ContentContainerTest.php
+++ b/protected/humhub/modules/content/tests/codeception/unit/models/ContentContainerTest.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * @link https://www.humhub.org/
+ * @copyright Copyright (c) 2017 HumHub GmbH & Co. KG
+ * @license https://www.humhub.com/licences
+ *
+ */
+
+namespace tests\codeception\unit\modules\content;
+
+use humhub\modules\content\models\Content;
+use humhub\modules\content\models\ContentContainer;
+use humhub\modules\user\models\User;
+use modules\content\tests\codeception\_support\ContentModelTest;
+
+class ContentContainerTest extends ContentModelTest
+{
+
+    public function testUniqueGuid()
+    {
+        $user = User::findOne(['id' => 1]);
+        $contentContainer = new ContentContainer(['guid' => $user->guid]);
+        $contentContainer->setPolymorphicRelation($user);
+
+        $this->assertFalse($contentContainer->save());
+        $this->assertNotEmpty($contentContainer->getErrors('guid'));
+    }
+
+    public function testUniqueModel()
+    {
+        $user = User::findOne(['id' => 1]);
+        $contentContainer = new ContentContainer(['guid' => 'xyz']);
+        $contentContainer->setPolymorphicRelation($user);
+
+        $this->assertFalse($contentContainer->save());
+        $this->assertNotEmpty($contentContainer->getErrors('class'));
+    }
+
+    public function testGuidRequired()
+    {
+        $user = User::findOne(['id' => 1]);
+        $contentContainer = new ContentContainer();
+        $contentContainer->setPolymorphicRelation($user);
+
+        $this->assertFalse($contentContainer->save());
+        $this->assertNotEmpty($contentContainer->getErrors('guid'));
+    }
+
+    public function testModelRequired()
+    {
+        $contentContainer = new ContentContainer();
+
+        $this->assertFalse($contentContainer->save());
+        $this->assertNotEmpty($contentContainer->getErrors('class'));
+    }
+
+    public function testInvalidModel()
+    {
+        $contentContainer = new ContentContainer();
+        $contentContainer->setPolymorphicRelation(Content::findOne(['id' => 1]));
+
+        $this->assertFalse($contentContainer->save());
+        $this->assertNotEmpty($contentContainer->getErrors('class'));
+    }
+
+    public function testFindByGuid()
+    {
+        $user = User::findOne(['id' => 1]);
+        $userRecord = ContentContainer::findRecord($user->guid);
+
+        $this->assertInstanceOf(User::class, $userRecord);
+        $this->assertEquals($user->id, $userRecord->id);
+        $this->assertEquals($user->contentcontainer_id, $userRecord->contentcontainer_id);
+    }
+
+    public function testFindByInvalidGuid()
+    {
+        $this->assertNull(ContentContainer::findRecord('xxx'));
+    }
+}

--- a/protected/humhub/modules/content/tests/codeception/unit/models/ContentTest.php
+++ b/protected/humhub/modules/content/tests/codeception/unit/models/ContentTest.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * @link https://www.humhub.org/
+ * @copyright Copyright (c) 2017 HumHub GmbH & Co. KG
+ * @license https://www.humhub.com/licences
+ *
+ */
+
+namespace tests\codeception\unit\modules\content;
+
+use humhub\modules\content\tests\codeception\unit\TestContent;
+use modules\content\tests\codeception\_support\ContentModelTest;
+
+use humhub\modules\space\models\Space;
+use humhub\modules\content\models\Content;
+use Yii;
+
+class ContentTest extends ContentModelTest
+{
+    public function testContentDefaults()
+    {
+        $this->assertNotEmpty($this->testContent->id);
+        $this->assertNotEmpty($this->testContent->guid);
+        $this->assertEquals($this->testContent->object_model, TestContent::class);
+        $this->assertEquals($this->testContent->object_id, $this->testModel->id);
+        $this->assertEquals($this->testContent->visibility, Content::VISIBILITY_PUBLIC);
+        $this->assertEquals($this->testContent->pinned, 0);
+        $this->assertEquals($this->testContent->archived, 0);
+        $this->assertNotEmpty($this->testContent->created_at);
+        $this->assertEquals($this->testContent->created_by, Yii::$app->user->id);
+        $this->assertNotEmpty($this->testContent->updated_at);
+        $this->assertEquals($this->testContent->updated_by, Yii::$app->user->id);
+        $this->assertEquals($this->testContent->updated_at, $this->testContent->created_at);
+        $this->assertEquals($this->testContent->stream_channel,Content::STREAM_CHANNEL_DEFAULT);
+        $this->assertEquals($this->testContent->contentcontainer_id,$this->space->contentcontainer_id);
+    }
+
+    public function testInvalidPolymorphicRelation1()
+    {
+        $testContent = new TestContent($this->space, Content::VISIBILITY_PUBLIC, [
+            'message' => 'Test'
+        ]);
+
+        $testContent->content->object_model = null;
+
+        try {
+            $testContent->save();
+            $this->assertTrue(false, 'Content should not be saved!');
+        } catch (\Exception $e) {
+            $this->assertTrue(true);
+        }
+    }
+
+    public function testInvalidPolymorphicRelation2()
+    {
+        $testContent = new TestContent($this->space, Content::VISIBILITY_PUBLIC, [
+            'message' => 'Test'
+        ]);
+
+        $testContent->content->object_id = null;
+
+        try {
+            $testContent->save();
+            $this->assertTrue(false, 'Content should not be saved!');
+        } catch (\Exception $e) {
+            $this->assertTrue(true);
+        }
+    }
+
+    public function testContentRelation()
+    {
+        $loadedContent = Content::Get(TestContent::class, $this->testModel->id);
+        $this->assertTrue($loadedContent->content instanceof Content);
+        $this->assertEquals($loadedContent->content->id, $this->testModel->content->id);
+        $this->assertTrue($loadedContent->content->container instanceof Space);
+        $this->assertEquals($loadedContent->content->container->id, $this->space->id);
+        $this->assertEquals($loadedContent->content->contentContainer->id, $this->space->contentcontainer_id);
+    }
+
+    public function testContentGet()
+    {
+        $loadedContent = Content::Get(TestContent::class, $this->testModel->id);
+        $this->assertEquals($loadedContent->id, $this->testModel->id);
+        $this->assertEquals($loadedContent->content->id, $this->testModel->content->id);
+    }
+
+    public function testContentGetNotFound()
+    {
+        $loadedContent = Content::Get(TestContent::class, 300);
+        $this->assertNull($loadedContent);
+    }
+
+    public function testContentGetInvalidClass()
+    {
+        $loadedContent = Content::Get('SomeNonExistingClass', 300);
+        $this->assertNull($loadedContent);
+    }
+}

--- a/protected/humhub/modules/content/tests/codeception/unit/models/ContentTypeTest.php
+++ b/protected/humhub/modules/content/tests/codeception/unit/models/ContentTypeTest.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * @link https://www.humhub.org/
+ * @copyright Copyright (c) 2017 HumHub GmbH & Co. KG
+ * @license https://www.humhub.com/licences
+ *
+ */
+
+namespace tests\codeception\unit\modules\content;
+
+use humhub\modules\content\models\Content;
+use humhub\modules\content\models\ContentContainer;
+use humhub\modules\content\models\ContentType;
+use humhub\modules\content\tests\codeception\unit\TestContent;
+use humhub\modules\post\models\Post;
+use humhub\modules\user\models\User;
+use modules\content\tests\codeception\_support\ContentModelTest;
+
+class ContentTypeTest extends ContentModelTest
+{
+
+    public function _before()
+    {
+        parent::_before();
+        ContentType::flush();
+        // Make sure there is no content
+        Content::deleteAll();
+        Post::deleteAll();
+    }
+
+    public function testContainerContentTypes()
+    {
+        $user = User::findOne(['id' => 1]);
+        $this->assertEmpty(ContentType::getContentTypes($user));
+
+        $testContent = new TestContent($user, ['message' => 'TestContent']);
+        $this->assertTrue($testContent->save());
+
+        ContentType::flush();
+        $contentTypes = ContentType::getContentTypes($user);
+        $this->assertCount(1, $contentTypes);
+        $this->assertEquals(TestContent::class, $contentTypes[0]->typeClass);
+        $this->assertEquals($testContent->getContentName(), $contentTypes[0]->getContentName());
+
+        $testPost = new Post($user, ['message' => 'TestPost']);
+        $this->assertTrue($testPost->save());
+
+        ContentType::flush();
+        $contentTypes = ContentType::getContentTypes($user);
+        $this->assertCount(2, $contentTypes);
+        $this->assertEquals(TestContent::class, $contentTypes[0]->typeClass);
+        $this->assertEquals($testContent->getContentName(), $contentTypes[0]->getContentName());
+        $this->assertEquals($testContent->getIcon(), $contentTypes[0]->getIcon());
+
+        $this->assertEquals(Post::class, $contentTypes[1]->typeClass);
+        $this->assertEquals($testPost->getContentName(), $contentTypes[1]->getContentName());
+        $this->assertEquals($testPost->getIcon(), $contentTypes[1]->getIcon());
+
+        $select = ContentType::getContentTypeSelection($user);
+        $this->assertEquals(TestContent::class, array_keys($select)[0]);
+        $this->assertEquals($testContent->getContentName(), $select[TestContent::class]);
+        $this->assertEquals(Post::class, array_keys($select)[1]);
+        $this->assertEquals($testPost->getContentName(), $select[Post::class]);
+    }
+
+    public function testGlobalContentTypes()
+    {
+        $this->assertEmpty(ContentType::getContentTypes());
+
+        $testContent = new TestContent(User::findOne(['id' => 1]), ['message' => 'TestContent']);
+        $this->assertTrue($testContent->save());
+
+        ContentType::flush();
+        $contentTypes = ContentType::getContentTypes();
+        $this->assertCount(1, $contentTypes);
+        $this->assertEquals(TestContent::class, $contentTypes[0]->typeClass);
+        $this->assertEquals($testContent->getContentName(), $contentTypes[0]->getContentName());
+
+        $testPost = new Post(User::findOne(['id' => 2]), ['message' => 'TestPost']);
+        $this->assertTrue($testPost->save());
+
+        ContentType::flush();
+        $contentTypes = ContentType::getContentTypes();
+        $this->assertCount(2, $contentTypes);
+        $this->assertEquals(TestContent::class, $contentTypes[0]->typeClass);
+        $this->assertEquals($testContent->getContentName(), $contentTypes[0]->getContentName());
+        $this->assertEquals(Post::class, $contentTypes[1]->typeClass);
+        $this->assertEquals($testPost->getContentName(), $contentTypes[1]->getContentName());
+
+        $select = ContentType::getContentTypeSelection();
+        $this->assertEquals(TestContent::class, array_keys($select)[0]);
+        $this->assertEquals($testContent->getContentName(), $select[TestContent::class]);
+        $this->assertEquals(Post::class, array_keys($select)[1]);
+        $this->assertEquals($testPost->getContentName(), $select[Post::class]);
+    }
+}

--- a/protected/humhub/modules/content/tests/codeception/unit/models/ContentVisibilityTest.php
+++ b/protected/humhub/modules/content/tests/codeception/unit/models/ContentVisibilityTest.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * @link https://www.humhub.org/
+ * @copyright Copyright (c) 2017 HumHub GmbH & Co. KG
+ * @license https://www.humhub.com/licences
+ *
+ */
+
+namespace tests\codeception\unit\modules\content;
+
+use humhub\modules\content\tests\codeception\unit\TestContent;
+use modules\content\tests\codeception\_support\ContentModelTest;
+use tests\codeception\_support\HumHubDbTestCase;
+use Codeception\Specify;
+
+use humhub\modules\space\models\Space;
+use humhub\modules\content\models\Content;
+use Yii;
+
+class ContentVisibilityTest extends ContentModelTest
+{
+
+    public function testDefaultVisibilityPrivateSpace()
+    {
+        $this->space->visibility = Space::VISIBILITY_NONE;
+
+        $newModel = new TestContent($this->space, [
+            'message' => 'Test'
+        ]);
+
+        $this->assertTrue($newModel->save());
+        $this->assertEquals($newModel->content->visibility, Content::VISIBILITY_PRIVATE);
+    }
+
+    public function testDefaultVisibilityProtectedSpace()
+    {
+        $this->space->visibility = Space::VISIBILITY_REGISTERED_ONLY;
+
+        $newModel = new TestContent($this->space, [
+            'message' => 'Test'
+        ]);
+
+        $this->assertTrue($newModel->save());
+        $this->assertEquals($newModel->content->visibility, Content::VISIBILITY_PRIVATE);
+    }
+
+    public function testDefaultVisibilityPublicSpace()
+    {
+        $this->space->visibility = Space::VISIBILITY_ALL;
+
+        $newModel = new TestContent($this->space, [
+            'message' => 'Test'
+        ]);
+
+        $this->assertTrue($newModel->save());
+        $this->assertEquals($newModel->content->visibility, Content::VISIBILITY_PRIVATE);
+    }
+
+    public function testCreatePublicContentOnPublicSpace()
+    {
+        $this->space->visibility = Space::VISIBILITY_ALL;
+
+        $newModel = new TestContent($this->space, Content::VISIBILITY_PUBLIC, [
+            'message' => 'Test'
+        ]);
+
+        $this->assertTrue($newModel->save());
+        $this->assertEquals($newModel->content->visibility, Content::VISIBILITY_PUBLIC);
+    }
+
+    public function testCreatePublicContentOnProtectedSpace()
+    {
+        $this->space->visibility = Space::VISIBILITY_REGISTERED_ONLY;
+
+        $newModel = new TestContent($this->space, Content::VISIBILITY_PUBLIC, [
+            'message' => 'Test'
+        ]);
+
+        $this->assertTrue($newModel->save());
+        $this->assertEquals($newModel->content->visibility, Content::VISIBILITY_PUBLIC);
+    }
+
+    public function testCreateContentOnDefaultContentVisibilityPublic()
+    {
+        $this->space->visibility = Space::VISIBILITY_ALL;
+        $this->space->default_content_visibility = Content::VISIBILITY_PUBLIC;
+
+        $newModel = new TestContent($this->space, [
+            'message' => 'Test'
+        ]);
+
+        $this->assertTrue($newModel->save());
+        $this->assertEquals($newModel->content->visibility, Content::VISIBILITY_PUBLIC);
+    }
+
+    public function testCreateContentOnDefaultContentVisibilityPrivate()
+    {
+        $this->space->visibility = Space::VISIBILITY_ALL;
+        $this->space->default_content_visibility = Content::VISIBILITY_PRIVATE;
+
+        $newModel = new TestContent($this->space, [
+            'message' => 'Test'
+        ]);
+
+        $this->assertTrue($newModel->save());
+        $this->assertEquals($newModel->content->visibility, Content::VISIBILITY_PRIVATE);
+    }
+
+    /**
+     * Make sure private spaces can not produce public content
+     *
+     * Visibility integrity check missing!
+     *
+     * @skip
+     * @throws \yii\base\Exception
+     */
+    public function testCreatePublicContentOnPrivateSpace()
+    {
+        $this->space->visibility = Space::VISIBILITY_NONE;
+
+        $newModel = new TestContent($this->space, Content::VISIBILITY_PUBLIC, [
+            'message' => 'Test'
+        ]);
+
+        $this->assertTrue($newModel->save());
+        $this->assertEquals($newModel->content->visibility, Content::VISIBILITY_PRIVATE);
+    }
+}


### PR DESCRIPTION
Removed `humhub\modules\content\components\ContentActiveRecord:initContent`. This property was introduced due to https://github.com/humhub/humhub/issues/3110 and is not required anymore.

This PR also adds some additional content related unit tests as well as minor doc enhancements.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [x] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [x] All tests are passing
- [x] New/updated tests are included
- [x] Changelog was modified
