### PR TITLE
Fixes richtext attachment of multiple files without title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ HumHub Changelog
 - Fix #4575: Increased text size of "Read more" link on short-text post 
 - Fix #4559: Don’t check platform php extensions by composer v2
 - Fix #4581: Users see content of archived spaces on dashboard
+- Fix #4666: Richtext attachment of multiple files without title fails
 
 
 1.7.0-beta.1 (October 16, 2020)

--- a/protected/humhub/modules/content/widgets/richtext/ProsemirrorRichText.php
+++ b/protected/humhub/modules/content/widgets/richtext/ProsemirrorRichText.php
@@ -295,7 +295,7 @@ class ProsemirrorRichText extends AbstractRichText
             $extension  = '[a-zA-Z]+';
         }
 
-        return '/(?<!\\\\)\[([^\]]*)\]\(('.$extension.'):{1}([^\)\s]*)(?:\s")?([^"]*)?(?:")?[^\)]*\)/is';
+        return '/(?<!\\\\)\[([^\]]*)\]\(('.$extension.'):{1}([^\)\s]*)(?:\s")?([^")]*)?(?:")?[^\)]*\)/is';
     }
 
     /**


### PR DESCRIPTION
This PR fixes an Issue in which multiple richtext files without title are not parsed correctly and therefore can not be attached to the model.

Related issue: https://github.com/humhub/humhub-modules-custom-pages/issues/155#issuecomment-734504073

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

**Does this PR introduce a breaking change?** (check one)

- [x] No