### PR TITLE
Update ProfileBannerImage.php

### DIFF
--- a/protected/humhub/libs/ProfileBannerImage.php
+++ b/protected/humhub/libs/ProfileBannerImage.php
@@ -33,12 +33,12 @@ class ProfileBannerImage extends ProfileImage
     /**
      * @var Integer width of the Image
      */
-    protected $width = 1134;
+    protected $width = 1240;
 
     /**
      * @var Integer height of the Image
      */
-    protected $height = 192;
+    protected $height = 552;
 
     /**
      * @var String folder name inside the uploads directory


### PR DESCRIPTION
Increasing the image width and height so that also bigger header images can be added to the header. As of now, there is no way to permanently set a bigger width it is recommended to set those values higher as the value can always be chosen smaller but unfortunately not bigger. The values of 1240X552 have been chosen so that it still displays nicely on a screen with 1280 width i.e. https://phuket.school/s/oak-meadow-international/.
smaller Banners still can be displayed too. https://phuket.church/s/phuket-international-church/space/space/about

Accordingly, the CSS has to be adjusted too in the Themes itself - but now can display images until a height of 552px.
.panel-profile .panel-profile-header .img-profile-header-background {
	width: 100%;
	max-height: 552px;
}

