### PR TITLE
Display all levels by default on info logging page

### DIFF
--- a/CHANGELOG-DEV.md
+++ b/CHANGELOG-DEV.md
@@ -5,3 +5,4 @@ HumHub Changelog
 -------------------
 - Enh #5808: Add a menu to remove all members of a space
 - Enh #5841: Possibility to show Members/Followers as list from Space about page
+- Enh #5850: Display all levels by default on info logging page

--- a/protected/humhub/modules/admin/models/forms/LogFilterForm.php
+++ b/protected/humhub/modules/admin/models/forms/LogFilterForm.php
@@ -66,19 +66,6 @@ class LogFilterForm extends Model
     private $query;
 
     /**
-     * @inheritDoc
-     */
-    public function init()
-    {
-        if($this->levels === null) {
-            $this->levels = [Logger::LEVEL_ERROR];
-        }
-
-        parent::init();
-    }
-
-
-    /**
      * @inheritdoc
      */
     public function rules()


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Feature

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] All tests are passing
- [x] Changelog was modified

**Other information:**
Issue: https://github.com/humhub/humhub/issues/5850