### PR TITLE
Fix space visibility options showing for users without permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ HumHub Changelog
 - Fix #4989: Translate profile field title in admin list
 - Fix #5002: Fix loading of fixture spaces on tests
 - Fix #5018: Activity stream problems with many user accounts
+- Fix: Space visibility options shown to users without permission
 
 
 1.8.1 (March 12, 2021)

--- a/protected/humhub/modules/space/modules/manage/controllers/SecurityController.php
+++ b/protected/humhub/modules/space/modules/manage/controllers/SecurityController.php
@@ -11,6 +11,9 @@ namespace humhub\modules\space\modules\manage\controllers;
 use Yii;
 use humhub\modules\space\modules\manage\components\Controller;
 use humhub\modules\space\models\Space;
+use humhub\modules\space\permissions\CreatePrivateSpace;
+use humhub\modules\space\permissions\CreatePublicSpace;
+use humhub\modules\user\helpers\AuthHelper;
 use yii\web\HttpException;
 
 /**
@@ -34,7 +37,18 @@ class SecurityController extends Controller
             $this->view->error(Yii::t('SpaceModule.base', 'Settings could not be saved!'));
         }
 
-        return $this->render('index', ['model' => $space]);
+        $visibilities = [];
+        if (Yii::$app->user->permissionManager->can(new CreatePrivateSpace)) {
+            $visibilities[Space::VISIBILITY_NONE] = Yii::t('SpaceModule.base', 'Private (Invisible)');
+        }
+        if (Yii::$app->user->permissionManager->can(new CreatePublicSpace)) {
+            $visibilities[Space::VISIBILITY_REGISTERED_ONLY] = Yii::t('SpaceModule.base', 'Public (Registered users only)');
+            if (AuthHelper::isGuestAccessEnabled()) {
+                $visibilities[Space::VISIBILITY_ALL] = Yii::t('SpaceModule.base', 'Visible for all (members and guests)');
+            }
+        }
+
+        return $this->render('index', ['model' => $space, 'visibilities' => $visibilities]);
     }
 
     /**

--- a/protected/humhub/modules/space/modules/manage/controllers/SecurityController.php
+++ b/protected/humhub/modules/space/modules/manage/controllers/SecurityController.php
@@ -38,14 +38,18 @@ class SecurityController extends Controller
         }
 
         $visibilities = [];
-        if (Yii::$app->user->permissionManager->can(new CreatePrivateSpace)) {
+        if ($space->visibility === Space::VISIBILITY_NONE ||
+            Yii::$app->user->permissionManager->can(new CreatePrivateSpace)) {
             $visibilities[Space::VISIBILITY_NONE] = Yii::t('SpaceModule.base', 'Private (Invisible)');
         }
-        if (Yii::$app->user->permissionManager->can(new CreatePublicSpace)) {
+        $canCreatePublicSpace = Yii::$app->user->permissionManager->can(new CreatePublicSpace);
+        if ($space->visibility === Space::VISIBILITY_REGISTERED_ONLY ||
+            $canCreatePublicSpace) {
             $visibilities[Space::VISIBILITY_REGISTERED_ONLY] = Yii::t('SpaceModule.base', 'Public (Registered users only)');
-            if (AuthHelper::isGuestAccessEnabled()) {
-                $visibilities[Space::VISIBILITY_ALL] = Yii::t('SpaceModule.base', 'Visible for all (members and guests)');
-            }
+        }
+        if ($space->visibility === Space::VISIBILITY_ALL ||
+            ($canCreatePublicSpace && AuthHelper::isGuestAccessEnabled())) {
+            $visibilities[Space::VISIBILITY_ALL] = Yii::t('SpaceModule.base', 'Visible for all (members and guests)');
         }
 
         return $this->render('index', ['model' => $space, 'visibilities' => $visibilities]);

--- a/protected/humhub/modules/space/modules/manage/views/security/index.php
+++ b/protected/humhub/modules/space/modules/manage/views/security/index.php
@@ -2,12 +2,12 @@
 
 use humhub\modules\space\models\Space;
 use humhub\modules\space\modules\manage\widgets\SecurityTabMenu;
-use humhub\modules\user\helpers\AuthHelper;
 use humhub\widgets\DataSaved;
 use yii\bootstrap\ActiveForm;
 use humhub\libs\Html;
 
 /* @var $model Space */
+/* @var $visibilities array */
 ?>
 
 <div class="panel panel-default">
@@ -22,15 +22,6 @@ use humhub\libs\Html;
     <div class="panel-body">
         <?php $form = ActiveForm::begin(); ?>
 
-        <?php
-        $visibilities = [
-            Space::VISIBILITY_NONE => Yii::t('SpaceModule.base', 'Private (Invisible)'),
-            Space::VISIBILITY_REGISTERED_ONLY => Yii::t('SpaceModule.base', 'Public (Registered users only)')
-        ];
-        if (AuthHelper::isGuestAccessEnabled()) {
-            $visibilities[Space::VISIBILITY_ALL] = Yii::t('SpaceModule.base', 'Visible for all (members and guests)');
-        }
-        ?>
         <?= $form->field($model, 'visibility')->dropDownList($visibilities); ?>
 
         <?php $joinPolicies = [0 => Yii::t('SpaceModule.base', 'Only by invite'), 1 => Yii::t('SpaceModule.base', 'Invite and request'), 2 => Yii::t('SpaceModule.base', 'Everyone can enter')]; ?>


### PR DESCRIPTION
Don't show the "Private (Invisible)" space visibility option in the
space security settings for users who cannot create private spaces.

Move the logic for assembling the visibility options from the view to
the controller.

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included
- [x] Changelog was modified

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

This fixes the problem where “Private (Invisible)” was showing as a space visibility option within the space security settings to users who don’t have permission to create private spaces. These users received an error if they tried to choose the option.