### PR TITLE
Fix: Metadata request creates new session if CSP nonce is enabled

### DIFF
--- a/protected/humhub/docs/CHANGELOG_DEV.md
+++ b/protected/humhub/docs/CHANGELOG_DEV.md
@@ -24,3 +24,4 @@ HumHub Change Log
 - Chg #4228: Removed unnecessary `ContentActiveRecord:initContent`
 - Fix #4229: `Space::canAccessPrivateContent()` throws error for guest user if `globalAdminCanAccessPrivateContent` setting is true
 - Fix #4227: Removed redundant code from `humhub.ui.widget.js`
+- Fix #4232: Metadata request creates guest session if CSP nonce header is enabled

--- a/protected/humhub/modules/web/Events.php
+++ b/protected/humhub/modules/web/Events.php
@@ -8,6 +8,8 @@
 
 namespace humhub\modules\web;
 
+use humhub\modules\web\pwa\controllers\OfflineController;
+use humhub\modules\web\pwa\controllers\ServiceWorkerController;
 use Yii;
 use humhub\controllers\ErrorController;
 use humhub\models\Setting;
@@ -20,14 +22,26 @@ use humhub\modules\web\security\helpers\Security;
  */
 class Events
 {
-    public static function onBeforeAction($evt)
+    public static function onAfterAction($evt)
     {
         if(Yii::$app->request->isConsoleRequest) {
             return;
         }
 
-        $withCSP = !Yii::$app->request->isAjax && Setting::isInstalled() && !(Yii::$app->controller instanceof ErrorController);
-        Security::applyHeader($withCSP);
+        Security::applyHeader(static::generateCSP());
+    }
+
+    /**
+     * @return bool whether or not to generate a csp header for the current request
+     */
+    private static function generateCSP()
+    {
+        return !Yii::$app->request->isAjax
+            && Yii::$app->response->format === 'html'
+            && Setting::isInstalled()
+            && !(Yii::$app->controller instanceof ErrorController)
+            && !(Yii::$app->controller instanceof OfflineController)
+            && !(Yii::$app->controller instanceof ServiceWorkerController);
     }
 
     public static function onAfterLogin($evt)

--- a/protected/humhub/modules/web/Events.php
+++ b/protected/humhub/modules/web/Events.php
@@ -28,13 +28,13 @@ class Events
             return;
         }
 
-        Security::applyHeader(static::generateCSP());
+        Security::applyHeader(static::generateCSPRequestCheck());
     }
 
     /**
      * @return bool whether or not to generate a csp header for the current request
      */
-    private static function generateCSP()
+    private static function generateCSPRequestCheck()
     {
         return !Yii::$app->request->isAjax
             && Yii::$app->response->format === 'html'

--- a/protected/humhub/modules/web/Events.php
+++ b/protected/humhub/modules/web/Events.php
@@ -8,6 +8,7 @@
 
 namespace humhub\modules\web;
 
+use humhub\modules\web\pwa\controllers\ManifestController;
 use humhub\modules\web\pwa\controllers\OfflineController;
 use humhub\modules\web\pwa\controllers\ServiceWorkerController;
 use Yii;
@@ -41,6 +42,7 @@ class Events
             && Setting::isInstalled()
             && !(Yii::$app->controller instanceof ErrorController)
             && !(Yii::$app->controller instanceof OfflineController)
+            && !(Yii::$app->controller instanceof ManifestController)
             && !(Yii::$app->controller instanceof ServiceWorkerController);
     }
 

--- a/protected/humhub/modules/web/config.php
+++ b/protected/humhub/modules/web/config.php
@@ -17,7 +17,7 @@ return [
         'offline.pwa.html' => 'web/pwa-offline/index'
     ],
     'events' => [
-        [Controller::class, Controller::EVENT_BEFORE_ACTION, [Events::class, 'onBeforeAction']],
+        [Controller::class, Controller::EVENT_AFTER_ACTION, [Events::class, 'onAfterAction']],
         [AuthController::class, AuthController::EVENT_AFTER_LOGIN, [Events::class, 'onAfterLogin']],
     ]
 ];


### PR DESCRIPTION
By default the browser does not send any credential information with the `manifest.json` request. Which will create a
guest session if CSP with script nonce is active. 

- Related to https://github.com/humhub/humhub/issues/4181

This PR adds some additional checks to prevent CSP creation in those cases:

- `Yii::$app->response->format === 'html'` - should block other non html metadata requests
- `!(Yii::$app->controller instanceof ManifestController)` - blocks manifest.json request
- ` !(Yii::$app->controller instanceof OfflineController)`  - blocks offline page request
- `!(Yii::$app->controller instanceof ServiceWorkerController)` - blocks service worker js request 

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No