### PR TITLE
Fix: Ignore multi-line paragraphs when applying short-text-post class

### DIFF
--- a/protected/humhub/modules/post/resources/js/humhub.post.js
+++ b/protected/humhub/modules/post/resources/js/humhub.post.js
@@ -10,7 +10,7 @@ humhub.module('post', function(module, require, $) {
             var $rtContent = $(this).children();
             var $first = $rtContent.first();
 
-            if($rtContent.length === 1 && $first.is('p') && $first.text().length < 150) {
+            if($rtContent.length === 1 && $first.is('p') && $first.text().length < 150 && !$first.find('br').length) {
                 that.$.addClass('post-short-text');
             }
         })
@@ -19,5 +19,4 @@ humhub.module('post', function(module, require, $) {
     module.export({
         Post: Post
     });
-
 });


### PR DESCRIPTION
Only apply `short-text-post` class on single paragraph without new lines.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No