### PR TITLE
Fix deprecated null value for `file_exists()` on PHP 8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ HumHub Changelog
 - Fix #5832: Exception in file open dialog when last update user no longer exists 
 - Fix #5814: Fix numerated lists in mail summary content
 - Fix #5830: Fix cron job of search index rebuilding
-- Fix: Fix deprecated null value for `file_exists()` on PHP 8.1
+- Fix #5838: Fix deprecated null value for `file_exists()` on PHP 8.1
 
 1.12.0 (July 27, 2022)
 ----------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ HumHub Changelog
 - Fix #5832: Exception in file open dialog when last update user no longer exists 
 - Fix #5814: Fix numerated lists in mail summary content
 - Fix #5830: Fix cron job of search index rebuilding
+- Fix: Fix deprecated null value for `file_exists()` on PHP 8.1
 
 1.12.0 (July 27, 2022)
 ----------------------

--- a/protected/humhub/components/rendering/DefaultViewPathRenderer.php
+++ b/protected/humhub/components/rendering/DefaultViewPathRenderer.php
@@ -58,7 +58,7 @@ class DefaultViewPathRenderer extends \humhub\components\rendering\ViewPathRende
     {
         $viewFile = parent::getViewFile($viewable);
 
-        if (!file_exists($viewFile) && $this->defaultViewPath) {
+        if (($viewFile === null || !file_exists($viewFile)) && $this->defaultViewPath) {
             $viewFile = Yii::getAlias($this->defaultViewPath) . '/' . $this->suffix($viewable->getViewName());
         }
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

**The PR fulfills these requirements:**

- [ ] All tests are passing
- [x] Changelog was modified


**Other information:**
`null` value for the function `file_exists` is deprecated on PHP 8.1

![file_exists_php81](https://user-images.githubusercontent.com/6995524/184090980-023a08a1-9e3d-471c-aacf-a7de128c1209.png)