### PR TITLE
Fix mixed up title for membership button

### DIFF
--- a/protected/humhub/modules/space/widgets/views/membershipButton.php
+++ b/protected/humhub/modules/space/widgets/views/membershipButton.php
@@ -36,7 +36,7 @@ if ($membership === null) {
     if ($canCancelMembership && $options['cancelMembership']['visible']) {
         echo Html::a($options['cancelMembership']['title'], '#', $options['cancelMembership']['attrs']);
     } elseif (!$canCancelMembership && $options['cannotCancelMembership']['visible']) {
-        $memberTitle = (!$space->isSpaceOwner() ? $options['cannotCancelMembership']['ownerTitle'] : $options['cannotCancelMembership']['memberTitle']);
+        $memberTitle = ($space->isSpaceOwner() ? $options['cannotCancelMembership']['ownerTitle'] : $options['cannotCancelMembership']['memberTitle']);
         echo Html::a($memberTitle, $space->createUrl(), $options['cannotCancelMembership']['attrs']);
     }
 }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included
- [ ] Changelog was modified

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Currently the membership buttons displays the owner title for members and member title for owners.