### PR TITLE
Fix deprecated null for DateTime in PHP 8.1

### DIFF
--- a/protected/humhub/libs/DbDateValidator.php
+++ b/protected/humhub/libs/DbDateValidator.php
@@ -78,7 +78,7 @@ class DbDateValidator extends DateValidator
             $this->addError($model, $attribute, $this->tooBig, ['max' => $this->maxString]);
         } else {
             // If there is no error, and attribute is not yet in DB Format - convert to DB
-            $date = new \DateTime(null, new \DateTimeZone('UTC'));
+            $date = new \DateTime('now', new \DateTimeZone('UTC'));
             $date->setTimestamp($timestamp);
 
             if ($timeValue) {


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

**The PR fulfills these requirements:**

- [ ] All tests are passing
- [ ] Changelog was modified

**Other information:**
![date_filter](https://user-images.githubusercontent.com/6995524/184619772-f4684b85-c209-4582-a948-f677238b9492.png)