### PR TITLE
Fix: Allowing guest like permission

### DIFF
--- a/CHANGELOG_DEV.md
+++ b/CHANGELOG_DEV.md
@@ -6,6 +6,7 @@ HumHub Changelog
 - Fix #4504: Fix `hasSidebar()` for empty sidebar
 - Fix #4526: `HeaderControlsMenu::init` called twice
 - Fix #4529: Aligned default dropdown text size
+- Fix: Allowing guest like permission
 
 1.7.0-beta.1 (October 16, 2020)
 -------------------------------

--- a/protected/humhub/modules/like/permissions/CanLike.php
+++ b/protected/humhub/modules/like/permissions/CanLike.php
@@ -36,6 +36,7 @@ class CanLike extends \humhub\libs\BasePermission
      */
     protected $fixedGroups = [
         Space::USERGROUP_GUEST,
+        User::USERGROUP_GUEST,
     ];
 
     /**


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included
- [x] Changelog was modified

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Shouldn't allow users to select `Not registered users` for likes as guests aren't allowed to like posts by default so this would confuse the user as well as contradict the CanLike permission. (Introduced in #4339)

![Screenshot_1](https://user-images.githubusercontent.com/35392110/96368200-a7fe0400-1120-11eb-92f3-9f023d3e1649.png)
