### PR TITLE
Fix enabling module on functional tests

### DIFF
--- a/protected/humhub/modules/content/components/ContentContainerModuleManager.php
+++ b/protected/humhub/modules/content/components/ContentContainerModuleManager.php
@@ -32,6 +32,11 @@ class ContentContainerModuleManager extends \yii\base\Component
     private $_available;
 
     /**
+     * @var array the cached states per module
+     */
+    private $_states;
+
+    /**
      * Disables a module for the content container
      *
      * @param string $id the module id
@@ -195,39 +200,36 @@ class ContentContainerModuleManager extends \yii\base\Component
     public function flushCache()
     {
         $this->_available = null;
-        $this->getStates(true);
+        $this->_states = null;
     }
 
     /**
      * Returns an array of all module states.
      *
-     * @param bool True for forcing cached states and load them all from DB
      * @return array a list of modules with the corresponding state
      * @see Module
      */
-    protected function getStates(bool $forceLoad = false)
+    protected function getStates()
     {
-        static $states = [];
-
-        if (!$forceLoad && isset($states[$this->contentContainer->contentcontainer_id])) {
-            return $states[$this->contentContainer->contentcontainer_id];
+        if (isset($this->_states)) {
+            return $this->_states;
         }
 
-        $states[$this->contentContainer->contentcontainer_id] = [];
+        $this->_states = [];
 
         // Get states for this contentcontainer from database
         foreach (ContentContainerModuleState::findAll(['contentcontainer_id' => $this->contentContainer->contentcontainer_id]) as $module) {
-            $states[$this->contentContainer->contentcontainer_id][$module->module_id] = $module->module_state;
+            $this->_states[$module->module_id] = $module->module_state;
         }
 
         // Get default states, when no state is stored
         foreach ($this->getAvailable() as $module) {
-            if (!isset($states[$this->contentContainer->contentcontainer_id][$module->id])) {
-                $states[$this->contentContainer->contentcontainer_id][$module->id] = self::getDefaultState($this->contentContainer->className(), $module->id);
+            if (!isset($this->_states[$module->id])) {
+                $this->_states[$module->id] = self::getDefaultState(get_class($this->contentContainer), $module->id);
             }
         }
 
-        return $states[$this->contentContainer->contentcontainer_id];
+        return $this->_states;
     }
 
     /**


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] All tests are passing
- [x] Changelog was modified

**Other information:**
Issue: https://github.com/humhub/wiki/issues/235

I have decided to replace the caching in static var completely with property var of the class, because it is impossible to clear the cache during tests. I already fixed this here https://github.com/humhub/humhub/pull/5631 and it solved the same issue for the module `news` but on `wiki` module it doesn't work.
The static var works well on web interface when after load each new page it was reset, but when several tests are run the static var is not cleared as expected.