### PR TITLE
Update AuthController.php

### DIFF
--- a/protected/humhub/modules/user/controllers/AuthController.php
+++ b/protected/humhub/modules/user/controllers/AuthController.php
@@ -36,6 +36,11 @@ class AuthController extends Controller
      * after the response is generated.
      */
     const EVENT_AFTER_LOGIN = 'afterLogin';
+    
+    /**
+     * @event Triggered after an successful login but before checking user status
+     */
+    const EVENT_BEFORE_CHECKING_USER_STATUS = 'beforeCheckingUserStatus';
 
     /**
      * @inheritdoc
@@ -203,6 +208,7 @@ class AuthController extends Controller
     {
         $redirectUrl = ['/user/auth/login'];
         $success = false;
+        $this->trigger(static::EVENT_BEFORE_CHECKING_USER_STATUS, new UserEvent(['user' => $user]));
         if ($user->status == User::STATUS_ENABLED) {
             $duration = 0;
             if (


### PR DESCRIPTION
I propose to add this `EVENT_BEFORE_CHECKING_USER_STATUS` to add the possibility to add event before checking the user status.
This event would give the possibility to a module, for instance, to reactivate a user if he tries to login.
Another use case would be to send an email to an administrator if a user tries to login but his status is disable or need approval.

I you approve this PR, I will add this new event in the changelog and documentation.

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [X] All tests are passing
- [ ] New/updated tests are included
- [ ] Changelog was modified

If adding a **new feature**, the PR's description includes:
- [X] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
