### PR TITLE
Enh: Implementation of Content::isEdited()

### DIFF
--- a/protected/humhub/modules/comment/models/Comment.php
+++ b/protected/humhub/modules/comment/models/Comment.php
@@ -291,4 +291,14 @@ class Comment extends ContentAddonActiveRecord implements ContentOwner
 
         return false;
     }
+
+    /**
+     * TODO: Unify with Content::isUpdated() see https://github.com/humhub/humhub/pull/4380
+     * @returns boolean true if this comment has been updated, otherwise false
+     * @since 1.7
+     */
+    public function isUpdated()
+    {
+        return $this->created_at !== $this->updated_at && !empty($this->updated_at) && is_string($this->updated_at);
+    }
 }

--- a/protected/humhub/modules/comment/tests/codeception/unit/CommentEditTest.php
+++ b/protected/humhub/modules/comment/tests/codeception/unit/CommentEditTest.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * @link https://www.humhub.org/
+ * @copyright Copyright (c) 2017 HumHub GmbH & Co. KG
+ * @license https://www.humhub.com/licences
+ *
+ */
+
+namespace tests\codeception\unit\modules\content;
+
+use humhub\modules\comment\models\Comment;
+use tests\codeception\_support\HumHubDbTestCase;
+use humhub\modules\post\models\Post;
+
+class CommentEditTest extends HumHubDbTestCase
+{
+
+    public function testNewCommentIsNotEdited()
+    {
+        $this->becomeUser('User2');
+        $comment = new Comment([
+            'message' => 'User2 comment!',
+            'object_model' => Post::class,
+            'object_id' => 11
+        ]);
+
+        $this->assertTrue($comment->save());
+        $this->assertFalse($comment->isUpdated());
+
+        // Reload content
+        $comment = Comment::findOne(['id' => $comment->id]);
+        $this->assertFalse($comment->content->isUpdated());
+    }
+
+    public function testEditedContentIsEdited()
+    {
+        $this->becomeUser('User2');
+        $comment = new Comment([
+            'message' => 'User2 comment!',
+            'object_model' => Post::class,
+            'object_id' => 11
+        ]);
+
+        $this->assertTrue($comment->save());
+
+        // Wait a second in order to prevent created_at = edited_at
+        sleep(1);
+
+        // Reload content
+        $comment = Comment::findOne(['id' => $comment->id]);
+        $comment->message = 'Updated Message';
+        $this->assertTrue($comment->save());
+
+        // See https://github.com/humhub/humhub/issues/4381
+        $comment->refresh();
+        $this->assertTrue($comment->isUpdated());
+
+        // Reload content
+        $comment = Comment::findOne(['id' => $comment->id]);
+        $this->assertTrue($comment->isUpdated());
+    }
+
+}

--- a/protected/humhub/modules/content/models/Content.php
+++ b/protected/humhub/modules/content/models/Content.php
@@ -880,7 +880,7 @@ class Content extends ActiveRecord implements Movable, ContentOwner
     }
 
     /**
-     * @returns boolean
+     * @returns boolean true if this content has been edited, otherwise false
      * @since 1.7
      */
     public function isEdited()

--- a/protected/humhub/modules/content/models/Content.php
+++ b/protected/humhub/modules/content/models/Content.php
@@ -880,10 +880,10 @@ class Content extends ActiveRecord implements Movable, ContentOwner
     }
 
     /**
-     * @returns boolean true if this content has been edited, otherwise false
+     * @returns boolean true if this content has been updated, otherwise false
      * @since 1.7
      */
-    public function isEdited()
+    public function isUpdated()
     {
         return $this->created_at !== $this->updated_at && !empty($this->updated_at) && is_string($this->updated_at);
     }

--- a/protected/humhub/modules/content/models/Content.php
+++ b/protected/humhub/modules/content/models/Content.php
@@ -538,6 +538,7 @@ class Content extends ActiveRecord implements Movable, ContentOwner
         if (!$container) {
             $container = $this->container;
         }
+
         return $this->getModel()->isOwner() || Yii::$app->user->can(ManageUsers::class) || $container->can(ManageContent::class);
     }
 
@@ -876,5 +877,14 @@ class Content extends ActiveRecord implements Movable, ContentOwner
     public function getContentDescription()
     {
         return $this->getModel()->getContentDescription();
+    }
+
+    /**
+     * @returns boolean
+     * @since 1.7
+     */
+    public function isEdited()
+    {
+        return $this->created_at !== $this->updated_at && !empty($this->updated_at) && is_string($this->updated_at);
     }
 }

--- a/protected/humhub/modules/content/tests/codeception/unit/ContentEditTest.php
+++ b/protected/humhub/modules/content/tests/codeception/unit/ContentEditTest.php
@@ -39,10 +39,14 @@ class ContentEditTest extends HumHubDbTestCase
         $post1 = new Post($space, Content::VISIBILITY_PUBLIC, ['message' => 'Test']);
         $this->assertTrue($post1->save());
 
+        // Wait a second in order to prevent created_at = edited_at
+        sleep(1);
+
         // Reload content
         $post1 = Post::findOne(['id' => $post1->id]);
         $post1->message = 'Updated Message';
         $this->assertTrue($post1->save());
+
 
         // See https://github.com/humhub/humhub/issues/4381
         $post1->refresh();

--- a/protected/humhub/modules/content/tests/codeception/unit/ContentEditTest.php
+++ b/protected/humhub/modules/content/tests/codeception/unit/ContentEditTest.php
@@ -14,10 +14,10 @@ use humhub\modules\post\models\Post;
 use humhub\modules\space\models\Space;
 use humhub\modules\content\models\Content;
 
-class ContentTest extends HumHubDbTestCase
+class ContentEditTest extends HumHubDbTestCase
 {
 
-    public function testNewPostIsNotEdited()
+    public function testNewContentIsNotEdited()
     {
         $this->becomeUser('User2');
         $space = Space::findOne(['id' => 2]);
@@ -31,7 +31,7 @@ class ContentTest extends HumHubDbTestCase
         $this->assertFalse($post1->content->isEdited());
     }
 
-    public function testEditedPostIsEdited()
+    public function testEditedContentIsEdited()
     {
         $this->becomeUser('User2');
         $space = Space::findOne(['id' => 2]);

--- a/protected/humhub/modules/content/tests/codeception/unit/ContentTest.php
+++ b/protected/humhub/modules/content/tests/codeception/unit/ContentTest.php
@@ -43,6 +43,8 @@ class ContentTest extends HumHubDbTestCase
         $post1 = Post::findOne(['id' => $post1->id]);
         $post1->message = 'Updated Message';
         $this->assertTrue($post1->save());
+
+        // See https://github.com/humhub/humhub/issues/4381
         $post1->refresh();
         $this->assertTrue($post1->content->isEdited());
 

--- a/protected/humhub/modules/content/tests/codeception/unit/ContentTest.php
+++ b/protected/humhub/modules/content/tests/codeception/unit/ContentTest.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * @link https://www.humhub.org/
+ * @copyright Copyright (c) 2017 HumHub GmbH & Co. KG
+ * @license https://www.humhub.com/licences
+ *
+ */
+
+namespace tests\codeception\unit\modules\content;
+
+use tests\codeception\_support\HumHubDbTestCase;
+use humhub\modules\post\models\Post;
+
+use humhub\modules\space\models\Space;
+use humhub\modules\content\models\Content;
+
+class ContentTest extends HumHubDbTestCase
+{
+
+    public function testNewPostIsNotEdited()
+    {
+        $this->becomeUser('User2');
+        $space = Space::findOne(['id' => 2]);
+
+        $post1 = new Post($space, Content::VISIBILITY_PUBLIC, ['message' => 'Test']);
+        $this->assertTrue($post1->save());
+        $this->assertFalse($post1->content->isEdited());
+
+        // Reload content
+        $post1 = Post::findOne(['id' => $post1->id]);
+        $this->assertFalse($post1->content->isEdited());
+    }
+
+    public function testEditedPostIsEdited()
+    {
+        $this->becomeUser('User2');
+        $space = Space::findOne(['id' => 2]);
+
+        $post1 = new Post($space, Content::VISIBILITY_PUBLIC, ['message' => 'Test']);
+        $this->assertTrue($post1->save());
+
+        // Reload content
+        $post1 = Post::findOne(['id' => $post1->id]);
+        $post1->message = 'Updated Message';
+        $this->assertTrue($post1->save());
+        $post1->refresh();
+        $this->assertTrue($post1->content->isEdited());
+
+        // Reload content
+        $post1 = Post::findOne(['id' => $post1->id]);
+        $this->assertTrue($post1->content->isEdited());
+    }
+
+}


### PR DESCRIPTION
Prior to this PR it was not obvious if a content entry has been edited or not. Its tempting to only check the `updated_at`
field, but this is also set on creation. The actual and rather complex check used in some views is:

```
$content->created_at !== $content->updated_at && !empty($content->updated_at) && is_string($content->updated_at);
```

which can now be replaced with:

```
$model->content->isEdited()
```

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No