### PR TITLE
Fixed usage of deprecated create_function in unit tests

### DIFF
--- a/protected/humhub/modules/content/tests/codeception/unit/ContentContainerStreamTest.php
+++ b/protected/humhub/modules/content/tests/codeception/unit/ContentContainerStreamTest.php
@@ -78,7 +78,7 @@ class ContentContainerStreamTest extends HumHubDbTestCase
 
         $wallEntries = $action->activeQuery->all();
 
-        $wallEntryIds = array_map(create_function('$entry', 'return $entry->id;'), $wallEntries);
+        $wallEntryIds = array_map(static function($entry) {return $entry->id; }, $wallEntries);
 
         return $wallEntryIds;
     }

--- a/protected/humhub/modules/dashboard/tests/codeception/unit/DashboardStreamTest.php
+++ b/protected/humhub/modules/dashboard/tests/codeception/unit/DashboardStreamTest.php
@@ -30,7 +30,7 @@ class DashboardStreamTest extends HumHubDbTestCase
         $post1->content->container = Yii::$app->user->getIdentity();
         $post1->content->visibility = Content::VISIBILITY_PRIVATE;
         $post1->save();
-        
+
         $w1 = $post1->content->id;
 
         $post2 = new Post();
@@ -38,12 +38,12 @@ class DashboardStreamTest extends HumHubDbTestCase
         $post2->content->container = Yii::$app->user->getIdentity();
         $post2->content->visibility = Content::VISIBILITY_PUBLIC;
         $post2->save();
-        
+
         $w2 = $post2->content->id;
 
         $this->becomeUser('Admin');
         $ids = $this->getStreamActionIds(2);
-        
+
         $this->assertFalse(in_array($w1, $ids));
         $this->assertTrue(in_array($w2, $ids));
     }
@@ -101,7 +101,7 @@ class DashboardStreamTest extends HumHubDbTestCase
         $post2->content->visibility = Content::VISIBILITY_PUBLIC;
         $post2->save();
         $w2 = $post2->content->id;
-        
+
         $this->assertEquals($this->getStreamActionIds(2), [$w2, $w1]);
 
         $this->becomeUser('User3');
@@ -140,10 +140,10 @@ class DashboardStreamTest extends HumHubDbTestCase
         $action = new DashboardStreamAction('stream', Yii::$app->controller, [
             'limit' => $limit,
         ]);
-        
+
         $action->init();
-        
+
         $streamEntries = $action->activeQuery->all();
-        return array_map(create_function('$entry', 'return $entry->id;'), $streamEntries);
+        return  array_map(static function($entry) {return $entry->id; }, $streamEntries);
     }
 }

--- a/protected/humhub/modules/notification/tests/codeception/unit/LoadNotificationTest.php
+++ b/protected/humhub/modules/notification/tests/codeception/unit/LoadNotificationTest.php
@@ -18,22 +18,22 @@ class LoadNotificationTest extends HumHubDbTestCase
 
         $notifications = Notification::loadMore();
         $this->assertEquals(6, count($notifications));
-        
-        $ids = array_map(create_function('$o', 'return $o->id;'), $notifications);
+
+        $ids = array_map(static function($o) {return $o->id; }, $notifications);
         $this->assertEquals(18, max($ids));
         $this->assertEquals(13, min($ids));
-        
+
         $notifications = Notification::loadMore(13);
         $this->assertEquals(6, count($notifications));
-        
-        $ids = array_map(create_function('$o', 'return $o->id;'), $notifications);
+
+        $ids = array_map(static function($o) {return $o->id; }, $notifications);
         $this->assertEquals(12, max($ids));
         $this->assertEquals(7, min($ids));
-        
+
         $notifications = Notification::loadMore(7);
         $this->assertEquals(6, count($notifications));
-        
-        $ids = array_map(create_function('$o', 'return $o->id;'), $notifications);
+
+        $ids = array_map(static function($o) {return $o->id; }, $notifications);
         $this->assertEquals(6, max($ids));
         $this->assertEquals(1, min($ids));
     }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

- Function `create_function()` is deprecated since PHP 7.2; Use an anonymous function instead