### PR TITLE
Fix #1438: Error "User or Password incorrect." not translatable

### DIFF
--- a/protected/humhub/docs/CHANGELOG_DEV.md
+++ b/protected/humhub/docs/CHANGELOG_DEV.md
@@ -5,7 +5,7 @@ HumHub Change Log
 ----------------------------
 
 - Fix #4256: MOV file support broken with wrong MIME Type
-
+- Fix #1438: Error "User or Password incorrect." not translatable
 
 1.6.0-beta.1 (July 16, 2020)
 ----------------------------

--- a/protected/humhub/modules/user/models/forms/Login.php
+++ b/protected/humhub/modules/user/models/forms/Login.php
@@ -6,8 +6,6 @@ use Yii;
 use yii\base\Model;
 use humhub\modules\user\authclient\BaseFormAuth;
 
-use humhub\modules\user\libs\Ldap;
-
 
 /**
  * LoginForm is the model behind the login form.
@@ -52,10 +50,10 @@ class Login extends Model
     public function init()
     {
         $this->rememberMe = Yii::$app->getModule('user')->loginRememberMeDefault;
-        
+
         parent::init();
     }
-    
+
     /**
      * @inheritdoc
      */
@@ -83,7 +81,7 @@ class Login extends Model
                     $this->authClient = $authClient;
 
                     // Delete password after successful auth
-                    $this->password = "";
+                    $this->password = '';
 
                     return;
                 }
@@ -91,11 +89,11 @@ class Login extends Model
         }
 
         if ($user === null) {
-            $this->addError('password', 'User or Password incorrect.');
+            $this->addError('password', Yii::t('UserModule.auth', 'User or Password incorrect.'));
         }
 
         // Delete current password value
-        $this->password = "";
+        $this->password = '';
 
         parent::afterValidate();
     }


### PR DESCRIPTION
Fix #1438: Error "User or Password incorrect." not translatable

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No