### PR TITLE
Allow to change user passwords by admin

### DIFF
--- a/CHANGELOG_DEV.md
+++ b/CHANGELOG_DEV.md
@@ -4,7 +4,8 @@ HumHub Changelog
 
 1.7.0 (Unreleased)
 ------------------
-- Fix #4590: Page loader color contrast too low 
+- Fix #4590: Page loader color contrast too low
+- Enh #3414: Allow to change user passwords by admin
 
 
 1.7.0-beta.2 (October 26, 2020)

--- a/protected/humhub/modules/admin/controllers/UserController.php
+++ b/protected/humhub/modules/admin/controllers/UserController.php
@@ -111,7 +111,10 @@ class UserController extends Controller
         $profile = $user->profile;
 
         if ($canEditAdminFields) {
-            $password = PasswordEditForm::findOne(['user_id' => $user->id]);
+            if (!($password = PasswordEditForm::findOne(['user_id' => $user->id]))) {
+                $password = new PasswordEditForm();
+                $password->user_id = $user->id;
+            }
         }
 
         // Build Form Definition

--- a/protected/humhub/modules/admin/controllers/UserController.php
+++ b/protected/humhub/modules/admin/controllers/UserController.php
@@ -123,7 +123,7 @@ class UserController extends Controller
         // Add User Form
         $definition['elements']['User'] = [
             'type' => 'form',
-            'title' => 'Account',
+            'title' => Yii::t('AdminModule.user', 'Account'),
             'elements' => [
                 'username' => [
                     'type' => 'text',
@@ -164,7 +164,7 @@ class UserController extends Controller
         if ($canEditAdminFields) {
             $definition['elements']['Password'] = [
                 'type' => 'form',
-                'title' => 'Change Password',
+                'title' => Yii::t('AdminModule.user', 'Password'),
                 'elements' => [
                     'newPassword' => [
                         'type' => 'password',

--- a/protected/humhub/modules/admin/models/forms/PasswordEditForm.php
+++ b/protected/humhub/modules/admin/models/forms/PasswordEditForm.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace humhub\modules\admin\models\forms;
+
+use humhub\modules\user\models\Password;
+
+/**
+ * PasswordEditForm
+ * used to edit password of other users by admin
+ */
+class PasswordEditForm extends Password
+{
+    const SCENARIO_EDIT_ADMIN = 'editAdmin';
+
+    /**
+     * @inheritdoc
+     */
+    public function init()
+    {
+        parent::init();
+        $this->scenario = self::SCENARIO_EDIT_ADMIN;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function scenarios()
+    {
+        $scenarios = parent::scenarios();
+        $scenarios[self::SCENARIO_EDIT_ADMIN] = ['newPassword', 'newPasswordConfirm'];
+
+        return $scenarios;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function rules()
+    {
+        return array_merge( parent::rules(), [
+            ['newPassword', 'compare', 'compareAttribute' => 'newPasswordConfirm', 'on' => self::SCENARIO_EDIT_ADMIN],
+            ['newPasswordConfirm', 'compare', 'compareAttribute' => 'newPassword', 'on' => self::SCENARIO_EDIT_ADMIN],
+        ]);
+    }
+}


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Feature
- [x] Fix undefined `UserEditForm::newPassword` for users without record in DB table `user_password` - https://github.com/humhub/humhub/issues/3414#issuecomment-722924295

**Other information:**

Issue: https://github.com/humhub/humhub/issues/3414
