### PR TITLE
Add shortName configuration setting

### DIFF
--- a/CHANGELOG_DEV.md
+++ b/CHANGELOG_DEV.md
@@ -2,3 +2,4 @@
 -------------------
 - Enh #5655: Possibility to archive and lock comments on global contents
 - Enh #5695: Truncate long profile texts in People cards
+- Enh: Allow a short app name to be configured for the PWA

--- a/protected/humhub/modules/admin/models/forms/BasicSettingsForm.php
+++ b/protected/humhub/modules/admin/models/forms/BasicSettingsForm.php
@@ -16,6 +16,7 @@ class BasicSettingsForm extends \yii\base\Model
 {
 
     public $name;
+    public $shortName;
     public $baseUrl;
     public $defaultLanguage;
     public $tour;
@@ -34,6 +35,7 @@ class BasicSettingsForm extends \yii\base\Model
         parent::init();
 
         $this->name = Yii::$app->settings->get('name');
+        $this->shortName = Yii::$app->settings->get('shortName') ?? $this->name;
         $this->baseUrl = Yii::$app->settings->get('baseUrl');
         $this->defaultLanguage = Yii::$app->settings->get('defaultLanguage');
         $this->defaultTimeZone = Yii::$app->settings->get('defaultTimeZone');
@@ -52,8 +54,9 @@ class BasicSettingsForm extends \yii\base\Model
     public function rules()
     {
         return [
-            [['name', 'baseUrl'], 'required'],
+            [['name', 'shortName', 'baseUrl'], 'required'],
             ['name', 'string', 'max' => 150],
+            ['shortName', 'string', 'max' => 15],
             ['defaultLanguage', 'in', 'range' => array_keys(Yii::$app->i18n->getAllowedLanguages())],
             [['defaultTimeZone', 'timeZone'], 'in', 'range' => \DateTimeZone::listIdentifiers()],
             [['tour', 'dashboardShowProfilePostForm', 'enableFriendshipModule', 'maintenanceMode'], 'in', 'range' => [0, 1]],
@@ -73,6 +76,7 @@ class BasicSettingsForm extends \yii\base\Model
     {
         return [
             'name' => Yii::t('AdminModule.settings', 'Name of the application'),
+            'shortName' => Yii::t('AdminModule.settings', 'Short name of the application'),
             'baseUrl' => Yii::t('AdminModule.settings', 'Base URL'),
             'defaultLanguage' => Yii::t('AdminModule.settings', 'Default language'),
             'defaultTimeZone' => Yii::t('AdminModule.settings', 'Default Timezone'),
@@ -111,6 +115,7 @@ class BasicSettingsForm extends \yii\base\Model
     public function save()
     {
         Yii::$app->settings->set('name', $this->name);
+        Yii::$app->settings->set('shortName', $this->shortName);
         Yii::$app->settings->set('baseUrl', $this->baseUrl);
         Yii::$app->settings->set('defaultLanguage', $this->defaultLanguage);
         Yii::$app->settings->set('defaultTimeZone', $this->defaultTimeZone);

--- a/protected/humhub/modules/admin/views/setting/basic.php
+++ b/protected/humhub/modules/admin/views/setting/basic.php
@@ -34,6 +34,7 @@ AdminAsset::register($this);
     <?php $form = ActiveForm::begin(['acknowledge' => true]); ?>
 
     <?= $form->field($model, 'name'); ?>
+    <?= $form->field($model, 'shortName'); ?>
     <?= $form->field($model, 'baseUrl'); ?>
 
     <?php $allowedLanguages = Yii::$app->i18n->getAllowedLanguages(); ?>

--- a/protected/humhub/modules/web/pwa/controllers/ManifestController.php
+++ b/protected/humhub/modules/web/pwa/controllers/ManifestController.php
@@ -55,7 +55,7 @@ class ManifestController extends Controller
     {
         $this->manifest['display'] = 'standalone';
         $this->manifest['start_url'] = Url::home(true);
-        $this->manifest['short_name'] = Yii::$app->name;
+        $this->manifest['short_name'] = Yii::$app->settings->get('shortName') ?? Yii::$app->name;
         $this->manifest['name'] = Yii::$app->name;
         $this->manifest['background_color'] = Yii::$app->view->theme->variable('primary');
         $this->manifest['theme_color'] = Yii::$app->view->theme->variable('primary');


### PR DESCRIPTION
The `short_name` setting for the PWA manifest is currently the same as the full app name. It would be helpful to have a separate short name for the app as a default for when users add the app to the home screen of their mobile device.

This pull request adds a separate configurable app short name, which defaults to the full name.

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included
- [x] Changelog was modified

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
