### PR TITLE
Fix #4918: Comment richtext gets focused when closing comment section

### DIFF
--- a/CHANGELOG_DEV.md
+++ b/CHANGELOG_DEV.md
@@ -6,6 +6,7 @@
 - Fix #4907: Positions of Comment / Like links under posts
 - Fix #4911: Auto logout user on maintenance mode
 - Fix #4912: Restrict guest access on maintenance mode
+- Fix #4918: Comment richtext gets focused when closing comment section
 
 
 1.8.0-beta.2 (February 18, 2021)

--- a/protected/humhub/modules/comment/resources/js/humhub.comment.js
+++ b/protected/humhub/modules/comment/resources/js/humhub.comment.js
@@ -274,7 +274,9 @@ humhub.module('comment', function (module, require, $) {
             target.slideToggle();
         }
 
-        target.find('.humhub-ui-richtext').trigger('focus');
+        if(!visible) {
+            target.find('.humhub-ui-richtext').trigger('focus');
+        }
     }
 
     var toggleCommentHandler = function (evt) {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

**Does this PR introduce a breaking change?** (check one)

- [x] No

**Other information:**

- Fixes https://github.com/humhub/humhub/issues/4918
