### PR TITLE
Fix comment in the logic checking if a user can join for free a space

### DIFF
--- a/protected/humhub/modules/space/models/Space.php
+++ b/protected/humhub/modules/space/models/Space.php
@@ -385,7 +385,7 @@ class Space extends ContentContainerActiveRecord implements Searchable
             return false;
         }
 
-        // No one can join
+        // Anyone can join
         if ($this->join_policy == self::JOIN_POLICY_FREE) {
             return true;
         }


### PR DESCRIPTION
If the join policy for a space is equal to JOIN_POLICY_FREE then anyone can join the space.

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included
- [ ] Changelog was modified

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
