### PR TITLE
Enh: Added second ContentTag default order by name

### DIFF
--- a/protected/humhub/modules/content/models/ContentTag.php
+++ b/protected/humhub/modules/content/models/ContentTag.php
@@ -334,7 +334,8 @@ class ContentTag extends ActiveRecord
      */
     public static function find()
     {
-        $query = parent::find()->orderBy('sort_order');
+        $query = parent::find()
+            ->orderBy('sort_order ASC')->addOrderBy('name ASC');
         return static::addQueryCondition($query);
     }
 


### PR DESCRIPTION
Adds second order by name sorting for ContentTags

Related to https://github.com/humhub/humhub/issues/4196

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No