### PR TITLE
checking if array_key_exists('jobCount', $counter) to avoid Undefined index: jobCount in

### DIFF
--- a/protected/humhub/modules/admin/widgets/IncompleteSetupWarning.php
+++ b/protected/humhub/modules/admin/widgets/IncompleteSetupWarning.php
@@ -97,7 +97,7 @@ class IncompleteSetupWarning extends Widget
                 ->one($queue->db);
 
 
-            if (is_array($counter) && $counter['jobCount'] > 0) {
+            if (is_array($counter) && array_key_exists('jobCount', $counter) && $counter['jobCount'] > 0) {
                 return false;
             }
         }


### PR DESCRIPTION
…\base\ErrorException: Undefined index: jobCount in /var/www/html/protected/humhub/modules/admin/widgets/IncompleteSetupWarning.php:100'

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [x] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included
- [ ] Changelog was modified


If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
In the file:
> protected\humhub\modules\admin\widgets\IncompleteSetupWarning.php

This 100th line of code:
`if (is_array($counter) && $counter['jobCount'] > 0) {`
Replaced with:
`if (is_array($counter) && array_key_exists('jobCount', $counter) && $counter['jobCount'] > 0) {`

Because of the warning:
> Undefined index: jobCount in /var/www/html/protected/humhub/modules/admin/widgets/IncompleteSetupWarning.php:100
You can find this issue [here](https://github.com/humhub/humhub-modules-calendar/issues/192#issuecomment-662027971)
