### PR TITLE
Fix file hash column length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ HumHub Changelog
 - Fix #4942: MemberOf Display in LDAP CLI Show User Details
 - Fix #4465: LDAP PHP 8 incompatibility (multiPageSearch)
 - Fix #4946: Fix migration of the default permissions
+- Fix: Fix file hash column length
 
 
 1.8.0 (March 1, 2021)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ HumHub Changelog
 - Fix #4942: MemberOf Display in LDAP CLI Show User Details
 - Fix #4465: LDAP PHP 8 incompatibility (multiPageSearch)
 - Fix #4946: Fix migration of the default permissions
-- Fix: Fix file hash column length
+- Fix #4956: Fix file hash column length
 
 
 1.8.0 (March 1, 2021)

--- a/protected/humhub/modules/file/migrations/m210310_103412_fix_hash.php
+++ b/protected/humhub/modules/file/migrations/m210310_103412_fix_hash.php
@@ -1,0 +1,28 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Class m210310_103412_fix_hash
+ */
+class m210310_103412_fix_hash extends Migration
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function safeUp()
+    {
+        $this->update('file', ['hash_sha1' => NULL]);
+        $this->alterColumn('file', 'hash_sha1', $this->string(40)->null());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function safeDown()
+    {
+        echo "m210310_103412_fix_hash cannot be reverted.\n";
+
+        return false;
+    }
+}


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included
- [x] Changelog was modified

**Other information:**
Fix size of the column `file.hash_sha1` because php function `sha1_file()` returns 40 chars string.
