### PR TITLE
Fix #4274: Force profile field attribute values of BaseTypeVirtual fields

### DIFF
--- a/protected/humhub/docs/CHANGELOG_DEV.md
+++ b/protected/humhub/docs/CHANGELOG_DEV.md
@@ -5,6 +5,7 @@ HumHub Change Log
 ----------------------------
 
 - Fix #4256: MOV file support broken with wrong MIME Type
+- Fix #4274: Force profile field attribute values of BaseTypeVirtual fields
 
 
 1.6.0-beta.1 (July 16, 2020)

--- a/protected/humhub/modules/admin/views/user-profile/editField.php
+++ b/protected/humhub/modules/admin/views/user-profile/editField.php
@@ -9,7 +9,7 @@ use yii\widgets\ActiveForm;
 /* @var $hForm HForm */
 ?>
 
-<div class="panel-body">
+<div id="edit-profile-field-root" class="panel-body">
     <div class="pull-right">
         <?= Html::backButton(['index'], ['label' => Yii::t('AdminModule.base', 'Back to overview'), 'class' => 'pull-right']); ?>
     </div>
@@ -32,25 +32,32 @@ use yii\widgets\ActiveForm;
     /**
      * Switcher for Sub Forms (FormField Type)
      */
+    var checkFieldTypeFormState = function()
+    {
+        $("#edit-profile-field-root .form-group").show();
 
-    // Hide all Subforms for types
-    $(".fieldTypeSettings").hide();
-
-    showTypeSettings = $("#profilefield-field_type_class").val();
-    showTypeSettings = showTypeSettings.replace(/[\\]/g, '_');
-
-    // Display only the current selected type form
-    $("." + showTypeSettings).show();
-
-    $("#profilefield-field_type_class").on('change', function () {
-        // Hide all Subforms for types
+        // Hide all form type specific forms
         $(".fieldTypeSettings").hide();
 
-        // Show Current Selected
-        showTypeSettings = $("#profilefield-field_type_class").val();
-        showTypeSettings = showTypeSettings.replace(/[\\]/g, '_');
+        var $fieldTypeSelect =  $("#profilefield-field_type_class");
+        var fieldTypeClass = $fieldTypeSelect.val();
+        var showTypeSettings = fieldTypeClass.replace(/[\\]/g, '_');
 
+        // Display only the current selected type form
         $("." + showTypeSettings).show();
+
+        var $selectedOption = $fieldTypeSelect.find(':selected');
+        var hideFields = $selectedOption.data('hiddenFields');
+
+        hideFields.forEach(function(value) {
+            $('.field-profilefield-'+value).hide();
+        })
+    };
+
+    checkFieldTypeFormState();
+
+    $("#profilefield-field_type_class").on('change', function () {
+        checkFieldTypeFormState();
     });
 
 </script>

--- a/protected/humhub/modules/user/components/ActiveQueryUser.php
+++ b/protected/humhub/modules/user/components/ActiveQueryUser.php
@@ -9,6 +9,7 @@
 namespace humhub\modules\user\components;
 
 use humhub\modules\admin\permissions\ManageUsers;
+use humhub\modules\user\models\fieldtype\BaseTypeVirtual;
 use humhub\modules\user\models\GroupUser;
 use humhub\modules\user\models\Group;
 use humhub\modules\user\models\ProfileField;
@@ -119,7 +120,9 @@ class ActiveQueryUser extends ActiveQuery
     {
         $fields = ['user.username', 'user.email', 'user.tags'];
         foreach (ProfileField::findAll(['searchable' => 1]) as $profileField) {
-            $fields[] = 'profile.' . $profileField->internal_name;
+            if(!($profileField->getFieldType() instanceof BaseTypeVirtual)) {
+                $fields[] = 'profile.' . $profileField->internal_name;
+            }
         }
 
         return $fields;

--- a/protected/humhub/modules/user/models/ProfileField.php
+++ b/protected/humhub/modules/user/models/ProfileField.php
@@ -235,6 +235,7 @@ class ProfileField extends ActiveRecord
                     'field_type_class' => [
                         'type' => 'dropdownlist',
                         'items' => $profileFieldTypes->getFieldTypes(),
+                        'htmlOptions' => ['options' => $profileFieldTypes->getFieldTypeItemOptions()],
                         'class' => 'form-control',
                     ],
                 ]

--- a/protected/humhub/modules/user/models/fieldtype/BaseType.php
+++ b/protected/humhub/modules/user/models/fieldtype/BaseType.php
@@ -92,6 +92,37 @@ class BaseType extends Model
     }
 
     /**
+     * Returns additional form field item options for all field types.
+     *
+     * @internal
+     * @return array
+     */
+    final public function getFieldTypeItemOptions()
+    {
+        $result = [];
+        foreach ($this->getFieldTypes() as $field_class => $label) {
+            $result[$field_class] = ['data-hidden-fields' => call_user_func($field_class.'::getHiddenFormFields')];
+        }
+        return $result;
+    }
+
+    /**
+     * Can be used to define form fields which should be hidden when editing or creating a profile field of this type e.g:
+     *
+     *  - searchable
+     *  - editable
+     *  - required
+     *  - show_at_registration
+     *  - visible
+     *
+     * @return array
+     */
+    protected static function getHiddenFormFields()
+    {
+        return [];
+    }
+
+    /**
      * Returns an array of instances of all available field types.
      *
      * @param ProfileField|null $profileField

--- a/protected/humhub/modules/user/models/fieldtype/BaseTypeVirtual.php
+++ b/protected/humhub/modules/user/models/fieldtype/BaseTypeVirtual.php
@@ -60,6 +60,14 @@ abstract class BaseTypeVirtual extends BaseType
     }
 
     /**
+     * @inheritdoc
+     */
+    protected static function getHiddenFormFields()
+    {
+        return ['searchable', 'required', 'show_at_registration', 'editable'];
+    }
+
+    /**
      * Returns the readonly virutal value for the given User
      *
      * @param User $user
@@ -67,4 +75,18 @@ abstract class BaseTypeVirtual extends BaseType
      * @return mixed
      */
     abstract protected function getVirtualUserValue($user, $raw = true);
+
+    /**
+     * @inheritDoc
+     */
+    public function save()
+    {
+        $this->profileField->editable = 0;
+        $this->profileField->searchable = 0;
+        $this->profileField->required = 0;
+        $this->profileField->show_at_registration = 0;
+        parent::save();
+    }
+
+
 }

--- a/protected/humhub/modules/user/models/fieldtype/BaseTypeVirtual.php
+++ b/protected/humhub/modules/user/models/fieldtype/BaseTypeVirtual.php
@@ -85,7 +85,7 @@ abstract class BaseTypeVirtual extends BaseType
         $this->profileField->searchable = 0;
         $this->profileField->required = 0;
         $this->profileField->show_at_registration = 0;
-        parent::save();
+        return parent::save();
     }
 
 


### PR DESCRIPTION
Fix #4274: Force profile field attribute values of BaseTypeVirtual fields

- Forces specific field attribute values for BaseTypeVirtual
- Adds possibility to hide form fields per profile type
- Adds additional check to avoid #4274

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No