### PR TITLE
Update CommentController.php

### DIFF
--- a/protected/humhub/modules/comment/controllers/CommentController.php
+++ b/protected/humhub/modules/comment/controllers/CommentController.php
@@ -62,21 +62,25 @@ class CommentController extends Controller
      */
     public function beforeAction($action)
     {
-        $modelClass = Yii::$app->request->get('objectModel', Yii::$app->request->post('objectModel'));
-        $modelPk = (int)Yii::$app->request->get('objectId', Yii::$app->request->post('objectId'));
+        if (parent::beforeAction($action)) {
+            $modelClass = Yii::$app->request->get('objectModel', Yii::$app->request->post('objectModel'));
+            $modelPk = (int)Yii::$app->request->get('objectId', Yii::$app->request->post('objectId'));
 
-        Helpers::CheckClassType($modelClass, [Comment::class, ContentActiveRecord::class]);
-        $this->target = $modelClass::findOne(['id' => $modelPk]);
+            Helpers::CheckClassType($modelClass, [Comment::class, ContentActiveRecord::class]);
+            $this->target = $modelClass::findOne(['id' => $modelPk]);
 
-        if (!$this->target) {
-            throw new NotFoundHttpException('Could not find underlying content or content addon record!');
+            if (!$this->target) {
+                throw new NotFoundHttpException('Could not find underlying content or content addon record!');
+            }
+
+            if (!$this->target->content->canView()) {
+                throw new ForbiddenHttpException();
+            }
+
+            return true;
         }
 
-        if (!$this->target->content->canView()) {
-            throw new ForbiddenHttpException();
-        }
-
-        return parent::beforeAction($action);
+        return false;
     }
 
 


### PR DESCRIPTION
It would be great if we could have the `parent::beforeAction($action)` before throwing exceptions.
This would allow to run the `Controller::EVENT_BEFORE_ACTION` before.
This is the way it's done in https://github.com/humhub/humhub/blob/master/protected/humhub/components/Controller.php#L206 and `yii\web\Controller` 
Thanks!

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included
- [ ] Changelog was modified

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
