### PR TITLE
Fix: removed deprecated safe_mode ini check in UrlOembedHttpClient

### DIFF
--- a/protected/humhub/libs/UrlOembedHttpClient.php
+++ b/protected/humhub/libs/UrlOembedHttpClient.php
@@ -25,8 +25,8 @@ class UrlOembedHttpClient implements UrlOembedClient
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($curl, CURLOPT_TIMEOUT, 15);
 
-        // Not available when open_basedir or safe_mode is set.
-        if (!function_exists('ini_get') || !ini_get('open_basedir') || !ini_get('safe_mode')) {
+        // Not available when open_basedir is set.
+        if (!function_exists('ini_get') || !ini_get('open_basedir')) {
             curl_setopt($curl, CURLOPT_FOLLOWLOCATION, true);
         }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

------------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
------------------------------------------------------------------------------------------------
 29 | WARNING | INI directive 'safe_mode' is deprecated since PHP 5.3 and removed since PHP 5.4
------------------------------------------------------------------------------------------------