### PR TITLE
Auto logout user on maintenance mode

### DIFF
--- a/CHANGELOG_DEV.md
+++ b/CHANGELOG_DEV.md
@@ -4,6 +4,7 @@
 - Fix #4893: Richtext extension events are ignored when using deprecated maxLength option
 - Fix #4896: Error thrown if live poll broadcast focus event is triggered
 - Fix #4907: Positions of Comment / Like links under posts
+- Fix: Auto logout user on maintenance mode
 
 
 1.8.0-beta.2 (February 18, 2021)

--- a/protected/humhub/components/access/ControllerAccess.php
+++ b/protected/humhub/components/access/ControllerAccess.php
@@ -522,13 +522,16 @@ class ControllerAccess extends BaseObject
     }
 
     /**
+     * @param string $beforeCustomInfo
      * @return string returns the maintenance mode warning text
      * @since 1.8
      */
-    public static function getMaintenanceModeWarningText()
+    public static function getMaintenanceModeWarningText($beforeCustomInfo = ' ')
     {
+        $customInfo = Yii::$app->settings->get('maintenanceModeInfo', '');
+
         return Yii::t('error', 'Maintenance mode is active. Only Administrators can access the platform.') .
-            ' ' . Yii::$app->settings->get('maintenanceModeInfo', '');
+            ($customInfo === '' ? '' : $beforeCustomInfo . $customInfo);
     }
 
 }

--- a/protected/humhub/components/access/ControllerAccess.php
+++ b/protected/humhub/components/access/ControllerAccess.php
@@ -156,7 +156,7 @@ class ControllerAccess extends BaseObject
     /**
      * Maintenance mode is active
      */
-    const RULE_MAINTENANCE_MODE= 'maintenance';
+    const RULE_MAINTENANCE_MODE = 'maintenance';
 
     /**
      * Check guest if request method is post
@@ -175,6 +175,7 @@ class ControllerAccess extends BaseObject
         [self::RULE_DISABLED_USER],
         [self::RULE_UNAPPROVED_USER],
         [self::RULE_MUST_CHANGE_PASSWORD],
+        [self::RULE_MAINTENANCE_MODE],
     ];
 
     /**
@@ -517,7 +518,7 @@ class ControllerAccess extends BaseObject
      */
     public function validateMaintenanceMode()
     {
-        return !Yii::$app->settings->get('maintenanceMode') || $this->isAdmin();
+        return !Yii::$app->settings->get('maintenanceMode') || $this->isAdmin() || $this->isGuest();
     }
 
     /**

--- a/protected/humhub/modules/admin/widgets/views/maintenanceModeWarning.php
+++ b/protected/humhub/modules/admin/widgets/views/maintenanceModeWarning.php
@@ -15,7 +15,7 @@ use yii\helpers\Url;
 <div class="panel panel-danger panel-invalid">
     <div class="panel-heading"><?= Yii::t('AdminModule.base', '<strong>Maintenance</strong> Mode'); ?></div>
     <div class="panel-body">
-        <p><?= ControllerAccess::getMaintenanceModeWarningText() ?></p>
+        <p><?= ControllerAccess::getMaintenanceModeWarningText('<br>') ?></p>
         <br>
         <?php if (Yii::$app->user->isAdmin()): ?>
             <?= Html::a(Yii::t('AdminModule.base', 'Settings'), Url::toRoute(['/admin/setting']), ['class' => 'btn btn-danger']); ?>


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included
- [x] Changelog was modified

**Other information:**
Issue: https://community.humhub.com/s/announcements/?contentId=236860# comment started with "On the user side there are some issues too. (The user default idle time is set to 600 in this instance.) ...", point:

> 1. A permanent logged in user is still logged in after opening the site, which is already in maintenance mode.
> (To be clear, this browser was closed as the m mode was set and browser and site was opend afterwards.)

+ Issue: https://github.com/humhub/humhub/issues/4910
