### PR TITLE
Fix issue when using deprecated richtext maxLength

### DIFF
--- a/CHANGELOG_DEV.md
+++ b/CHANGELOG_DEV.md
@@ -1,3 +1,9 @@
+1.8.0 (Unreleased)
+--------------------------------
+
+- Fix #4893: Richtext extension events are ignored when using deprecated maxLength option
+
+
 1.8.0-beta.2 (February 18, 2021)
 --------------------------------
 

--- a/protected/humhub/modules/content/widgets/richtext/ProsemirrorRichText.php
+++ b/protected/humhub/modules/content/widgets/richtext/ProsemirrorRichText.php
@@ -168,7 +168,7 @@ class ProsemirrorRichText extends AbstractRichText
 
         // Can be removed in a future version, richtext should not be cut anymore, only text or shorttext version should be cut
         if ($this->maxLength > 0) {
-            $output = Helpers::truncateText($this->text, $this->maxLength);
+            $output = Helpers::truncateText($output, $this->maxLength);
         }
 
         // Wrap encoded output in root div


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

**Does this PR introduce a breaking change?** (check one)

- [x] No

**Other information:**

Fixes an issue in which richtext extension events are ignored when using the deprecated `maxLength` option of the richtext.

Fixes https://github.com/humhub/humhub-modules-wiki/issues/160


