### PR TITLE
Increases about section text read-more text limit

### DIFF
--- a/protected/humhub/modules/space/views/space/about.php
+++ b/protected/humhub/modules/space/views/space/about.php
@@ -18,8 +18,7 @@ use humhub\modules\user\widgets\Image;
     <div class="panel-body">
         <?php if ($space->about || $space->description): ?>
             <div>
-                <div data-ui-markdown data-ui-show-more
-                     data-read-more-text="<?= Yii::t('SpaceModule.base', 'Read More') ?>">
+                <div data-ui-markdown data-ui-show-more data-collapse-at="600">
                     <?= RichText::output(empty($space->about) ? $space->description : $space->about) ?>
                 </div>
             </div>

--- a/protected/humhub/widgets/CoreJsConfig.php
+++ b/protected/humhub/widgets/CoreJsConfig.php
@@ -227,8 +227,8 @@ class CoreJsConfig extends Widget
                 ],
                 'ui.showMore' => [
                     'text' => [
-                        'readMore' => Yii::t('PostModule.base', 'Read full post...'),
-                        'readLess' => Yii::t('PostModule.base', 'Collapse'),
+                        'readMore' => Yii::t('UiModule.base', 'Read more'),
+                        'readLess' => Yii::t('UiModule.base', 'Collapse'),
                     ]
                 ],
                 'ui.panel' => [


### PR DESCRIPTION
Related to https://github.com/humhub/humhub/issues/4483#issuecomment-707829189

- Increases the read-more text limit in the about section from 380px to 600px.
- Changes the defaul text of read-more feature from "Read full post..." to "Read more"

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

![grafik](https://user-images.githubusercontent.com/9800854/95974453-4898af00-0e15-11eb-928e-19a44afe698e.png)
