### PR TITLE
Fix #4526: `HeaderControlsMenu::init` called twice

### DIFF
--- a/CHANGELOG_DEV.md
+++ b/CHANGELOG_DEV.md
@@ -4,6 +4,7 @@ HumHub Changelog
 1.7.0-beta.2 (Unreleased)
 -------------------------
 - Fix #4504: Fix `hasSidebar()` for empty sidebar
+- Fix #4526: `HeaderControlsMenu::init` called twice
 
 
 1.7.0-beta.1 (October 16, 2020)

--- a/protected/humhub/modules/space/widgets/HeaderControlsMenu.php
+++ b/protected/humhub/modules/space/widgets/HeaderControlsMenu.php
@@ -148,7 +148,5 @@ class HeaderControlsMenu extends DropdownMenu
                 ]));
             }
         }
-
-        return parent::init();
     }
 }


### PR DESCRIPTION
Fixes https://github.com/humhub/humhub/issues/4526

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

**Does this PR introduce a breaking change?** (check one)

- [x] No