### PR TITLE
Fix confirmation before close a form with unsaved changes on modal wi…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 HumHub Changelog
 ================
 
+1.10.2 (Unreleased)
+--------------------------
+- Fix #5450: Fix confirmation before close a form with unsaved changes on modal window
+
+
 1.10.1 (November 26, 2021)
 --------------------------
 

--- a/static/js/humhub/humhub.client.js
+++ b/static/js/humhub/humhub.client.js
@@ -395,8 +395,13 @@ humhub.module('client', function (module, require, $) {
         });
 
         var confirmFormChanges = function (evt, message) {
-            if (unloadForm($form, message)) {
-                $form.resetChanges();
+            var form = $(evt.target).find('form');
+            if (!form.length) {
+                return;
+            }
+
+            if (unloadForm(form, message)) {
+                form.data('state', null);
             } else {
                 evt.preventDefault();
             }


### PR DESCRIPTION
…ndow

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

**The PR fulfills these requirements:**

- [ ] All tests are passing
- [ ] Changelog was modified

**Other information:**
Related to issue: https://github.com/humhub/text-editor/issues/11