### PR TITLE
Fix people sorting by "Default" when filter "Group" is selected

### DIFF
--- a/protected/humhub/modules/user/components/PeopleQuery.php
+++ b/protected/humhub/modules/user/components/PeopleQuery.php
@@ -211,8 +211,8 @@ class PeopleQuery extends ActiveQueryUser
                 if (empty($defaultSortingGroupId)) {
                     $this->addOrderBy('last_login DESC');
                 } else {
-                    $this->leftJoin('group_user', 'group_user.user_id = user.id AND group_user.group_id = :defaultGroupId', [':defaultGroupId' => $defaultSortingGroupId]);
-                    $this->addOrderBy('group_user.group_id DESC, last_login DESC');
+                    $this->leftJoin('group_user AS top_group_sorting', 'top_group_sorting.user_id = user.id AND top_group_sorting.group_id = :defaultGroupId', [':defaultGroupId' => $defaultSortingGroupId]);
+                    $this->addOrderBy('top_group_sorting.group_id DESC, last_login DESC');
                 }
         }
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] All tests are passing
- [ ] Changelog was modified

**Other information:**
Issue: https://github.com/humhub/team_tasks/issues/123#issuecomment-856961594 - "If a user group is used as a filter, there is an internal error.".