### PR TITLE
Fix tests after new added user fixture “AdminNotMember”

### DIFF
--- a/protected/humhub/modules/admin/tests/codeception/functional/ApprovalCest.php
+++ b/protected/humhub/modules/admin/tests/codeception/functional/ApprovalCest.php
@@ -129,7 +129,7 @@ class ApprovalCest
         $I->see('Pending user approvals');
 
         $I->see('approvalTest@test.de');
-        $I->amOnRoute('/admin/approval/approve', ['id' => 8]);
+        $I->amOnRoute('/admin/approval/approve', ['id' => 9]);
 
         $I->see('Accept user: approval test');
         $I->click('Send & save');

--- a/protected/humhub/modules/content/tests/codeception/unit/ContentCreatedTest.php
+++ b/protected/humhub/modules/content/tests/codeception/unit/ContentCreatedTest.php
@@ -225,7 +225,7 @@ class ContentCreatedTest extends HumHubDbTestCase
         $post->save();
 
         // Note Admin is following Space2 so we expect one notification mail.
-        $this->assertMailSent(3, 'ContentCreated Notification Mail sent');
+        $this->assertMailSent(4, 'ContentCreated Notification Mail sent');
     }
     
     /**
@@ -249,7 +249,7 @@ class ContentCreatedTest extends HumHubDbTestCase
         $post->save();
 
         // Note Admin is following Space2 so we expect one notification mail.
-        $this->assertMailSent(2, 'ContentCreated Notification Mail sent');
+        $this->assertMailSent(3, 'ContentCreated Notification Mail sent');
     }
     
     /**
@@ -273,7 +273,7 @@ class ContentCreatedTest extends HumHubDbTestCase
         $post->save();
 
         // Note Admin is following Space2 so we expect one notification mail.
-        $this->assertMailSent(2, 'ContentCreated Notification Mail sent');
+        $this->assertMailSent(3, 'ContentCreated Notification Mail sent');
     }
     
     /**
@@ -305,6 +305,6 @@ class ContentCreatedTest extends HumHubDbTestCase
         $post->save();
 
         // Note Admin is following Space2 so we expect one notification mail.
-        $this->assertMailSent(1, 'ContentCreated Notification Mail sent');
+        $this->assertMailSent(2, 'ContentCreated Notification Mail sent');
     }
 }

--- a/protected/humhub/modules/user/tests/codeception/unit/models/UserFilterTest.php
+++ b/protected/humhub/modules/user/tests/codeception/unit/models/UserFilterTest.php
@@ -33,7 +33,7 @@ class UserFilterTest extends HumHubDbTestCase
     {
         $users = UserFilter::filter(User::find(), 'Admin', 5);
 
-        $this->assertEquals(1, count($users));
+        $this->assertEquals(2, count($users));
         $this->assertEquals('Admin', $users[0]->username);
     }
 

--- a/protected/humhub/modules/user/tests/codeception/unit/models/UserPickerTest.php
+++ b/protected/humhub/modules/user/tests/codeception/unit/models/UserPickerTest.php
@@ -16,11 +16,11 @@ class UserPickerTest extends HumHubDbTestCase
     public function testReturnFilteredUsers()
     {
         $users = UserPicker::filter(['maxResult' => 3, 'keyword' => 'Admin']);
-        $this->assertEquals(1, count($users));
+        $this->assertEquals(2, count($users));
         $this->assertEquals('Admin Tester', $users[0]['text']);
 
         $users = UserPicker::filter(['maxResult' => 3, 'keyword' => 'Admin', 'fillUser' => true]);
-        $this->assertEquals(1, count($users));
+        $this->assertEquals(2, count($users));
     }
 
 }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included
- [ ] Changelog was modified

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
New user fixture was added here https://github.com/humhub/humhub/pull/4693/commits/aeb12517e9c2747d9d5856d2aa42a588bbfc4027#diff-93a0674f91dd888bcb0f290b085e786d90c2dc8e1690ea33216408e5d27f46ccR29 for issue https://github.com/humhub/tasks/issues/48#issuecomment-752645923