### PR TITLE
Left menu with list of topic tags on space view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@ HumHub Changelog
 ================
 
 
-1.7.1 (Unreleased)
-------------------
+1.7.1 (November 27, 2020)
+-------------------------
 - Fix #4612: Dashboard wall stream entry displays user name in sub title in post style layout
 - Fix #4614: Profile Image crop broken
 - Fix #4607: Changed grid size of image preview on fluid themes
@@ -17,6 +17,7 @@ HumHub Changelog
 - Fix #4660: Topic stream filter leads to stream entry duplication in combination with stream suppression
 - Fix #4638: Profile settings do not accept birthdate in russian format
 - Fix #4596: Set `autocomplete="off"` on date picker fields
+
 
 1.7.0 (November 4, 2020)
 ------------------------

--- a/protected/humhub/modules/space/widgets/TopicList.php
+++ b/protected/humhub/modules/space/widgets/TopicList.php
@@ -42,7 +42,7 @@ class TopicList extends LeftNavigation
         }
 
 
-        $this->panelTitle = "étiquettes";
+        $this->panelTitle = "<b>" . Yii::t('TopicModule.base', 'Topics') . "</b>";
         $topics = Topic::findByContainer($this->space)->all();
 
         foreach ($topics as $topic) {
@@ -50,7 +50,7 @@ class TopicList extends LeftNavigation
             $this->addEntry(new MenuLink([
                 'label' => $topic->name,
                 'url' => $topic->getUrl(),
-              //  'icon' => 'fa-bars',
+                'icon' => 'fa-tag',
                 'sortOrder' => $topic->sort_order,
             ]));
          }


### PR DESCRIPTION
I have added a left menu with list of topic tags for my instance.
Here is what it looks like (in french here, but the menu label is internationalized)

![image](https://user-images.githubusercontent.com/1201600/105234768-f251af80-5b6b-11eb-848e-4fca1f9856ec.png)

I leave it there if you want to integrate it.
Thanks for your work BTW !