### PR TITLE
Fixed #4456 PHP8 deprecated warning for LessHelper::updateVariables()

### DIFF
--- a/CHANGELOG_DEV.md
+++ b/CHANGELOG_DEV.md
@@ -41,4 +41,4 @@ HumHub Changelog
 - Fix #4428: Replace db Expression time now with func date('Y-m-d G:i:s')
 - Fix #4452: `humhub.ui.filter.getActiveFilterCount` returns wrong value with exclude array option
 - Fix #4452: Ignore `scope` profile filter in stream filter count and hasActiveFilters
-- Fixed #4456 PHP8 deprecated warning for LessHelper::updateVariables()
+- Fix #4456: PHP8 deprecated warning for LessHelper::updateVariables()

--- a/CHANGELOG_DEV.md
+++ b/CHANGELOG_DEV.md
@@ -41,3 +41,4 @@ HumHub Changelog
 - Fix #4428: Replace db Expression time now with func date('Y-m-d G:i:s')
 - Fix #4452: `humhub.ui.filter.getActiveFilterCount` returns wrong value with exclude array option
 - Fix #4452: Ignore `scope` profile filter in stream filter count and hasActiveFilters
+- Fixed #4456 PHP8 deprecated warning for LessHelper::updateVariables()

--- a/protected/humhub/modules/ui/view/helpers/LessHelper.php
+++ b/protected/humhub/modules/ui/view/helpers/LessHelper.php
@@ -33,7 +33,7 @@ class LessHelper
      * @param array $variables
      * @param $file
      */
-    public static function updateVariables($variables = [], $file)
+    public static function updateVariables($variables, $file)
     {
         $content = file_get_contents($file);
         foreach ($variables as $key => $value) {
@@ -83,6 +83,7 @@ class LessHelper
      *     @thirdColor: @secondColor;
      *
      * @param array $variables
+     * @since 1.7
      * @return array $variables
      */
     public static function updateLinkedLessVariables($variables)


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

Fixes https://github.com/humhub/humhub/issues/4456