### PR TITLE
Update PermaController.php

### DIFF
--- a/protected/humhub/modules/comment/controllers/PermaController.php
+++ b/protected/humhub/modules/comment/controllers/PermaController.php
@@ -31,7 +31,7 @@ class PermaController extends Controller
     {
         $comment = Comment::findOne(['id' => $id]);
 
-        if (!$comment || !$comment->content || !$comment->canRead() || !$comment->content->container) {
+        if (!$comment || !$comment->content || !$comment->canRead()) {
             throw new NotFoundHttpException();
         }
 


### PR DESCRIPTION
We should be able to be redirected to the content if it's a global content.
I don't know if there was a reason to send a not found exception for global contents, but removing this check, the redirection works well with global contents, and email notification buttons now redirects to the global content.

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included
- [ ] Changelog was modified

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
