### PR TITLE
Fix: File preview not visible if initialized in background

### DIFF
--- a/CHANGELOG_DEV.md
+++ b/CHANGELOG_DEV.md
@@ -5,6 +5,7 @@ HumHub Changelog
 1.7.0 (Unreleased)
 ------------------
 - Fix #4590: Page loader color contrast too low 
+- Fix #4599: File preview not visible if initialized in background
 
 
 1.7.0-beta.2 (October 26, 2020)

--- a/protected/humhub/modules/file/resources/js/humhub.file.js
+++ b/protected/humhub/modules/file/resources/js/humhub.file.js
@@ -353,7 +353,8 @@ humhub.module('file', function (module, require, $) {
             that.add(file)
         });
 
-        if(!this.$.find('.file-preview-item:visible').length) {
+        // Note we are not using :visible since the preview itself may not visible on init
+        if(!this.$.find('.file-preview-item:not(.hiddenFile)').length) {
             this.$.hide();
         }
     };
@@ -406,6 +407,8 @@ humhub.module('file', function (module, require, $) {
 
         if(!(this.isMedia(file) && this.options.excludeMediaFilesPreview)) {
             $file.fadeIn();
+        } else {
+            $file.addClass('hiddenFile');
         }
     };
 

--- a/protected/humhub/modules/file/widgets/FilePreview.php
+++ b/protected/humhub/modules/file/widgets/FilePreview.php
@@ -94,7 +94,7 @@ class FilePreview extends JsWidget
             'prevent-popover' => $this->preventPopover,
             'popover-position' => $this->popoverPosition,
             'file-edit' => $this->edit,
-            'exclude-media-files-preview' => $this->excludeMediaFilesPreview
+            'exclude-media-files-preview' => (int) $this->excludeMediaFilesPreview
         ];
     }
 


### PR DESCRIPTION
File preview widget is not visible when rendered in the background e.g. a hidden tab. 
This issue was introduced in 1.7.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

**Does this PR introduce a breaking change?** (check one)

- [x] No