### PR TITLE
Empty "Add Modules" modal on space creation #4494

### DIFF
--- a/protected/humhub/docs/CHANGELOG.md
+++ b/protected/humhub/docs/CHANGELOG.md
@@ -5,6 +5,7 @@ HumHub Changelog
 ------------------
 
 - Fix #4555: Default password validation error message missing translation and wrong min. characters
+- Fix #4494: Empty "Add Modules" step on space creation when all modules are always enabled
 
 
 1.6.4 (October 9, 2020)

--- a/protected/humhub/modules/content/components/ContentContainerModule.php
+++ b/protected/humhub/modules/content/components/ContentContainerModule.php
@@ -219,25 +219,4 @@ class ContentContainerModule extends Module
         return [];
     }
 
-    /**
-     * This method is called to find all modules which available and set as default
-     *
-     * @param $container
-     * @return mixed
-     * @since 1.7
-     */
-    public static function getInstallableModules($container)
-    {
-        $availableModules = $container->getAvailableModules();
-        foreach ($availableModules as $moduleId => $module) {
-            if (($container->isModuleEnabled($moduleId) && !$container->canDisableModule($moduleId)) ||
-                (!$container->isModuleEnabled($moduleId) && !$container->canEnableModule($moduleId))
-            ) {
-                unset($availableModules[$moduleId]);
-            }
-        }
-        return $availableModules;
-    }
 }
-
-

--- a/protected/humhub/modules/content/components/ContentContainerModule.php
+++ b/protected/humhub/modules/content/components/ContentContainerModule.php
@@ -219,4 +219,25 @@ class ContentContainerModule extends Module
         return [];
     }
 
+    /**
+     * This method is called to find all modules which available and set as default
+     *
+     * @param $container
+     * @return mixed
+     * @since 1.7
+     */
+    public static function getInstallableModules($container)
+    {
+        $availableModules = $container->getAvailableModules();
+        foreach ($availableModules as $moduleId => $module) {
+            if (($container->isModuleEnabled($moduleId) && !$container->canDisableModule($moduleId)) ||
+                (!$container->isModuleEnabled($moduleId) && !$container->canEnableModule($moduleId))
+            ) {
+                unset($availableModules[$moduleId]);
+            }
+        }
+        return $availableModules;
+    }
 }
+
+

--- a/protected/humhub/modules/content/components/ContentContainerModuleManager.php
+++ b/protected/humhub/modules/content/components/ContentContainerModuleManager.php
@@ -22,21 +22,6 @@ use humhub\modules\content\models\ContentContainer;
 class ContentContainerModuleManager extends \yii\base\Component
 {
     /**
-     * @var integer Module option "set as default" is in activated state
-     */
-    const STATE_ACTIVATED = 0;
-
-    /**
-     * @var integer Module option "set as default" is in deactivated state
-     */
-    const STATE_DEACTIVATED = 1;
-
-    /**
-     * @var integer Module option "set as default" is in always active state
-     */
-    const STATE_ALWAYS_ACTIVE = 2;
-
-    /**
      * @var \humhub\modules\content\components\ContentContainerActiveRecord
      */
     public $contentContainer;
@@ -292,15 +277,5 @@ class ContentContainerModuleManager extends \yii\base\Component
         }
 
         return $query;
-    }
-
-    /**
-     * Check module for "set as default" state as "Always active"
-     * @param $id
-     * @return bool
-     */
-    public function isAlwaysActive($id)
-    {
-        return self::getDefaultState($this->contentContainer->className(), $id) === self::STATE_ALWAYS_ACTIVE;
     }
 }

--- a/protected/humhub/modules/content/components/ContentContainerModuleManager.php
+++ b/protected/humhub/modules/content/components/ContentContainerModuleManager.php
@@ -21,6 +21,20 @@ use humhub\modules\content\models\ContentContainer;
  */
 class ContentContainerModuleManager extends \yii\base\Component
 {
+    /**
+     * @var integer Module option "set as default" is in activated state
+     */
+    const STATE_ACTIVATED = 0;
+
+    /**
+     * @var integer Module option "set as default" is in deactivated state
+     */
+    const STATE_DEACTIVATED = 1;
+
+    /**
+     * @var integer Module option "set as default" is in always active state
+     */
+    const STATE_ALWAYS_ACTIVE = 2;
 
     /**
      * @var \humhub\modules\content\components\ContentContainerActiveRecord
@@ -280,4 +294,13 @@ class ContentContainerModuleManager extends \yii\base\Component
         return $query;
     }
 
+    /**
+     * Check module for "set as default" state as "Always active"
+     * @param $id
+     * @return bool
+     */
+    public function isAlwaysActive($id)
+    {
+        return self::getDefaultState($this->contentContainer->className(), $id) === self::STATE_ALWAYS_ACTIVE;
+    }
 }

--- a/protected/humhub/modules/content/components/ContentContainerModuleManager.php
+++ b/protected/humhub/modules/content/components/ContentContainerModuleManager.php
@@ -84,7 +84,7 @@ class ContentContainerModuleManager extends \yii\base\Component
     public function isEnabled($id)
     {
         // Workaround for core post module
-        if($id === 'post') {
+        if ($id === 'post') {
             return true;
         }
 
@@ -157,12 +157,34 @@ class ContentContainerModuleManager extends \yii\base\Component
 
         foreach (Yii::$app->moduleManager->getModules() as $id => $module) {
             if ($module instanceof ContentContainerModule && Yii::$app->hasModule($module->id) &&
-                    $module->hasContentContainerType($this->contentContainer->className())) {
+                $module->hasContentContainerType($this->contentContainer->className())) {
                 $this->_available[$module->id] = $module;
             }
         }
 
         return $this->_available;
+    }
+
+    /**
+     * Returns a list of modules that can be installed by the ContentContainer.
+     * Unlike `getAvailable()` it does not contain any modules which cannot be disabled or enabled.
+     *
+     * @return ContentContainerModule[] a list of modules
+     * @since 1.7
+     */
+    public function getInstallable()
+    {
+
+        $availableModules = $this->getAvailable();
+        foreach ($availableModules as $moduleId => $module) {
+            if (($this->isEnabled($moduleId) && !$this->canDisable($moduleId)) ||
+                (!$this->isEnabled($moduleId) && !$this->canEnable($moduleId))
+            ) {
+                unset($availableModules[$moduleId]);
+            }
+        }
+        return $availableModules;
+
     }
 
     /**
@@ -177,8 +199,8 @@ class ContentContainerModuleManager extends \yii\base\Component
     /**
      * Returns an array of all module states.
      *
-     * @see Module
      * @return array a list of modules with the corresponding state
+     * @see Module
      */
     protected function getStates()
     {
@@ -227,16 +249,16 @@ class ContentContainerModuleManager extends \yii\base\Component
         if ($state === null) {
             return null;
         } else {
-            return (int) $state;
+            return (int)$state;
         }
     }
 
     /**
      * Returns an Module record instance for the given module id
      *
-     * @see Module
      * @param string $id the module id
      * @return ContentContainerModuleState
+     * @see Module
      */
     protected function getModuleStateRecord($id)
     {
@@ -270,7 +292,7 @@ class ContentContainerModuleManager extends \yii\base\Component
         $contentContainerClasses = [\humhub\modules\user\models\User::class, \humhub\modules\space\models\Space::class];
         foreach ($contentContainerClasses as $class) {
             $reflect = new ReflectionClass($class);
-            $defaultState = (int) $moduleSettings->get('moduleManager.defaultState.' . $reflect->getShortName());
+            $defaultState = (int)$moduleSettings->get('moduleManager.defaultState.' . $reflect->getShortName());
             if ($defaultState === ContentContainerModuleState::STATE_ENABLED || $defaultState === ContentContainerModuleState::STATE_FORCE_ENABLED) {
                 $query->orWhere(['contentcontainer.class' => $class]);
             }

--- a/protected/humhub/modules/content/components/behaviors/CompatModuleManager.php
+++ b/protected/humhub/modules/content/components/behaviors/CompatModuleManager.php
@@ -66,4 +66,9 @@ class CompatModuleManager extends Behavior
     {
         return $this->moduleManager->disable($moduleId);
     }
+
+    public function isModuleAlwaysActive($id)
+    {
+        return $this->moduleManager->isAlwaysActive($id);
+    }
 }

--- a/protected/humhub/modules/content/components/behaviors/CompatModuleManager.php
+++ b/protected/humhub/modules/content/components/behaviors/CompatModuleManager.php
@@ -66,9 +66,4 @@ class CompatModuleManager extends Behavior
     {
         return $this->moduleManager->disable($moduleId);
     }
-
-    public function isModuleAlwaysActive($id)
-    {
-        return $this->moduleManager->isAlwaysActive($id);
-    }
 }

--- a/protected/humhub/modules/space/controllers/CreateController.php
+++ b/protected/humhub/modules/space/controllers/CreateController.php
@@ -135,10 +135,11 @@ class CreateController extends Controller
      */
     public function actionModules($space_id)
     {
-        $space = Space::find()->where(['id' => $space_id])->one();
+        $space = Space::find()->where(['id' => (int)$space_id])->one();
 
-        $installableModules = ContentContainerModule::getInstallableModules($space);
-        if (count($installableModules) == 0) {
+        $installableModules = $space->moduleManager->getInstallable();
+
+        if (count($installableModules) === 0) {
             return $this->actionInvite($space);
         } else {
             return $this->renderAjax('modules', ['space' => $space, 'availableModules' => $installableModules]);

--- a/protected/humhub/modules/space/controllers/CreateController.php
+++ b/protected/humhub/modules/space/controllers/CreateController.php
@@ -11,6 +11,7 @@ namespace humhub\modules\space\controllers;
 use humhub\components\Controller;
 use humhub\components\behaviors\AccessControl;
 use humhub\models\Setting;
+use humhub\modules\content\components\ContentContainerModule;
 use humhub\modules\content\components\ContentContainerModuleManager;
 use humhub\modules\space\models\Space;
 use humhub\modules\space\permissions\CreatePrivateSpace;
@@ -136,21 +137,11 @@ class CreateController extends Controller
     {
         $space = Space::find()->where(['id' => $space_id])->one();
 
-        //search through all modules to find module not set as default
-        $availableModules = $space->getAvailableModules();
-        foreach ($availableModules as $moduleId => $module) {
-            if (($space->isModuleEnabled($moduleId) && !$space->canDisableModule($moduleId)) ||
-                (!$space->isModuleEnabled($moduleId) && !$space->canEnableModule($moduleId)) ||
-                ($space->isModuleAlwaysActive($moduleId))
-            ) {
-                unset($availableModules[$moduleId]);
-            }
-        }
-
-        if (count($availableModules) == 0 /*|| !$hasModuleNotSetAsDefault*/) {
+        $installableModules = ContentContainerModule::getInstallableModules($space);
+        if (count($installableModules) == 0) {
             return $this->actionInvite($space);
         } else {
-            return $this->renderAjax('modules', ['space' => $space, 'availableModules' => $availableModules]);
+            return $this->renderAjax('modules', ['space' => $space, 'availableModules' => $installableModules]);
         }
     }
 

--- a/protected/humhub/modules/space/views/create/modules.php
+++ b/protected/humhub/modules/space/views/create/modules.php
@@ -21,13 +21,7 @@ SpaceAsset::register($this);
 
             <div class="row">
 
-                <?php foreach ($availableModules as $moduleId => $module) :
-
-                    if (($space->isModuleEnabled($moduleId) && !$space->canDisableModule($moduleId)) ||
-                        (!$space->isModuleEnabled($moduleId) && !$space->canEnableModule($moduleId))) {
-                        continue;
-                    }
-                    ?>
+                <?php foreach ($availableModules as $moduleId => $module) :?>
                     <div class="col-md-6">
                         <div class="media well well-small ">
                             <img class="media-object img-rounded pull-left" data-src="holder.js/64x64" alt="64x64"

--- a/protected/humhub/modules/space/views/create/modules.php
+++ b/protected/humhub/modules/space/views/create/modules.php
@@ -4,6 +4,8 @@ use humhub\modules\space\assets\SpaceAsset;
 use humhub\libs\Helpers;
 use yii\helpers\Url;
 
+/* @var $availableModules array available modules for space*/
+
 SpaceAsset::register($this);
 
 ?>


### PR DESCRIPTION
…oller.php

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included
- [ ] Changelog was modified

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
This issue happened then all modules **set as default** and the system try to show a list of modules **to choose what to enable**, but the list is **empty** and it shows up an empty modal window.
The window is empty because in the view system check every module for **canEnableModule()**, but we can not enable the module which set as default.

To resolve the issue I added a check for modules not set as default. If all modules set as default we did not show up the list of modules to enable and proceed to invite users window.