### PR TITLE
Fixes image crop modal overflow on mobile

### DIFF
--- a/protected/humhub/modules/content/views/container-image/cropModal.php
+++ b/protected/humhub/modules/content/views/container-image/cropModal.php
@@ -63,7 +63,7 @@ $model->cropSetSelect = Json::decode('['.$cropSelect.']');
                 }
             </style>
 
-            <div id="cropimage">
+            <div id="cropimage" style="overflow:hidden;">
                 <?= Html::img($profileImage->getUrl('_org'), ['id' => 'crop-profile-image']) ?>
 
                 <?= JCropWidget::widget([


### PR DESCRIPTION
Fixes image overflow in crop modal on mobile. The solution is not ideal since the image is just cut, but better than the current sate in which the image just overflows the modal. In order to implement a solution in which the image is not cut we probably need a more complex js based solution similar to https://stackoverflow.com/questions/13648162/using-jcrop-on-responsive-images.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

**Does this PR introduce a breaking change?** (check one)

- [x] No