### PR TITLE
Improve SORT_CREATED_AT

### DIFF
--- a/protected/humhub/modules/stream/models/StreamQuery.php
+++ b/protected/humhub/modules/stream/models/StreamQuery.php
@@ -505,11 +505,25 @@ class StreamQuery extends Model
                     ], [':to' => $this->to]);
             }
         } else {
-            $this->_query->orderBy('content.id DESC');
+            $this->_query->orderBy('content.created_at DESC');
             if (!empty($this->from)) {
-                $this->_query->andWhere("content.id < :from", [':from' => $this->from]);
+                $this->_query->andWhere(
+                    ['or',
+                        "content.created_at < (SELECT created_at FROM content wd WHERE wd.id=:from)",
+                        ['and',
+                            "content.created_at = (SELECT created_at FROM content wd WHERE wd.id=:from)",
+                            "content.id > :from"
+                        ],
+                    ], [':from' => $this->from]);
             } elseif (!empty($this->to)) {
-                $this->_query->andWhere("content.id > :to", [':to' => $this->to]);
+                $this->_query->andWhere(
+                    ['or',
+                        "content.created_at > (SELECT created_at FROM content wd WHERE wd.id=:to)",
+                        ['and',
+                            "content.created_at = (SELECT created_at FROM content wd WHERE wd.id=:to)",
+                            "content.id < :to"
+                        ],
+                    ], [':to' => $this->to]);
             }
         }
     }


### PR DESCRIPTION
SORT_CREATED_AT actually sorts stream by content.id, which is totally fine if all content records are created by humhub engine natively, but doesn't work if some of them were modified by administrator or imported from external source. In this case order of [id] may not match order of [created_at].

A proposed change is based on how SORT_UPDATED_AT is handled (with stream_sort_date replaced by created_at).

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included
- [ ] Changelog was modified

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
