### PR TITLE
Allow to detach file from simple ActiveRecord

### DIFF
--- a/CHANGELOG_DEV.md
+++ b/CHANGELOG_DEV.md
@@ -3,6 +3,7 @@
 - Enh #5403: Confirmation before close a not saved modal form
 - Fix #5401: Fix profile field value result type 
 - Fix #5402: Fix mentioning search in comment content
+- Enh #5418: Allow to detach file from simple ActiveRecord
 
 
 1.10.0-beta.1 (October 27, 2021)

--- a/protected/humhub/modules/file/models/File.php
+++ b/protected/humhub/modules/file/models/File.php
@@ -208,23 +208,20 @@ class File extends FileCompat
     {
         $object = $this->getPolymorphicRelation();
 
-        if ($object != null) {
-            if ($object instanceof ContentAddonActiveRecord) {
-                /** @var ContentAddonActiveRecord $object */
-                return $object->canEdit($userId);
-            } elseif ($object instanceof ContentActiveRecord) {
-                /** @var ContentActiveRecord $object */
-                return $object->content->canEdit($userId);
-            }
-        }
-
-        if ($object !== null && ($object instanceof ContentActiveRecord || $object instanceof ContentAddonActiveRecord)) {
-            return $object->content->canEdit($userId);
-        }
-
         // File is not bound to an object
-        if ($object == null) {
+        if ($object === null) {
             return true;
+        }
+
+        if ($object instanceof ContentAddonActiveRecord) {
+            /** @var ContentAddonActiveRecord $object */
+            return $object->canEdit($userId) || $object->content->canEdit($userId);
+        } elseif ($object instanceof ContentActiveRecord) {
+            /** @var ContentActiveRecord $object */
+            return $object->content->canEdit($userId);
+        } elseif ($object instanceof ActiveRecord && method_exists($object, 'canEdit')) {
+            /** @var ActiveRecord $object */
+            return $object->canEdit($userId);
         }
 
         return false;


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Feature
- [x] Code style update

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] All tests are passing
- [x] Changelog was modified

**Other information:**
Request: https://github.com/humhub/spd-otf/issues/2#issuecomment-957745957:

> **Please note** currently impossible to remove the attached image from the Topic Forum because the `Upload` was developed to works only with Content Active Records, but the `TopicForum` is a simple `ActiveRecord`. It would be good to modify the core `\humhub\modules\file\models\File->canDelete()`(https://github.com/humhub/humhub/blob/master/protected/humhub/modules/file/models/File.php#L197-L221) to allow to check `$object->canEdit($userId);` even the `$object` is a simple `ActiveRecord`.