### PR TITLE
Fix: Misleading error message 'Unable to determine dataType from resp…

### DIFF
--- a/protected/humhub/docs/CHANGELOG_DEV.md
+++ b/protected/humhub/docs/CHANGELOG_DEV.md
@@ -31,3 +31,4 @@ HumHub Change Log
 - Fix #4232: Metadata request creates guest session if CSP nonce header is enabled
 - Enh #4234: Enhanced custom test environment configuration in `@protected/humhub/tests/config/env/env.php` file
 - Fix #4233: `humhub\modules\web\security\helpers\Security:setNonce()` does not remove nonce session value if nonce is null
+- Fix #4235: Misleading error message 'Unable to determine dataType from response' logged on ajax error

--- a/static/js/humhub/humhub.client.js
+++ b/static/js/humhub/humhub.client.js
@@ -25,10 +25,11 @@ humhub.module('client', function (module, require, $) {
                 dataType = 'json';
             } else if (responseType && responseType.indexOf('html') > -1) {
                 dataType = 'html';
-            } else if(!this.isAbort()){
-                console.error('unable to determine dataType from response, this may cause problems.');
+            } else if(!this.isAbort() && !this.isError()){
+                console.error('Unable to determine dataType from response, this may cause problems.');
             }
         }
+
         this.dataType = dataType;
 
         // If we expect json and received json we merge the json result with our response object.
@@ -40,7 +41,11 @@ humhub.module('client', function (module, require, $) {
     };
 
     Response.prototype.isAbort = function () {
-        return this.textStatus == "abort";
+        return this.textStatus === "abort";
+    };
+
+    Response.prototype.isError = function () {
+        return this.textStatus === "error";
     };
 
     Response.prototype.header = function (key) {


### PR DESCRIPTION
Fix: Misleading error message 'Unable to determine dataType from response' logged on ajax error.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No