### PR TITLE
Added middot between stream entry date and stream entry icons

### DIFF
--- a/protected/humhub/modules/content/widgets/stream/views/wallStreamEntryHeader.php
+++ b/protected/humhub/modules/content/widgets/stream/views/wallStreamEntryHeader.php
@@ -81,6 +81,8 @@ $container = $model->content->container;
             <?= TimeAgo::widget(['timestamp' => $model->content->created_at]) ?>
         </a>
 
+        &middot;
+
         <div class="wall-entry-icons">
             <?php if ($model->content->isUpdated()) : ?>
                 <?= UpdatedIcon::getByDated($model->content->updated_at) ?>


### PR DESCRIPTION
This PR adds a middot between stream entry date and stream entry icons.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No