### PR TITLE
Fix: Jplayer overflow on mobile stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ HumHub Changelog
 - Fix #4609: Error on downscale command
 - Fix #4621: Wrong image orientation on downscaling with imagick
 - Fix #4628: Fixed stream gallery ratio issues on fluid themes
+- Fix #4636: Jplayer overflow on mobile stream
 
 
 1.7.0 (November 4, 2020)

--- a/static/less/file.less
+++ b/static/less/file.less
@@ -213,7 +213,7 @@ ul.files {
     }
 
     .jp-audio {
-        width: 280px !important;
+        width: auto !important;
         margin-left: 0 !important;
     }
 
@@ -242,7 +242,7 @@ ul.files {
     .jp-audio .jp-toggles {
         left: 210px !important;
         top: 45px !important;
-        width: 199px !important;
+        width: auto !important;
     }
 
     .jp-playlist ul {

--- a/static/less/stream.less
+++ b/static/less/stream.less
@@ -63,7 +63,6 @@
 // Wall-Entries
 .wall-entry {
     position: relative;
-    overflow:hidden;
 
     .panel .panel-body {
         padding: @wallEntryInnerPadding;

--- a/static/less/stream.less
+++ b/static/less/stream.less
@@ -63,6 +63,7 @@
 // Wall-Entries
 .wall-entry {
     position: relative;
+    overflow:hidden;
 
     .panel .panel-body {
         padding: @wallEntryInnerPadding;


### PR DESCRIPTION
Fixes an issue in which the jplayer overflows the stream entry on mobile.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

**Does this PR introduce a breaking change?** (check one)

- [x] No