### PR TITLE
Space: Show "Owner" Tab also for SystemAdmins

### DIFF
--- a/protected/humhub/modules/space/modules/manage/widgets/MemberMenu.php
+++ b/protected/humhub/modules/space/modules/manage/widgets/MemberMenu.php
@@ -56,7 +56,7 @@ class MemberMenu extends TabMenu
             ]));
         }
 
-        if ($this->space->isSpaceOwner()) {
+        if ($this->space->isSpaceOwner() || (!Yii::$app->user->isGuest && Yii::$app->user->identity->isSystemAdmin())) {
             $this->addEntry(new MenuLink([
                 'label' => Yii::t('SpaceModule.manage', 'Owner'),
                 'url' => $this->space->createUrl('/space/manage/member/change-owner'),


### PR DESCRIPTION
As change owner page is accessible to system admin, the tab menu should be shown to.
It will be useful for sys admin to to avoid the need to go through the administration page of the spaces to access to this space owner page.
Perhaps there is a nicer way to replace `($this->space->isSpaceOwner() || (!Yii::$app->user->isGuest && Yii::$app->user->identity->isSystemAdmin()))` but I didn't find.

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [x] All tests are passing
- [ ] New/updated tests are included
- [ ] Changelog was modified

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
