### PR TITLE
WIP: Restore stream state

### DIFF
--- a/protected/humhub/modules/stream/resources/js/humhub.stream.Stream.js
+++ b/protected/humhub/modules/stream/resources/js/humhub.stream.Stream.js
@@ -23,6 +23,7 @@ humhub.module('stream.Stream', function (module, require, $) {
     var StreamRequest =  require('stream').StreamRequest;
     var loader = require('ui.loader');
     var event = require('event');
+    var view = require('ui.view');
 
     var EVENT_AFTER_ADD_ENTRIES = 'humhub:stream:afterAddEntries';
     var EVENT_BEFORE_ADD_ENTRIES = 'humhub:stream:beforeAddEntries';
@@ -550,6 +551,8 @@ humhub.module('stream.Stream', function (module, require, $) {
         var hasEntries = this.hasEntries();
 
         this.$.find('.streamMessage').remove();
+
+        view.snapShot({instance: this});
 
         if(!hasEntries && this.isShowSingleEntry()) {
             // we only show an error if we load a single entry we are not allowed to view, otherwise just reload the stream

--- a/static/js/humhub/humhub.client.js
+++ b/static/js/humhub/humhub.client.js
@@ -338,7 +338,7 @@ humhub.module('client', function (module, require, $) {
         redirect(url);
     };
 
-    var redirect = function(url) {
+    var redirect = function(url, options) {
         if(!url) {
             return;
         }
@@ -347,11 +347,10 @@ humhub.module('client', function (module, require, $) {
 
         if (object.isString(url)) {
             if(module.pjax && module.pjax.config.active) {
-                module.pjax.redirect(url);
+                module.pjax.redirect(url, options);
             } else {
                 document.location = url;
             }
-            return;
         }
     };
 

--- a/static/js/humhub/humhub.client.pjax.js
+++ b/static/js/humhub/humhub.client.pjax.js
@@ -19,8 +19,12 @@ humhub.module('client.pjax', function (module, require, $) {
         $.pjax($options);
     };
 
-    var redirect = function(url) {
-        $.pjax({url: url, container: PJAX_CONTAINER_SELECTOR, timeout : module.config.options.timeout});
+    var redirect = function(url, options) {
+        options = options || {};
+        options.url = url;
+        options.container = PJAX_CONTAINER_SELECTOR;
+        options.timeout = module.config.options.timeout;
+        $.pjax(options);
     };
 
     var reload = function() {

--- a/static/js/jquery.pjax.modified.js
+++ b/static/js/jquery.pjax.modified.js
@@ -922,7 +922,7 @@
             maxCacheLength: 20,
             version: findVersion
         }
-        $(window).on('popstate.pjax', onPjaxPopstate)
+       // $(window).on('popstate.pjax', onPjaxPopstate)
     }
 
 // Disable pushState behavior.


### PR DESCRIPTION
This PR introduces a way of caching and restoring views by means of the browser history API.

The main aim of this PR is to properly restore a Stream when clicking back/forward. Currently when reentering a stream by browser back button, the whole stream is reloaded, and the scroll position as well as stream progress/state is lost.

Pjax provides a way of caching and restoring the result of a pjax request. The problem with the native pjax caching is, that it just caches the server response and not the current state of the view when leaving a page. E.g. we want to restore the stream when leaving the dashboard, but the stream is loaded asynchronously and pjax just caches the empty stream. In HumHub we've disabled the pjax caching mechanism since most page content is updated frequently and caching may lead to outdated views.

This PR replaces the default `window.onpopstate` of pjax responsible for caching and implements a custom handler. In this case views need to make sure to enable caching manually by calling `view.snapShot()`, this will replace or push the current view state to the browser history.

Open Issues:

 - [ ] Imitate pjax calls (pjax events) and module init, unload
 - [ ] Navigation management (restore navigation state)
 - [ ] Script handling

Other possible solutions

Maybe we could stick with the native pjax caching (but still require views to explicitely allow it) and implement a custom caching and restoring within the stream module itself. This could be less complex in terms of managing the view state and handling scripts/events.

**What kind of change does this PR introduce?** (check at least one)

- [x] Feature

**Does this PR introduce a breaking change?** (check one)

- [x] No