### PR TITLE
Update comment.less

### DIFF
--- a/static/less/comment.less
+++ b/static/less/comment.less
@@ -145,7 +145,7 @@
     .text-break();
 }
 
-.comment-create-input-group {
+.comment-create-input-group, .post-richtext-input-group {
     position: relative;
 
     .ProsemirrorEditor {


### PR DESCRIPTION
When editing the text of a content (not the comment, the publication), field's text goes under the "Save" button. Using the same margin-right as the comment field solves the problem the same was as the comment field with the "Submit" button.

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [X] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included
- [ ] Changelog was modified

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
