### PR TITLE
Fix: Richtext extension scan cuts title if title contains `)`

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -10,12 +10,12 @@ plugins:
             standard: phpcs.xml.dist
 exclude_patterns:
     - '**/messages/'
-    - config/
-    - **/node_modules/
-    - **/test/
-    - **/tests/
-    - **/vendor/
-    - **/*_test.go
-    - **/*.d.ts
-    - static/assets/
-    - assets/
+    - 'config/'
+    - '**/node_modules/'
+    - '**/test/'
+    - '**/tests/'
+    - '**/vendor/'
+    - '**/*_test.go'
+    - '**/*.d.ts'
+    - 'static/assets/'
+    - 'assets/'

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -10,5 +10,5 @@ plugins:
             standard: phpcs.xml.dist
 exclude_patterns:
     - '**/messages/'
-    - '**/codeception/_support/_generated/'
+    - '**/codeception/'
     - static/assets/

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -10,5 +10,12 @@ plugins:
             standard: phpcs.xml.dist
 exclude_patterns:
     - '**/messages/'
-    - '**/codeception/'
+    - config/
+    - **/node_modules/
+    - **/test/
+    - **/tests/
+    - **/vendor/
+    - **/*_test.go
+    - **/*.d.ts
     - static/assets/
+    - assets/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ HumHub Changelog
 1.7.2 (Unreleased)
 -------------------------
 - Fix #4668: table-responsive tables do not overflow due to default word break style
+- Fix #4679: Richtext extension scan does not include full title if title contains a `)`
 
 
 1.7.1 (November 27, 2020)
@@ -21,6 +22,7 @@ HumHub Changelog
 - Fix #4660: Topic stream filter leads to stream entry duplication in combination with stream suppression
 - Fix #4638: Profile settings do not accept birthdate in russian format
 - Fix #4596: Set `autocomplete="off"` on date picker fields
+- Fix #4666: Richtext attachment of multiple files without title fails
 
 
 1.7.0 (November 4, 2020)
@@ -48,7 +50,6 @@ HumHub Changelog
 - Fix #4575: Increased text size of "Read more" link on short-text post 
 - Fix #4559: Don’t check platform php extensions by composer v2
 - Fix #4581: Users see content of archived spaces on dashboard
-- Fix #4666: Richtext attachment of multiple files without title fails
 
 
 1.7.0-beta.1 (October 16, 2020)

--- a/protected/humhub/modules/content/tests/codeception/unit/RichtextExtensionTest.php
+++ b/protected/humhub/modules/content/tests/codeception/unit/RichtextExtensionTest.php
@@ -9,7 +9,7 @@ use tests\codeception\_support\HumHubDbTestCase;
 
 class RichtextExtensionTest extends HumHubDbTestCase
 {
-    public function testStripHtml()
+    public function testScanMultipleFileGuid()
     {
         $text = '[img3.jpg](http://humhub.com "img)3.jpg" xasdfjpös0as) 
 

--- a/protected/humhub/modules/content/tests/codeception/unit/RichtextExtensionTest.php
+++ b/protected/humhub/modules/content/tests/codeception/unit/RichtextExtensionTest.php
@@ -1,0 +1,54 @@
+<?php
+
+
+namespace humhub\modules\content\tests\codeception\unit;
+
+
+use humhub\modules\content\widgets\richtext\ProsemirrorRichText;
+use tests\codeception\_support\HumHubDbTestCase;
+
+class RichtextExtensionTest extends HumHubDbTestCase
+{
+    public function testStripHtml()
+    {
+        $text = '[img3.jpg](http://humhub.com "img)3.jpg" xasdfjpös0as) 
+
+[test2.txt](file-guid:aef0eb95-b715-4707-9792-180e4395e681)
+
+test
+![img3.jpg](file-guid:3f1e14a2-4375-434a-a554-a19ec5e48909 "img))))3.jpg")asdfas
+asdfasdfasdf
+
+[test2.txt](file-guid:aef0eb95-b715-4707-9792-180e4395e681 "test")
+
+asdfasdfasdf
+
+[test2.txt](file-guid:aef0eb95-b715-4707-9792-180e4395e681)';
+
+        $matches = ProsemirrorRichText::scanLinkExtension($text, 'file-guid');
+
+        static::assertCount(4, $matches);
+
+        static::assertEquals('[test2.txt](file-guid:aef0eb95-b715-4707-9792-180e4395e681)', $matches[0][0]);
+        static::assertEquals('test2.txt', $matches[0][1]);
+        static::assertEquals('file-guid', $matches[0][2]);
+        static::assertEquals('aef0eb95-b715-4707-9792-180e4395e681', $matches[0][3]);
+
+        static::assertEquals('[img3.jpg](file-guid:3f1e14a2-4375-434a-a554-a19ec5e48909 "img))))3.jpg")', $matches[1][0]);
+        static::assertEquals('img3.jpg', $matches[1][1]);
+        static::assertEquals('file-guid', $matches[1][2]);
+        static::assertEquals('3f1e14a2-4375-434a-a554-a19ec5e48909', $matches[1][3]);
+        static::assertEquals('img))))3.jpg', $matches[1][4]);
+
+        static::assertEquals('[test2.txt](file-guid:aef0eb95-b715-4707-9792-180e4395e681 "test")', $matches[2][0]);
+        static::assertEquals('test2.txt', $matches[2][1]);
+        static::assertEquals('file-guid', $matches[2][2]);
+        static::assertEquals('aef0eb95-b715-4707-9792-180e4395e681', $matches[2][3]);
+        static::assertEquals('test', $matches[2][4]);
+
+        static::assertEquals('[test2.txt](file-guid:aef0eb95-b715-4707-9792-180e4395e681)', $matches[3][0]);
+        static::assertEquals('test2.txt', $matches[3][1]);
+        static::assertEquals('file-guid', $matches[3][2]);
+        static::assertEquals('aef0eb95-b715-4707-9792-180e4395e681', $matches[3][3]);
+    }
+}

--- a/protected/humhub/modules/content/widgets/richtext/ProsemirrorRichText.php
+++ b/protected/humhub/modules/content/widgets/richtext/ProsemirrorRichText.php
@@ -292,10 +292,10 @@ class ProsemirrorRichText extends AbstractRichText
     protected static function getLinkExtensionPattern($extension = '[a-zA-Z]+')
     {
         if($extension === null) {
-            $extension  = '[a-zA-Z]+';
+            $extension  = '[a-zA-Z-_]+';
         }
 
-        return '/(?<!\\\\)\[([^\]]*)\]\(('.$extension.'):{1}([^\)\s]*)(?:\s")?([^")]*)?(?:")?[^\)]*\)/is';
+        return '/(?<!\\\\)\[([^\]]*)\]\(('.$extension.'):{1}([^\)\s]*)(?:\s)?(?:"([^"]*)")?[^\)]*\)/is';
     }
 
     /**


### PR DESCRIPTION
Fixes an issue in which the richtext extension regex does not fully scan the title in case the title contains a `)`.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

**Does this PR introduce a breaking change?** (check one)

- [x] No