### PR TITLE
Fix #5903: ContentContainerModule::getEnabledContentContainers() returns an empty array

### DIFF
--- a/CHANGELOG-DEV.md
+++ b/CHANGELOG-DEV.md
@@ -10,3 +10,4 @@ HumHub Changelog
 - Enh #5872: Invalidate active sessions after password changing
 - Enh #5820: Selftest for base URL
 - Enh #5891: Improve select2 width on people filters
+- Fix #5903: ContentContainerModule::getEnabledContentContainers() returns an empty array

--- a/protected/humhub/modules/content/components/ContentContainerModule.php
+++ b/protected/humhub/modules/content/components/ContentContainerModule.php
@@ -9,6 +9,7 @@
 namespace humhub\modules\content\components;
 
 use humhub\components\Module;
+use humhub\modules\content\models\ContentContainer;
 use humhub\modules\content\models\ContentContainerModuleState;
 use humhub\modules\content\models\ContentContainerPermission;
 
@@ -158,11 +159,22 @@ class ContentContainerModule extends Module
      * Returns an array of all content containers where this module is enabled.
      *
      * @param string $containerClass optional filter to specific container class
-     * @return array of content container instances
+     * @return ContentContainer[]
      */
-    public function getEnabledContentContainers($containerClass = "")
+    public function getEnabledContentContainers($containerClass = null)
     {
-        return [];
+        $enabledContentContainers = [];
+        $contentContainerModuleStates = ContentContainerModuleState::findAll(['module_id' => $this->id, 'module_state' => [ContentContainerModuleState::STATE_ENABLED, ContentContainerModuleState::STATE_FORCE_ENABLED]]);
+        foreach ($contentContainerModuleStates as $contentContainerModuleState) {
+            $contentContainer = $contentContainerModuleState->contentContainer;
+            if (
+                $contentContainer !== null
+                && (!$containerClass || $contentContainer->class === $containerClass)
+            ) {
+                $enabledContentContainers[] = $contentContainer;
+            }
+        }
+        return $enabledContentContainers;
     }
 
     /**

--- a/protected/humhub/modules/content/models/ContentContainerModuleState.php
+++ b/protected/humhub/modules/content/models/ContentContainerModuleState.php
@@ -10,6 +10,7 @@ namespace humhub\modules\content\models;
 
 use Yii;
 use yii\db\ActiveRecord;
+use yii\db\ActiveQuery;
 
 /**
  * This is the model class for table "contentcontainer_module".
@@ -17,6 +18,8 @@ use yii\db\ActiveRecord;
  * @property integer $contentcontainer_id
  * @property string $module_id
  * @property integer $module_state
+ *
+ * @property ContentContainer $contentContainer
  */
 class ContentContainerModuleState extends ActiveRecord
 {
@@ -50,5 +53,14 @@ class ContentContainerModuleState extends ActiveRecord
         ];
 
         return $labels ? $states : array_keys($states);
+    }
+
+    /**
+     * @return ActiveQuery
+     */
+    public function getContentContainer()
+    {
+        return $this
+            ->hasOne(ContentContainer::class, ['id' => 'contentcontainer_id']);
     }
 }


### PR DESCRIPTION
https://github.com/humhub/humhub/issues/5903

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: https://github.com/humhub/humhub/issues/5903

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [x] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included
- [x] Changelog was modified

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
