### PR TITLE
Microsoft Auth Remember me checkbox fix

### DIFF
--- a/CHANGELOG_DEV.md
+++ b/CHANGELOG_DEV.md
@@ -37,4 +37,4 @@
 - Enh #4823: Removed CHTML and CActiveForm classes as well as usages (plus refactoring)
 - Fix #5449: File - Update info after `setStoredFileContent` and `setStoredFile`
 - Enh #5127: LDAP: Reset mapping for single user only
-- Fix #5578: Microsoft Auth `rememberMe` Checkbox Fix
+- Fix #5578: Improved `rememberMe` parameter handling for thirdparty auth provider 

--- a/CHANGELOG_DEV.md
+++ b/CHANGELOG_DEV.md
@@ -37,4 +37,4 @@
 - Enh #4823: Removed CHTML and CActiveForm classes as well as usages (plus refactoring)
 - Fix #5449: File - Update info after `setStoredFileContent` and `setStoredFile`
 - Enh #5127: LDAP: Reset mapping for single user only
-
+- Fix #5578: Microsoft Auth `rememberMe` Checkbox Fix

--- a/protected/humhub/modules/user/resources/js/humhub.user.login.js
+++ b/protected/humhub/modules/user/resources/js/humhub.user.login.js
@@ -11,7 +11,12 @@ humhub.module('user.login', function (module, require, $) {
                 $this.data('originalUrl', original);
             }
 
-            $this.attr('href', checked ? original + '&rememberMe=1' : original);
+            var url = new URL(original, window.location.origin);
+            if(checked) {
+                url.searchParams.set('rememberMe', 1);
+            }
+
+            $this.attr('href', url.toString());
         });
 
     };


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [x] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [x] All tests are passing
- [x] New/updated tests are included
- [x] Changelog was modified

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

When resolving this [issue](https://github.com/humhub/team_tasks/issues/62) I faced a problem, that when the "remember me" checkbox is checked, the script breaks pretty url `/user/auth/microsoft`, that is required for [auth-microsoft module](https://github.com/humhub-contrib/auth-microsoft)