### PR TITLE
Upgrade to Yii 2.0.38

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,11 @@
     "minimum-stability": "stable",
     "require": {
         "php": ">=7.0.0",
+        "ext-exif": "*",
         "ext-zip": "*",
         "cebe/markdown": "1.0.2",
+        "codeception/phpunit-wrapper": ">6.0.15 <6.1.0 | ^6.6.1 | ^7.7.1 | ^8.1.1 | ^9.0",
+        "codeception/stub": "^2.0 | ^3.0",
         "firebase/php-jwt": "^5.0",
         "jbroadway/urlify": "^1.0",
         "kartik-v/yii2-widgets": "*",
@@ -49,7 +52,7 @@
         "raoul2000/yii2-jcrop-widget": "*",
         "twig/twig": "^1.0",
         "xj/yii2-jplayer-widget": "*",
-        "yiisoft/yii2": "~2.0.35",
+        "yiisoft/yii2": "2.0.38",
         "yiisoft/yii2-authclient": "~2.2.0",
         "yiisoft/yii2-bootstrap": "~2.0.0",
         "yiisoft/yii2-httpclient": "~2.0.0",
@@ -59,10 +62,7 @@
         "yiisoft/yii2-redis": "~2.0.0",
         "yiisoft/yii2-swiftmailer": "~2.0.0",
         "zendframework/zend-http": "*",
-        "zendframework/zend-ldap": "^2.5",
-        "codeception/phpunit-wrapper": ">6.0.15 <6.1.0 | ^6.6.1 | ^7.7.1 | ^8.1.1 | ^9.0",
-        "codeception/stub": "^2.0 | ^3.0",
-        "ext-exif": "*"
+        "zendframework/zend-ldap": "^2.5"
     },
     "require-dev": {
         "codeception/codeception": "^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,14 +4,14 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bc6c87c6cc3b5b69a286d782e9150613",
+    "content-hash": "5a253757a2f52ea476c00e5bff4d7169",
     "packages": [
         {
             "name": "bower-asset/bootstrap",
             "version": "v3.4.1",
             "source": {
                 "type": "git",
-                "url": "git@github.com:twbs/bootstrap.git",
+                "url": "https://github.com/twbs/bootstrap.git",
                 "reference": "68b0d231a13201eb14acd3dc84e51543d16e5f7e"
             },
             "dist": {
@@ -32,7 +32,7 @@
             "version": "3.3.11",
             "source": {
                 "type": "git",
-                "url": "https://github.com/RobinHerbots/Inputmask.git",
+                "url": "git@github.com:RobinHerbots/Inputmask.git",
                 "reference": "5e670ad62f50c738388d4dcec78d2888505ad77b"
             },
             "dist": {
@@ -71,7 +71,7 @@
             "version": "1.12.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/components/jqueryui.git",
+                "url": "git@github.com:components/jqueryui.git",
                 "reference": "44ecf3794cc56b65954cc19737234a3119d036cc"
             },
             "dist": {
@@ -92,7 +92,7 @@
             "version": "v1.3.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/bestiejs/punycode.js.git",
+                "url": "git@github.com:bestiejs/punycode.js.git",
                 "reference": "38c8d3131a82567bfef18da09f7f4db68c84f8a3"
             },
             "dist": {
@@ -3448,6 +3448,7 @@
             "keywords": [
                 "tokenizer"
             ],
+            "abandoned": true,
             "time": "2017-11-27T05:48:46+00:00"
         },
         {
@@ -4812,16 +4813,16 @@
         },
         {
             "name": "yiisoft/yii2",
-            "version": "2.0.36",
+            "version": "2.0.38",
             "source": {
                 "type": "git",
                 "url": "https://github.com/yiisoft/yii2-framework.git",
-                "reference": "a557111ea6c27794b98c98b76ff3f127eb55f309"
+                "reference": "fd01e747cc66a049ec105048f0ab8dfbdf60bf4b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/yiisoft/yii2-framework/zipball/a557111ea6c27794b98c98b76ff3f127eb55f309",
-                "reference": "a557111ea6c27794b98c98b76ff3f127eb55f309",
+                "url": "https://api.github.com/repos/yiisoft/yii2-framework/zipball/fd01e747cc66a049ec105048f0ab8dfbdf60bf4b",
+                "reference": "fd01e747cc66a049ec105048f0ab8dfbdf60bf4b",
                 "shasum": ""
             },
             "require": {
@@ -4922,7 +4923,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-07-07T21:45:32+00:00"
+            "time": "2020-09-14T21:52:10+00:00"
         },
         {
             "name": "yiisoft/yii2-authclient",
@@ -7572,8 +7573,8 @@
     "prefer-lowest": false,
     "platform": {
         "php": ">=7.0.0",
-        "ext-zip": "*",
-        "ext-exif": "*"
+        "ext-exif": "*",
+        "ext-zip": "*"
     },
     "platform-dev": [],
     "platform-overrides": {

--- a/protected/humhub/docs/CHANGELOG.md
+++ b/protected/humhub/docs/CHANGELOG.md
@@ -3,8 +3,12 @@ HumHub Changelog
 
 1.6.4 (Unreleased)
 ------------------
+
+This release also brings a [security update](https://github.com/yiisoft/yii2/security/advisories/GHSA-699q-wcff-g9mj) of the Yii2 framework. HumHub itself and the modules provided by our offical marketplace are not affected by this bug.
+
 - Fix #4361: Added missing nonce attribute in inline marketplace script
 - Fix #4371: Word break issue in notification dropdown
+- Fix #4384: Upgrade to Yii 2.0.38
 
 
 1.6.3 (September 9, 2020)


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

---

It seems that HumHub and the official marketplace modules are not affected by the Yii2 security bug CVE-2020-15148. 

Although we should provide an update for individual modules here. The Yii2 update does not sound critical.

```
  Seems you have upgraded Yii Framework from version 2.0.36 to 2.0.38.

  Please check the upgrade notes for possible incompatible changes
  and adjust your application code accordingly.

  Upgrade from Yii 2.0.37
  -----------------------

  * Resolving DI references inside of arrays in dependencies was made optional and turned off by default. In order
    to turn it on, set `resolveArrays` of container instance to `true`.

  Upgrade from Yii 2.0.36
  -----------------------

  * `yii\db\Exception::getCode()` now returns full PDO code that is SQLSTATE string. If you have relied on comparing code
    with an integer value, adjust your code.

  You can find the upgrade notes for all versions online at:
  https://github.com/yiisoft/yii2/blob/2.0.38/framework/UPGRADE.md


```



