### PR TITLE
Fix/mail summary stream broken

### DIFF
--- a/protected/humhub/modules/activity/components/MailSummary.php
+++ b/protected/humhub/modules/activity/components/MailSummary.php
@@ -141,29 +141,33 @@ class MailSummary extends Component
      */
     public function getActivities()
     {
-        $stream = new DashboardStreamAction('stream', Yii::$app->controller);
-        $stream->activity = true;
-        $stream->limit = $this->maxActivityCount;
-        $stream->user = $this->user;
+        $stream = new DashboardStreamAction('stream', Yii::$app->controller , [
+            'activity' => true,
+            'limit' => $this->maxActivityCount,
+            'user' => $this->user,
+        ]);
+
         $stream->init();
-        $stream->activeQuery->andWhere(['>', 'content.created_at', $this->getLastSummaryDate()]);
+
+        $query = $stream->getStreamQuery()->query();
+        $query->andWhere(['>', 'content.created_at', $this->getLastSummaryDate()]);
 
         // Handle suppressed activities
         $suppressedActivities = $this->getSuppressedActivities();
         if (!empty($suppressedActivities)) {
-            $stream->activeQuery->leftJoin('activity ax', 'ax.id=content.object_id');
-            $stream->activeQuery->andWhere(['NOT IN', 'ax.class', $suppressedActivities]);
+            $query->leftJoin('activity ax', 'ax.id=content.object_id');
+            $query->andWhere(['NOT IN', 'ax.class', $suppressedActivities]);
         }
 
         // Handle defined content container mode
         $limitContainer = $this->getLimitContentContainers();
         if (!empty($limitContainer)) {
             $mode = ($this->getLimitContentContainerMode() == MailSummaryForm::LIMIT_MODE_INCLUDE) ? 'IN' : 'NOT IN';
-            $stream->activeQuery->andWhere([$mode, 'content.contentcontainer_id', $limitContainer]);
+            $query->andWhere([$mode, 'content.contentcontainer_id', $limitContainer]);
         }
 
         $activities = [];
-        foreach ($stream->activeQuery->all() as $content) {
+        foreach ($stream->getStreamQuery()->all() as $content) {
             try {
                 $activity = $content->getPolymorphicRelation();
                 if ($activity instanceof Activity) {

--- a/protected/humhub/modules/activity/widgets/ActivityStreamViewer.php
+++ b/protected/humhub/modules/activity/widgets/ActivityStreamViewer.php
@@ -23,6 +23,11 @@ class ActivityStreamViewer extends StreamViewer
     /**
      * @inheritDoc
      */
+    public $streamFilterNavigation = null;
+
+    /**
+     * @inheritDoc
+     */
     public function __construct(array $config = [])
     {
         $defaults = [

--- a/protected/humhub/modules/content/tests/codeception/unit/ContentContainerStreamTest.php
+++ b/protected/humhub/modules/content/tests/codeception/unit/ContentContainerStreamTest.php
@@ -76,7 +76,7 @@ class ContentContainerStreamTest extends HumHubDbTestCase
         $action->contentContainer = $container;
         $action->limit = $limit;
 
-        $wallEntries = $action->activeQuery->all();
+        $wallEntries = $action->getStreamQuery()->all();
 
         $wallEntryIds = array_map(static function($entry) {return $entry->id; }, $wallEntries);
 

--- a/protected/humhub/modules/dashboard/components/actions/DashboardStreamAction.php
+++ b/protected/humhub/modules/dashboard/components/actions/DashboardStreamAction.php
@@ -76,8 +76,9 @@ class DashboardStreamAction extends ActivityStreamAction
             ->where('user.status=1 AND user.visibility = ' . User::VISIBILITY_ALL);
         $union .= " UNION " . Yii::$app->db->getQueryBuilder()->build($publicProfilesSql)[0];
 
-        $this->activeQuery->andWhere('content.contentcontainer_id IN (' . $union . ') OR content.contentcontainer_id IS NULL', [':spaceClass' => Space::class, ':userClass' => User::class]);
-        $this->activeQuery->andWhere(['content.visibility' => Content::VISIBILITY_PUBLIC]);
+        $query = $this->getStreamQuery()->query();
+        $query->andWhere('content.contentcontainer_id IN (' . $union . ') OR content.contentcontainer_id IS NULL', [':spaceClass' => Space::class, ':userClass' => User::class]);
+        $query->andWhere(['content.visibility' => Content::VISIBILITY_PUBLIC]);
     }
 
     public function setupUserFilter()

--- a/protected/humhub/modules/dashboard/tests/codeception/unit/DashboardStreamTest.php
+++ b/protected/humhub/modules/dashboard/tests/codeception/unit/DashboardStreamTest.php
@@ -143,7 +143,7 @@ class DashboardStreamTest extends HumHubDbTestCase
 
         $action->init();
 
-        $streamEntries = $action->activeQuery->all();
+        $streamEntries = $action->getStreamQuery()->all();
         return  array_map(static function($entry) {return $entry->id; }, $streamEntries);
     }
 }

--- a/protected/humhub/modules/directory/components/UserPostsStreamAction.php
+++ b/protected/humhub/modules/directory/components/UserPostsStreamAction.php
@@ -12,6 +12,7 @@ use Yii;
 use humhub\modules\stream\actions\Stream;
 use humhub\modules\user\models\User;
 use humhub\modules\content\models\Content;
+use yii\db\Query;
 
 /**
  * UserPostsStreamAction creates a stream of all public profile posts.
@@ -29,9 +30,10 @@ class UserPostsStreamAction extends Stream
     {
         parent::init();
 
-        $this->activeQuery->andWhere(['content.visibility' => Content::VISIBILITY_PUBLIC]);
+        $query = $this->streamQuery->query();
+        $query->andWhere(['content.visibility' => Content::VISIBILITY_PUBLIC]);
 
-        $wallIdsQuery = (new \yii\db\Query())
+        $wallIdsQuery = (new Query())
                 ->select('contentcontainer.id')
                 ->from('user')
                 ->leftJoin('contentcontainer', 'contentcontainer.pk=user.id AND contentcontainer.class=:userClass');
@@ -39,7 +41,7 @@ class UserPostsStreamAction extends Stream
             $wallIdsQuery->andWhere('visibility=' . User::VISIBILITY_ALL);
         }
         $wallIdsSql = Yii::$app->db->getQueryBuilder()->build($wallIdsQuery)[0];
-        $this->activeQuery->andWhere('content.contentcontainer_id IN (' . $wallIdsSql . ')', [':userClass' => User::class]);
+        $query->andWhere('content.contentcontainer_id IN (' . $wallIdsSql . ')', [':userClass' => User::class]);
     }
 
 }

--- a/protected/humhub/modules/stream/actions/LegacyStreamTrait.php
+++ b/protected/humhub/modules/stream/actions/LegacyStreamTrait.php
@@ -35,15 +35,6 @@ trait LegacyStreamTrait
     public $activeQuery;
 
     /**
-     * Optional stream user
-     * if no user is specified, the current logged in user will be used.
-     *
-     * @var User
-     * @deprecated since 1.7 use StreamQuery->user
-     */
-    public $user;
-
-    /**
      * First wall entry id to deliver
      *
      * @var int

--- a/protected/humhub/modules/stream/actions/LegacyStreamTrait.php
+++ b/protected/humhub/modules/stream/actions/LegacyStreamTrait.php
@@ -181,7 +181,7 @@ trait LegacyStreamTrait
      */
     protected function isInitialRequest()
     {
-        return $this->from === null && $this->to === null && $this->limit != 1;
+        return $this->from === null && $this->to === null && $this->limit !== 1;
     }
 
     private function setDeprecatedActionProperties()

--- a/protected/humhub/modules/stream/actions/Stream.php
+++ b/protected/humhub/modules/stream/actions/Stream.php
@@ -9,6 +9,7 @@
 namespace humhub\modules\stream\actions;
 
 use humhub\modules\stream\events\StreamResponseEvent;
+use humhub\modules\user\models\User;
 use Yii;
 use yii\base\Action;
 use yii\base\Exception;
@@ -96,6 +97,13 @@ abstract class Stream extends Action
     const MAX_LIMIT = 50;
 
     /**
+     * Optional stream user if no user is specified, the current logged in user will be used.
+     *
+     * @var User
+     */
+    public $user;
+
+    /**
      * Used to load single content entries.
      * @since 1.2
      */
@@ -177,12 +185,13 @@ abstract class Stream extends Action
     {
         parent::init();
 
+        if(!$this->user) {
+            $this->user = Yii::$app->user->identity;
+        }
+
         $this->excludes = array_merge($this->excludes, Yii::$app->getModule('stream')->streamExcludes);
 
         $this->streamQuery = $this->initQuery();
-
-        // Just make sure legacy user property is available
-        $this->user = $this->streamQuery->user;
 
         if(!$this->viewContext) {
             $this->viewContext = Yii::$app->request->get('viewContext');
@@ -226,7 +235,7 @@ abstract class Stream extends Action
 
         /* @var $instance StreamQuery */
         $instance = $streamQueryClass::find();
-        $instance->forUser(Yii::$app->user->identity);
+        $instance->forUser($this->user);
         $instance->setAttributes($options, false);
         return $instance;
     }

--- a/protected/humhub/modules/stream/models/StreamQuery.php
+++ b/protected/humhub/modules/stream/models/StreamQuery.php
@@ -368,7 +368,7 @@ class StreamQuery extends Model
      */
     public function query($build = false)
     {
-        if ($build) {
+        if ($build && !$this->_built) {
             $this->setupQuery();
         }
 


### PR DESCRIPTION
The MailSummary process uses the DashboardStreamAction with the deprecated `user` property. This PR reverts to the old behavior and deprecation of the user property and also removes the usage of other deprecated Stream properties.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No