### PR TITLE
Fix #4838: ProsemirrorRichText::replaceLinkExtension() not compatible…

### DIFF
--- a/CHANGELOG_DEV.md
+++ b/CHANGELOG_DEV.md
@@ -8,6 +8,7 @@
 - Fix #4850: New AuthClient method onSuccessLogin() not available on standard OAuths 
 - Fix #4856: Allow to invite users to space with pending membership application
 - Fix #4869: Fix cached comment content in email notification
+- Fix #4838: ProsemirrorRichText::replaceLinkExtension() not compatible with HumHub < 1.8
 
 
 1.8.0-beta.1 (February 4, 2021)

--- a/CHANGELOG_DEV.md
+++ b/CHANGELOG_DEV.md
@@ -9,6 +9,7 @@
 - Fix #4856: Allow to invite users to space with pending membership application
 - Fix #4869: Fix cached comment content in email notification
 - Fix #4838: ProsemirrorRichText::replaceLinkExtension() not compatible with HumHub < 1.8
+- Fix #4847: RichText::postProcess(null) throws error
 
 
 1.8.0-beta.1 (February 4, 2021)

--- a/protected/humhub/modules/content/tests/codeception/unit/widgets/RichTextLinkExtensionLegacyTest.php
+++ b/protected/humhub/modules/content/tests/codeception/unit/widgets/RichTextLinkExtensionLegacyTest.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * @link https://www.humhub.org/
+ * @copyright Copyright (c) 2017 HumHub GmbH & Co. KG
+ * @license https://www.humhub.com/licences
+ *
+ */
+
+namespace tests\codeception\unit\modules\content\widgets;
+
+use humhub\models\UrlOembed;
+use humhub\modules\content\widgets\richtext\ProsemirrorRichText;
+use humhub\modules\content\widgets\richtext\RichText;
+use humhub\modules\file\models\File;
+use humhub\modules\post\models\Post;
+use humhub\modules\user\models\User;
+use tests\codeception\_support\HumHubDbTestCase;
+
+
+class RichTextLinkExtensionLegacyTest extends HumHubDbTestCase
+{
+
+    /**
+     * @throws \yii\base\InvalidConfigException
+     */
+    public function testScanLinkExtension()
+    {
+        $match = ProsemirrorRichText::scanLinkExtension('[Text](test:id "title")', 'test');
+
+        static::assertEquals('[Text](test:id "title")', $match[0][0]);
+        static::assertEquals('Text', $match[0][1]);
+        static::assertEquals('test', $match[0][2]);
+        static::assertEquals('id', $match[0][3]);
+        static::assertEquals('title', $match[0][4]);
+    }
+
+    /**
+     * @throws \yii\base\InvalidConfigException
+     */
+    public function testReplaceLinkExtension()
+    {
+        $resultMatch = [];
+
+        $result = ProsemirrorRichText::replaceLinkExtension('[Text](test:id "title")', 'test', function($match) use (&$resultMatch) {
+            $resultMatch = $match;
+            return 'tested';
+        });
+
+        static::assertEquals('tested', $result);
+        static::assertEquals('[Text](test:id "title")', $resultMatch[0]);
+        static::assertEquals('Text', $resultMatch[1]);
+        static::assertEquals('test', $resultMatch[2]);
+        static::assertEquals('id', $resultMatch[3]);
+        static::assertEquals('title', $resultMatch[4]);
+    }
+}

--- a/protected/humhub/modules/content/widgets/richtext/AbstractRichText.php
+++ b/protected/humhub/modules/content/widgets/richtext/AbstractRichText.php
@@ -225,6 +225,11 @@ abstract class AbstractRichText extends JsWidget
         $result = [];
         $original = $text;
 
+        if(empty($text)) {
+            $result['text'] = $text;
+            return $result;
+        }
+
         foreach (static::getExtensions() as $extension) {
             $text = $extension->onPostProcess($text, $record, $attribute, $result);
         }

--- a/protected/humhub/modules/content/widgets/richtext/ProsemirrorRichText.php
+++ b/protected/humhub/modules/content/widgets/richtext/ProsemirrorRichText.php
@@ -13,6 +13,7 @@ use humhub\libs\Helpers;
 use humhub\libs\ParameterEvent;
 use humhub\modules\content\widgets\richtext\extensions\emoji\RichTextEmojiExtension;
 use humhub\modules\content\widgets\richtext\extensions\file\FileExtension;
+use humhub\modules\content\widgets\richtext\extensions\link\RichTextLinkExtensionMatch;
 use humhub\modules\content\widgets\richtext\extensions\mentioning\MentioningExtension;
 use humhub\modules\content\widgets\richtext\extensions\oembed\OembedExtension;
 use humhub\modules\content\widgets\richtext\extensions\RichTextCompatibilityExtension;
@@ -220,12 +221,13 @@ class ProsemirrorRichText extends AbstractRichText
      *
      * @param $text string rich text content to parse
      * @param $extension string|null extension string if not given all extension types will be included
-     * @param callable $callback
      * @return mixed
      * @deprecated since 1.8 use `ProsemirrorRichTextConverter::replaceLinkExtension()`
      */
     public static function replaceLinkExtension(string $text, $extension, callable $callback)
     {
-        return RichTextLinkExtension::replaceLinkExtension($text, $extension, $callback);
+        return RichTextLinkExtension::replaceLinkExtension($text, $extension, function (RichTextLinkExtensionMatch $match) use ($callback) {
+            return $callback($match->match);
+        });
     }
 }

--- a/protected/humhub/modules/content/widgets/richtext/extensions/link/LinkParserBlock.php
+++ b/protected/humhub/modules/content/widgets/richtext/extensions/link/LinkParserBlock.php
@@ -7,6 +7,9 @@ namespace humhub\modules\content\widgets\richtext\extensions\link;
 use yii\base\Model;
 use yii\helpers\Url;
 
+/**
+ * <orig> = [<text>](<url> "<title>")
+ */
 class LinkParserBlock extends Model
 {
     const BLOCK_KEY_URL = 'url';

--- a/protected/humhub/modules/content/widgets/richtext/extensions/mentioning/MentioningExtension.php
+++ b/protected/humhub/modules/content/widgets/richtext/extensions/mentioning/MentioningExtension.php
@@ -118,9 +118,4 @@ class MentioningExtension extends RichTextLinkExtension
 
         return $text;
     }
-
-    public function onBeforeConvert(string $text, string $format, array $options = []): string
-    {
-        return $text;
-    }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

**Does this PR introduce a breaking change?** (check one)

- [x] No

**Other information:**

- Fixes https://github.com/humhub/humhub/issues/4838
- Fixes https://github.com/humhub/humhub/issues/4847
