### PR TITLE
Fix: `Space::canAccessPrivateContent()` may throws error for guest user

### DIFF
--- a/protected/humhub/docs/CHANGELOG_DEV.md
+++ b/protected/humhub/docs/CHANGELOG_DEV.md
@@ -21,3 +21,4 @@ HumHub Change Log
 - Enh #4222: Added virtual profile fields to display users e-mail address and username
 - Enh #4194: Increased max pinnable space content
 - Enh #4194: Make max pinnable content configurable on space/profile level
+- Fix #4229: `Space::canAccessPrivateContent()` throws error for guest user if `globalAdminCanAccessPrivateContent` setting is true

--- a/protected/humhub/modules/space/models/Space.php
+++ b/protected/humhub/modules/space/models/Space.php
@@ -489,6 +489,10 @@ class Space extends ContentContainerActiveRecord implements Searchable
     {
         $user = !$user && !Yii::$app->user->isGuest ? Yii::$app->user->getIdentity() : $user;
 
+        if(!$user) {
+            return false;
+        }
+
         if (Yii::$app->getModule('space')->globalAdminCanAccessPrivateContent && $user->isSystemAdmin()) {
             return true;
         }


### PR DESCRIPTION
Fix: `Space::canAccessPrivateContent()` throws error for guest user if `globalAdminCanAccessPrivateContent` setting is true-

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No