### PR TITLE
Fix: Component.instance() throws error for invalid selectors

### DIFF
--- a/static/js/humhub/humhub.action.js
+++ b/static/js/humhub/humhub.action.js
@@ -89,7 +89,7 @@ humhub.module('action', function(module, require, $) {
                 this.$ = node;
             } else if(object.isString(node)) {
                 this.$ = $(node);
-                if(!this.$.length) {
+                if(!this.$.length && !string.startsWith(node, '#')) {
                     this.$ = $('#' + node);
                 }
             }
@@ -278,8 +278,8 @@ humhub.module('action', function(module, require, $) {
         try {
             var $node = _getNode(node);
 
-            if(!$node.length) {
-                return;
+            if(!$node || !$node.length) {
+                return null;
             }
 
             var ns = Component.getNameSpace($node);
@@ -295,8 +295,12 @@ humhub.module('action', function(module, require, $) {
     var _getNode = function(node) {
         var $node = (node instanceof $) ? node : $(node);
 
-        if(!$node.length && object.isString(node) && node.length) {
-            $node = $('#' + node);
+        if(!$node.length && object.isString(node) && node.length && !string.startsWith(node, '#')) {
+            try {
+                $node = $('#' + node);
+            } catch(e) {
+                return null;
+            }
         }
         return $node;
     };

--- a/static/js/humhub/humhub.action.js
+++ b/static/js/humhub/humhub.action.js
@@ -293,16 +293,17 @@ humhub.module('action', function(module, require, $) {
     };
 
     var _getNode = function(node) {
-        var $node = (node instanceof $) ? node : $(node);
+        try {
+            var $node = (node instanceof $) ? node : $(node);
 
-        if(!$node.length && object.isString(node) && node.length && !string.startsWith(node, '#')) {
-            try {
-                $node = $('#' + node);
-            } catch(e) {
-                return null;
+            if(!$node.length && object.isString(node) && node.length && !string.startsWith(node, '#')) {
+                    $node = $('#' + node);
             }
+
+            return $node;
+        } catch(e) {
+            return null;
         }
-        return $node;
     };
 
     Component._getInstance = function(ComponentClass, $node, options) {


### PR DESCRIPTION
This pr prevents an error being thrown when using `humhub.action.Component.instance()` with an invalid selector.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No