### PR TITLE
Fix: Security:setNonce() does not remove nonce session value if nonce is null

### DIFF
--- a/protected/humhub/docs/CHANGELOG_DEV.md
+++ b/protected/humhub/docs/CHANGELOG_DEV.md
@@ -24,3 +24,4 @@ HumHub Change Log
 - Chg #4228: Removed unnecessary `ContentActiveRecord:initContent`
 - Fix #4229: `Space::canAccessPrivateContent()` throws error for guest user if `globalAdminCanAccessPrivateContent` setting is true
 - Fix #4227: Removed redundant code from `humhub.ui.widget.js`
+- Fix #4233: `humhub\modules\web\security\helpers\Security:setNonce()` does not remove nonce session value if nonce is null

--- a/protected/humhub/modules/web/security/helpers/Security.php
+++ b/protected/humhub/modules/web/security/helpers/Security.php
@@ -64,7 +64,11 @@ class Security
 
     public static function setNonce($nonce = null)
     {
-        Yii::$app->session->set(static::SESSION_KEY_NONCE, $nonce);
+        if(!$nonce) {
+            Yii::$app->session->remove(static::SESSION_KEY_NONCE);
+        } else {
+            Yii::$app->session->set(static::SESSION_KEY_NONCE, $nonce);
+        }
     }
 
     /**


### PR DESCRIPTION
Fix: `humhub\modules\web\security\helpers\Security:setNonce()` does not remove nonce session value if nonce is null.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No