### PR TITLE
Don't require type for first param of the function ProsemirrorRichTex…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ HumHub Changelog
 - Fix #5066: Fix pin and archive global content without container
 - Fix #5107: Fix captcha client validation after request new code
 - Fix #22: Fix misplaced OEmbed provider buttons on general settings form
+- Fix #5130: Don't require type for first param of the function ProsemirrorRichText::replaceLinkExtension()
 
 
 1.8.2 (April 26, 2021)

--- a/protected/humhub/modules/content/widgets/richtext/ProsemirrorRichText.php
+++ b/protected/humhub/modules/content/widgets/richtext/ProsemirrorRichText.php
@@ -224,7 +224,7 @@ class ProsemirrorRichText extends AbstractRichText
      * @return mixed
      * @deprecated since 1.8 use `ProsemirrorRichTextConverter::replaceLinkExtension()`
      */
-    public static function replaceLinkExtension(string $text, $extension, callable $callback)
+    public static function replaceLinkExtension($text, $extension, callable $callback)
     {
         return RichTextLinkExtension::replaceLinkExtension($text, $extension, function (RichTextLinkExtensionMatch $match) use ($callback) {
             return $callback($match->match);

--- a/protected/humhub/modules/content/widgets/richtext/ProsemirrorRichText.php
+++ b/protected/humhub/modules/content/widgets/richtext/ProsemirrorRichText.php
@@ -219,12 +219,13 @@ class ProsemirrorRichText extends AbstractRichText
      * Can be used to scan and replace link extensions of the form [<text>](<extension>:<url> "<title>") in which the actual meaning
      * of the placeholders is up to the extension itself.
      *
-     * @param $text string rich text content to parse
-     * @param $extension string|null extension string if not given all extension types will be included
+     * @param string|null $text string rich text content to parse
+     * @param string|null $extension extension string if not given all extension types will be included
+     * @param callable $callback
      * @return mixed
      * @deprecated since 1.8 use `ProsemirrorRichTextConverter::replaceLinkExtension()`
      */
-    public static function replaceLinkExtension($text, $extension, callable $callback)
+    public static function replaceLinkExtension(?string $text, ?string $extension, callable $callback)
     {
         return RichTextLinkExtension::replaceLinkExtension($text, $extension, function (RichTextLinkExtensionMatch $match) use ($callback) {
             return $callback($match->match);

--- a/protected/humhub/modules/content/widgets/richtext/extensions/link/RichTextLinkExtension.php
+++ b/protected/humhub/modules/content/widgets/richtext/extensions/link/RichTextLinkExtension.php
@@ -26,12 +26,12 @@ class RichTextLinkExtension extends RichTextContentExtension
      * Can be used to scan and replace link extensions of the form [<text>](<extension>:<url> "<title>") in which the actual meaning
      * of the placeholders is up to the extension itself.
      *
-     * @param $text string rich text content to parse
-     * @param $extension string|null extension string if not given all extension types will be included
+     * @param string|null $text rich text content to parse
+     * @param string|null $extension extension string if not given all extension types will be included
      * @param callable $callback callable expecting RichTextExtensionMatch as first parameter
      * @return mixed
      */
-    public static function replaceLinkExtension(string $text, $extension, callable $callback)
+    public static function replaceLinkExtension(?string $text, ?string $extension, callable $callback)
     {
         return (new static(['key' => $extension]))->replaceExtension($text, $callback);
     }


### PR DESCRIPTION
…t::replaceLinkExtension()

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

**The PR fulfills these requirements:**

- [ ] All tests are passing
- [x] Changelog was modified

**Other information:**
Issue: https://github.com/humhub/wiki/issues/179
