### PR TITLE
Fix users being disabled because operational attributes are not queried

### DIFF
--- a/protected/humhub/modules/ldap/Module.php
+++ b/protected/humhub/modules/ldap/Module.php
@@ -27,5 +27,5 @@ class Module extends \humhub\components\Module
     /**
      * @var array|null the queried LDAP attributes, leave empty to retrieve all
      */
-    public $queriedAttributes = [];
+    public $queriedAttributes = ['*', '+'];
 }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included
- [ ] Changelog was modified

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
In OpenLDAP, the `entryUUID` attribute is an operational attribute which is only returned when explicitly queried. Before, HumHub would refuse to work with our LDAP server and disable all of the users when running `ldap/sync`. This is because `entryUUID` is correctly set as the ID attribute in the HumHub LDAP settings, however, since HumHub does not request operational attributes, it would not be able to find our users in the database and end up disabling everyone. Issue #3534 might be related to this.

This might break compatibility with Active Directory, if it can not handle `+` in the requested attribute list. Unfortunately, I do not have an AD server ready for testing.