### PR TITLE
Implemented admin-permission to add users to spaces directly

### DIFF
--- a/protected/humhub/modules/space/Module.php
+++ b/protected/humhub/modules/space/Module.php
@@ -42,10 +42,10 @@ class Module extends \humhub\components\Module
      */
     public $disableFollow = false;
 
-	/**
-	 * @var boolean defines if a space members can add anyone the the space without invitation
-	 * @since 1.8
-	 */
+    /**
+     * @var boolean defines if a space members can add anyone the the space without invitation
+     * @since 1.8
+     */
     public $membersCanAddWithoutInvite = false;
 
     /**

--- a/protected/humhub/modules/space/Module.php
+++ b/protected/humhub/modules/space/Module.php
@@ -42,6 +42,12 @@ class Module extends \humhub\components\Module
      */
     public $disableFollow = false;
 
+	/**
+	 * @var boolean defines if a space members can add anyone the the space without invitation
+	 * @since 1.8
+	 */
+	public $membersCanAddWithoutInvite = false;
+
     /**
      * @var int maximum space url length
      * @since 1.3

--- a/protected/humhub/modules/space/Module.php
+++ b/protected/humhub/modules/space/Module.php
@@ -46,7 +46,7 @@ class Module extends \humhub\components\Module
 	 * @var boolean defines if a space members can add anyone the the space without invitation
 	 * @since 1.8
 	 */
-	public $membersCanAddWithoutInvite = false;
+    public $membersCanAddWithoutInvite = false;
 
     /**
      * @var int maximum space url length

--- a/protected/humhub/modules/space/models/forms/InviteForm.php
+++ b/protected/humhub/modules/space/models/forms/InviteForm.php
@@ -112,32 +112,31 @@ class InviteForm extends Model
     }
 
     /**
-     * @return bool checks if
+     * @return bool checks if user is allowed to add without invite
      */
-    public function isQueuedJob()
-    {
-		// Pre-check if adding without invite / adding all members was requested
-		if (!($this->withoutInvite || $this->allRegisteredUsers)) {
-			return false;
-		}
+    public function isQueuedJob() {
+        // Pre-check if adding without invite / adding all members was requested
+        if (!($this->withoutInvite || $this->allRegisteredUsers)) {
+            return false;
+        }
 
-		// If user has permission to manage users, this action is allowed
-		if (Yii::$app->user->can(ManageUsers::class)) {
-			return true;
-		}
+        // If user has permission to manage users, this action is allowed
+        if (Yii::$app->user->can(ManageUsers::class)) {
+            return true;
+        }
 
-		// Allow users to perform this action if this is allowed by config file
-		// Pre-check if user is member of the space in question
-		if (Yii::$app->getModule('space')->membersCanAddWithoutInvite === true) {
-			$membership = Membership::findOne([
-				'space_id' => $this->space->id,
-				'user_id' => Yii::$app->user->identity->id,
-			]);
+        // Allow users to perform this action if this is allowed by config file
+        // Pre-check if user is member of the space in question
+        if (Yii::$app->getModule('space')->membersCanAddWithoutInvite === true) {
+            $membership = Membership::findOne([
+                'space_id' => $this->space->id,
+                'user_id' => Yii::$app->user->identity->id,
+            ]);
 
-			if ($membership && $membership->status == Membership::STATUS_MEMBER) {
-				return true;
-			}
-		}
+            if ($membership && $membership->status == Membership::STATUS_MEMBER) {
+                return true;
+            }
+        }
 
         return false;
     }
@@ -213,9 +212,9 @@ class InviteForm extends Model
                 }
 
                 $membership = Membership::findOne([
-					'space_id' => $this->space->id,
-					'user_id' => $user->id,
-				]);
+                    'space_id' => $this->space->id,
+                    'user_id' => $user->id,
+                ]);
 
                 if ($membership && $membership->status == Membership::STATUS_MEMBER) {
                     $this->addError(

--- a/protected/humhub/modules/space/models/forms/InviteForm.php
+++ b/protected/humhub/modules/space/models/forms/InviteForm.php
@@ -114,7 +114,8 @@ class InviteForm extends Model
     /**
      * @return bool checks if user is allowed to add without invite
      */
-    public function isQueuedJob() {
+    public function isQueuedJob()
+    {
         // Pre-check if adding without invite / adding all members was requested
         if (!($this->withoutInvite || $this->allRegisteredUsers)) {
             return false;
@@ -141,7 +142,8 @@ class InviteForm extends Model
         return false;
     }
 
-    public function forceInvite() {
+    public function forceInvite()
+    {
         Yii::$app->queue->push(new AddUsersToSpaceJob([
             'originatorId' => Yii::$app->user->identity->id,
             'forceMembership' => $this->withoutInvite,
@@ -156,7 +158,8 @@ class InviteForm extends Model
      *
      * @throws \yii\base\Exception
      */
-    public function inviteMembers() {
+    public function inviteMembers()
+    {
         foreach ($this->getInvites() as $user) {
             $this->space->inviteMember($user->id, Yii::$app->user->id);
         }

--- a/protected/humhub/modules/space/widgets/InviteModal.php
+++ b/protected/humhub/modules/space/widgets/InviteModal.php
@@ -37,7 +37,7 @@ class InviteModal extends Widget
             'model' => $this->model,
             'attribute' => $this->attribute,
             'searchUrl' => $this->searchUrl,
-            'canManageMembers' => Yii::$app->user->can(ManageUsers::class),
+            'canAddWithoutInvite' => Yii::$app->user->can(ManageUsers::class) || Yii::$app->getModule('space')->membersCanAddWithoutInvite === true,
         ]);
     }
 }

--- a/protected/humhub/modules/space/widgets/views/inviteModal.php
+++ b/protected/humhub/modules/space/widgets/views/inviteModal.php
@@ -1,7 +1,7 @@
 <?php
 /* @var $this \humhub\modules\ui\view\components\View */
 /* @var $canInviteExternal bool */
-/* @var $canManageMembers bool */
+/* @var $canAddWithoutInvite bool */
 /* @var $submitText string */
 /* @var $submitAction string */
 /* @var $model \humhub\modules\space\models\forms\InviteForm */
@@ -70,7 +70,7 @@ $form = ActiveForm::begin([
             ]);
             ?>
 
-            <?php if ($canManageMembers) : ?>
+            <?php if ($canAddWithoutInvite) : ?>
                 <br />
                 <?= $form
                     ->field($model, 'withoutInvite')


### PR DESCRIPTION
It would be great to **allow users to add other users to space without an invitation**, but giving them the "ManageUsers" admin permission (where it is part of at the moment) is a huge deal. This would allow them to also edit and delete users, for example. I therefore **added a specific permission "Add Users to Spaces" as a sub-permission to it for just that purpose**. If you have "Manage Users" as permission, this will not introduce any changes. If you don't have "Manage Users" permission, this will neither introduce any changes, since the default for "Add Users to Spaces" is _deny_. So there is no harm done by giving the admin more freedom.

---

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [x] Feature
- [x] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included
- [ ] Changelog was modified

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature

