### PR TITLE
Fix #4493: Removed legacy ControllerAccess in notification ListController

### DIFF
--- a/CHANGELOG_DEV.md
+++ b/CHANGELOG_DEV.md
@@ -61,3 +61,4 @@ HumHub Changelog
 - Enh #4476: Reworked TimeAgo widget
 - Chng #4482: Removed old legacy richtext editor which is deprecated since v1.3
 - Fix #4354: Set `about` as target url of space invitation notification
+- Fix #4493: Removed legacy ControllerAccess in notification ListController

--- a/protected/humhub/modules/notification/controllers/ListController.php
+++ b/protected/humhub/modules/notification/controllers/ListController.php
@@ -8,6 +8,7 @@
 
 namespace humhub\modules\notification\controllers;
 
+use humhub\components\access\ControllerAccess;
 use humhub\components\Controller;
 use humhub\modules\notification\models\Notification;
 use Yii;
@@ -20,16 +21,13 @@ use yii\db\IntegrityException;
  */
 class ListController extends Controller
 {
-
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
-    public function behaviors()
+    public function getAccessRules()
     {
         return [
-            'acl' => [
-                'class' => \humhub\components\behaviors\AccessControl::class,
-            ]
+            [ControllerAccess::RULE_LOGGED_IN_ONLY]
         ];
     }
 


### PR DESCRIPTION

Fixes: https://github.com/humhub/humhub/issues/4493

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No