### PR TITLE
Separate notifications for comment replies #4316

### DIFF
--- a/CHANGELOG_DEV.md
+++ b/CHANGELOG_DEV.md
@@ -8,3 +8,4 @@ HumHub Changelog
 - Enh #4347: Add `hideMembersSidebar` to make members sidebar optional in space stream page
 - Enh #4585: Group notifications must be enabled explicitly
 - Fix #4646: Clean up duplicated array keys
+- Enh #4316: Separate notifications for comment replies

--- a/protected/humhub/modules/comment/tests/codeception/unit/CommentFollowersNotificationTest.php
+++ b/protected/humhub/modules/comment/tests/codeception/unit/CommentFollowersNotificationTest.php
@@ -30,7 +30,6 @@ class CommentFollowersNotificationTest extends HumHubDbTestCase
 
         //check up for sent emails at least one
         $this->assertMailSent(1, 'Comment Notification Mail sent');
-
     }
 
     public function testSubCommentReplyNotification()
@@ -64,7 +63,7 @@ class CommentFollowersNotificationTest extends HumHubDbTestCase
         $this->assertNotEmpty($comment->getCommentedRecord()->getFollowers(null, true, true), 'Followers for this comment not found');
 
         //check up parent object of current comment
-        /** @var Comment $parent*/
+        /** @var Comment $parent */
         $parent = $comment->getPolymorphicRelation();
 
         $this->assertNotEmpty($parent->created_by, 'Parent object created by user id is empty!');
@@ -74,6 +73,5 @@ class CommentFollowersNotificationTest extends HumHubDbTestCase
 
         //check up for sent emails at least one
         $this->assertMailSent(1, 'Comment Notification Mail sent');
-
     }
 }

--- a/protected/humhub/modules/comment/tests/codeception/unit/CommentFollowersNotificationTest.php
+++ b/protected/humhub/modules/comment/tests/codeception/unit/CommentFollowersNotificationTest.php
@@ -47,10 +47,8 @@ class CommentFollowersNotificationTest extends HumHubDbTestCase
          * author of the commented record
          */
         $followersShouldReceiveNotification = [
-            $comment->user, // author of the current comment
             $parentUser, // author of the parent comment
             $comment->getCommentedRecord()->owner, // author of the commented record
-            1, // id od admin  user in test db
         ];
 
         $this->assertNotEmpty($followersShouldReceiveNotification, 'Followers who should receive notification array is empty!');

--- a/protected/humhub/modules/comment/tests/codeception/unit/CommentFollowersNotificationTest.php
+++ b/protected/humhub/modules/comment/tests/codeception/unit/CommentFollowersNotificationTest.php
@@ -1,0 +1,58 @@
+<?php namespace comment;
+
+use Codeception\Specify;
+use humhub\modules\comment\models\Comment;
+use humhub\modules\post\models\Post;
+use humhub\modules\user\models\User;
+use tests\codeception\_support\HumHubDbTestCase;
+
+class CommentFollowersNotificationTest extends HumHubDbTestCase
+{
+    use Specify;
+
+    public function testCommentFollowersNotification()
+    {
+        //test comment on base content
+        $this->becomeUser('User2');
+
+        $comment = new Comment([
+            'message' => 'User2 comment!',
+            'object_model' => Post::class,
+            'object_id' => 11
+        ]);
+
+        $comment->save();
+
+        //check up followers
+        $this->assertNotEmpty($comment->content->getPolymorphicRelation()->getFollowers(null, true, true), 'Followers for this comment not found');
+
+        //check up the current comment author
+        $this->assertNotEmpty($comment->user, 'Current comment user is empty!');
+
+        //check up parent object of current comment
+        $parent = $comment->object_model::findOne(['id', $comment->object_id]);
+        $parentUser = User::findOne(['id' => $parent->created_by]);
+        $this->assertNotEmpty($parentUser, 'Parent object of current comment not found!');
+
+        //check up the user author of commented record
+        $this->assertNotEmpty($comment->getCommentedRecord()->owner, 'Author of the commented record of this comment not found!');
+
+        //check up for sent emails at least one
+        $this->assertMailSent(1, 'Comment Notification Mail sent');
+
+        /**
+         * Send notifications to only these followers:
+         * author of the current comment
+         * author of the parent comment
+         * author of the commented record
+         */
+        $followersShouldReceiveNotification = [
+            $comment->user, // author of the current comment
+            $parentUser, // author of the parent comment
+            $comment->getCommentedRecord()->owner, // author of the commented record
+            1, // id od admin  user in test db
+        ];
+
+        $this->assertNotEmpty($followersShouldReceiveNotification, 'Followers who should receive notification array is empty!');
+    }
+}

--- a/protected/humhub/modules/comment/tests/codeception/unit/CommentFollowersNotificationTest.php
+++ b/protected/humhub/modules/comment/tests/codeception/unit/CommentFollowersNotificationTest.php
@@ -42,7 +42,6 @@ class CommentFollowersNotificationTest extends HumHubDbTestCase
 
         /**
          * Send notifications to only these followers:
-         * author of the current comment
          * author of the parent comment
          * author of the commented record
          */

--- a/protected/humhub/modules/comment/tests/codeception/unit/CommentFollowersNotificationTest.php
+++ b/protected/humhub/modules/comment/tests/codeception/unit/CommentFollowersNotificationTest.php
@@ -1,16 +1,16 @@
 <?php namespace comment;
 
 use Codeception\Specify;
+use humhub\modules\comment\notifications\NewComment;
 use humhub\modules\comment\models\Comment;
 use humhub\modules\post\models\Post;
-use humhub\modules\user\models\User;
 use tests\codeception\_support\HumHubDbTestCase;
 
 class CommentFollowersNotificationTest extends HumHubDbTestCase
 {
     use Specify;
 
-    public function testCommentFollowersNotification()
+    public function testCommentNotification()
     {
         //test comment on base content
         $this->becomeUser('User2');
@@ -24,15 +24,50 @@ class CommentFollowersNotificationTest extends HumHubDbTestCase
         $comment->save();
 
         //check up followers
-        $this->assertNotEmpty($comment->content->getPolymorphicRelation()->getFollowers(null, true, true), 'Followers for this comment not found');
+        $this->assertNotEmpty($comment->getCommentedRecord()->getFollowers(null, true, true), 'Followers for this comment not found');
 
-        //check up the current comment author
-        $this->assertNotEmpty($comment->user, 'Current comment user is empty!');
+        $this->assertHasNotification(NewComment::class, $comment);
+
+        //check up for sent emails at least one
+        $this->assertMailSent(1, 'Comment Notification Mail sent');
+
+    }
+
+    public function testSubCommentReplyNotification()
+    {
+        //test comment on base content
+        $this->becomeUser('User2');
+
+        $comment = new Comment([
+            'message' => 'User2 comment!',
+            'object_model' => Post::class,
+            'object_id' => 11
+        ]);
+
+        $comment->save();
+        $commentId = $comment->id;
+
+        $this->assertHasNotification(NewComment::class, $comment);
+
+        //test comment on base content
+        $this->becomeUser('User2');
+
+        $comment = new Comment([
+            'message' => 'User3 comment!',
+            'object_model' => Comment::class,
+            'object_id' => $commentId
+        ]);
+
+        $comment->save();
+
+        //check up followers
+        $this->assertNotEmpty($comment->getCommentedRecord()->getFollowers(null, true, true), 'Followers for this comment not found');
 
         //check up parent object of current comment
-        $parent = $comment->object_model::findOne(['id', $comment->object_id]);
-        $parentUser = User::findOne(['id' => $parent->created_by]);
-        $this->assertNotEmpty($parentUser, 'Parent object of current comment not found!');
+        /** @var Comment $parent*/
+        $parent = $comment->getPolymorphicRelation();
+
+        $this->assertNotEmpty($parent->created_by, 'Parent object created by user id is empty!');
 
         //check up the user author of commented record
         $this->assertNotEmpty($comment->getCommentedRecord()->owner, 'Author of the commented record of this comment not found!');
@@ -40,16 +75,5 @@ class CommentFollowersNotificationTest extends HumHubDbTestCase
         //check up for sent emails at least one
         $this->assertMailSent(1, 'Comment Notification Mail sent');
 
-        /**
-         * Send notifications to only these followers:
-         * author of the parent comment
-         * author of the commented record
-         */
-        $followersShouldReceiveNotification = [
-            $parentUser, // author of the parent comment
-            $comment->getCommentedRecord()->owner, // author of the commented record
-        ];
-
-        $this->assertNotEmpty($followersShouldReceiveNotification, 'Followers who should receive notification array is empty!');
     }
 }

--- a/protected/humhub/tests/config/common.php
+++ b/protected/humhub/tests/config/common.php
@@ -4,8 +4,8 @@ return [
     'components' => [
         'db' => [
             'dsn' => 'mysql:host=localhost;dbname=humhub_test',
-            'username' => 'root',
-            'password' => '123',
+            'username' => 'travis',
+            'password' => '',
             'charset' => 'utf8',
             'attributes' => [
                 PDO::ATTR_PERSISTENT => true

--- a/protected/humhub/tests/config/common.php
+++ b/protected/humhub/tests/config/common.php
@@ -4,8 +4,8 @@ return [
     'components' => [
         'db' => [
             'dsn' => 'mysql:host=localhost;dbname=humhub_test',
-            'username' => 'travis',
-            'password' => '',
+            'username' => 'root',
+            'password' => '123',
             'charset' => 'utf8',
             'attributes' => [
                 PDO::ATTR_PERSISTENT => true


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x ] No

**Other information:**
Allow notifications to followers participated in current comment replay and parent object owner only
