### PR TITLE
Fix incorrect <div> nesting in <p>

### DIFF
--- a/protected/humhub/modules/user/views/profile/about.php
+++ b/protected/humhub/modules/user/views/profile/about.php
@@ -41,7 +41,7 @@ $categories = $user->profile->getProfileFieldCategories();
                                 </label>
                                 <?php if (strtolower($field->title) == 'about'): ?>
                                     <div class="col-sm-9">
-                                        <p class="form-control-static"><?= RichText::output($field->getUserValue($user, true)) ?></p>
+                                        <div class="form-control-static"><?= RichText::output($field->getUserValue($user, true)) ?></div>
                                     </div>
                                 <?php else: ?>
                                     <div class="col-sm-9">


### PR DESCRIPTION
RichText::output produces div. Syntactically, a div inside a p is invalid in HTML: https://www.w3.org/TR/html401/struct/text.html#h-9.3.1

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included
- [ ] Changelog was modified

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
