### PR TITLE
Update ProfileBannerImage.php

### DIFF
--- a/protected/humhub/libs/ProfileBannerImage.php
+++ b/protected/humhub/libs/ProfileBannerImage.php
@@ -38,7 +38,7 @@ class ProfileBannerImage extends ProfileImage
     /**
      * @var Integer height of the Image
      */
-    protected $height = 192;
+    protected $height = 552;
 
     /**
      * @var String folder name inside the uploads directory


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [x] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [x] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [x] All tests are passing
- [ ] New/updated tests are included
- [x] Changelog was modified

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

It is only a Pixel Value Change from max-height:192px; to max-height:552px; which is a no-breaking change that simply enables the upload of bigger profile images without the need to write a custom module and without breaking existing sites or profile image header banners.- no other changes. The same applies to the changes made in the below-mentioned pull requests. It is much easier to handle for Users as no additional tools to modify a smartphone or camera Image would be needed to achieve a very good result.

Changing the max Profile header Image background height from 192px to 552px as described in Issues:
https://github.com/humhub/humhub/pull/5389
https://github.com/humhub/humhub/pull/5380

https://github.com/humhub/humhub/pull/5391 (Dev)
https://github.com/humhub/humhub/pull/5392 (Dev)
https://github.com/humhub/humhub/pull/5393 (Dev)
and
https://community.humhub.com/content/perma?id=247417

Increasing the image width and height so that also bigger header images can be added to the header. As of now, there is no way to permanently set a bigger width it is recommended to set those values higher as the value can always be chosen smaller but unfortunately not bigger. The values of 1240X552 have been chosen so that it still displays nicely on a screen with 1280 width i.e. https://phuket.school/s/oak-meadow-international/.
smaller Banners still can be displayed too. https://phuket.church/s/phuket-international-church/space/space/about

Accordingly, the CSS has to be adjusted too in the Themes itself - but now can display images until a height of 552px.

.panel-profile .panel-profile-header .img-profile-header-background {
width: 100%;
max-height: 552px;
}

**Other information:**

Especially Community Site Admins of NGO organizations ./ Schools / Churches etc most are not at all professionals and they often have also not the tools to modify an existing image so it really fits in 192px height. By having the ability to insert an image with up to 552px height most images will be able to create a nice looking header without additional tools.

Some already changed screenshots made of sites where this change has already been applied.
![Screen Shot 2021-10-25 at 08 53 10](https://user-images.githubusercontent.com/1982011/138727917-ea93b2b8-d8af-434f-8190-3520f1506cec.png)
![Screen Shot 2021-10-25 at 08 53 32](https://user-images.githubusercontent.com/1982011/138727941-fe483df6-c64d-4a84-b908-a4c310f8781a.png)
![Screen Shot 2021-10-25 at 08 55 39](https://user-images.githubusercontent.com/1982011/138727945-e73ba428-ac6b-419d-b05e-8e9b21e364e4.png)

![Screen Shot 2021-10-25 at 22 45 48](https://user-images.githubusercontent.com/1982011/138728271-e982ddcc-0e0e-49fc-a732-9ee0d168948d.png)
![Screen Shot 2021-10-25 at 22 46 43](https://user-images.githubusercontent.com/1982011/138728304-b8564792-41ab-4da5-9cb1-1dfe2e4d321d.png)
![Screen Shot 2021-10-25 at 22 47 06](https://user-images.githubusercontent.com/1982011/138728308-b6676f91-535a-4451-86db-124c725843e9.png)
![Screen Shot 2021-10-25 at 22 49 12](https://user-images.githubusercontent.com/1982011/138728610-5bd0313f-4afa-4433-88e2-ab1162f824ce.png)

