### PR TITLE
Fix/get active filter count with exclude array

### DIFF
--- a/CHANGELOG_DEV.md
+++ b/CHANGELOG_DEV.md
@@ -39,3 +39,5 @@ HumHub Changelog
 - Enh #4401: Allow to use less variable name in value of another less variable
 - Fix #4434: Fix title quoting for space icons in widget “Member in these spaces”
 - Fix #4428: Replace db Expression time now with func date('Y-m-d G:i:s')
+- Fix #4452: `humhub.ui.filter.getActiveFilterCount` returns wrong value with exclude array option
+- Fix #4452: Ignore `scope` profile filter in stream filter count and hasActiveFilters

--- a/protected/humhub/modules/stream/resources/js/humhub.stream.Stream.js
+++ b/protected/humhub/modules/stream/resources/js/humhub.stream.Stream.js
@@ -603,7 +603,7 @@ humhub.module('stream.Stream', function (module, require, $) {
     };
 
     Stream.prototype.hasActiveFilters = function () {
-        return this.filter && this.filter.getActiveFilterCount({exclude: 'sort'}) > 0;
+        return this.filter && this.filter.getActiveFilterCount({exclude: ['sort', 'scope']}) > 0;
     };
 
     /**

--- a/protected/humhub/modules/stream/resources/js/humhub.stream.wall.js
+++ b/protected/humhub/modules/stream/resources/js/humhub.stream.wall.js
@@ -134,7 +134,6 @@ humhub.module('stream.wall', function (module, require, $) {
         var isContainer = this.isSpaceStream() || this.isUserStream();
 
 
-
         if (!isDashboard && !isContainer) {
             return false;
         }
@@ -380,7 +379,7 @@ humhub.module('stream.wall', function (module, require, $) {
     };
 
     WallStreamFilter.prototype.updateFilterCount = function () {
-        var count = this.getActiveFilterCount({exclude:'sort'});
+        var count = this.getActiveFilterCount({exclude: ['sort', 'scope']});
 
         var $filterToggle = this.$.find('.wall-stream-filter-toggle');
         var $filterCount = $filterToggle.find('.filterCount');

--- a/protected/humhub/modules/ui/filter/resources/js/humhub.ui.filter.js
+++ b/protected/humhub/modules/ui/filter/resources/js/humhub.ui.filter.js
@@ -262,7 +262,7 @@ humhub.module('ui.filter', function(module, require, $) {
         var result = true;
         if(options.exclude) {
             if(object.isArray(options.exclude)) {
-                result = options.exclude.indexOf(input.getCategory()) <= 0;
+                result = options.exclude.indexOf(input.getCategory()) < 0;
             } else {
                 result = input.getCategory() !== options.exclude;
             }


### PR DESCRIPTION
- Fix: humhub.ui.filter.getActiveFilterCount with exclude array option
- Fix: Ignore scope filter in filter count and hasActiveFilters

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No