### PR TITLE
Enh: Show update tick on AdminMenu

### DIFF
--- a/protected/humhub/modules/admin/widgets/AdminMenu.php
+++ b/protected/humhub/modules/admin/widgets/AdminMenu.php
@@ -106,7 +106,7 @@ class AdminMenu extends LeftNavigation
 
         $this->addEntry(new MenuLink([
             'id' => 'modules',
-            'label' => Yii::t('AdminModule.base', 'Modules') .$updatesBadge,
+            'label' => Yii::t('AdminModule.base', 'Modules') . $updatesBadge,
             'url' => ['/admin/module'],
             'icon' => 'rocket',
             'sortOrder' => 500,

--- a/protected/humhub/modules/admin/widgets/AdminMenu.php
+++ b/protected/humhub/modules/admin/widgets/AdminMenu.php
@@ -89,9 +89,24 @@ class AdminMenu extends LeftNavigation
             ])
         ]));
 
+        /** @var Module $module */
+        $module = Yii::$app->getModule('marketplace');
+
+        if (!$module->enabled) {
+            return;
+        }
+
+        $updatesBadge = '';
+        $updatesCount = count($module->onlineModuleManager->getModuleUpdates());
+        if ($updatesCount > 0) {
+            $updatesBadge = '&nbsp;&nbsp;<span class="label label-danger">' . $updatesCount . '</span>';
+        } else {
+            $updatesBadge = '&nbsp;&nbsp;<span class="label label-default">0</span>';
+        }
+
         $this->addEntry(new MenuLink([
             'id' => 'modules',
-            'label' => Yii::t('AdminModule.base', 'Modules'),
+            'label' => Yii::t('AdminModule.base', 'Modules') .$updatesBadge,
             'url' => ['/admin/module'],
             'icon' => 'rocket',
             'sortOrder' => 500,


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [x] All tests are passing
- [ ] New/updated tests are included
- [ ] Changelog was modified

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Currently, the only way to actually see that there are any updates for modules is if you actually enter the Module tab, this p/r will help admins/those with the permissions to manage modules that there are updates for modules

![Screenshot_1](https://user-images.githubusercontent.com/35392110/119244092-f0f4bb80-bb3a-11eb-8015-6d3e7172f45e.png)
