### PR TITLE
Update Like.php

### DIFF
--- a/protected/humhub/modules/like/models/Like.php
+++ b/protected/humhub/modules/like/models/Like.php
@@ -94,12 +94,14 @@ class Like extends ContentAddonActiveRecord
     {
         Yii::$app->cache->delete('likes_' . $this->object_model . "_" . $this->object_id);
 
-        \humhub\modules\like\activities\Liked::instance()->about($this)->save();
+        if ($insert) {
+            \humhub\modules\like\activities\Liked::instance()->about($this)->save();
 
-        if ($this->getSource() instanceof ContentOwner && $this->getSource()->content->createdBy !== null) {
-            // This is required for comments where $this->getSoruce()->createdBy contains the comment author.
-            $target = isset($this->getSource()->createdBy) ? $this->getSource()->createdBy : $this->getSource()->content->createdBy;
-            NewLike::instance()->from(Yii::$app->user->getIdentity())->about($this)->send($target);
+            if ($this->getSource() instanceof ContentOwner && $this->getSource()->content->createdBy !== null) {
+                // This is required for comments where $this->getSoruce()->createdBy contains the comment author.
+                $target = isset($this->getSource()->createdBy) ? $this->getSource()->createdBy : $this->getSource()->content->createdBy;
+                NewLike::instance()->from(Yii::$app->user->getIdentity())->about($this)->send($target);
+            }
         }
 
         $this->automaticContentFollowing = Yii::$app->getModule('like')->autoFollowLikedContent;


### PR DESCRIPTION
After saving, create activity and notify only if it's a new like. Without surrounding with `if ($insert) {}`, it is not possible to update an entry in command line, as a new Activity is created and the related created content throw new Exception("Could not save content without created_by!") This is needed for the https://github.com/cuzy-app/humhub-modules-move-content module. Thanks!

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included
- [ ] Changelog was modified

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
