### PR TITLE
Update humhub.ui.topNavigation.js: make menu shrink and grow

### DIFF
--- a/static/js/humhub/humhub.ui.topNavigation.js
+++ b/static/js/humhub/humhub.ui.topNavigation.js
@@ -1,35 +1,37 @@
 humhub.module('ui.topNavigation', function (module, require, $) {
     var $topBarSecond = $('#topbar-second');
-    var $topNav = $topBarSecond.find('#top-menu-nav');
-
-    // Prevent overflow on init
-    $topBarSecond.css('overflow', 'hidden');
+    var $topNav = $('#top-menu-nav');
 
     var init = function () {
         $(window).on('resize', function () {
+            // Prevent overflow on to start with
+            $topBarSecond.css('overflow', 'hidden');
+            // Start with hidden pulldown menu
+            $('#top-menu-sub').hide();
+            // Bring items in the MenuDropdown back in the menu
+            $('#top-menu-sub-dropdown').children().appendTo('#top-menu-nav');
+            // move pulldown menu to last position
+            $topNav.append($('#top-menu-sub'));
+
             fixNavigationOverflow();
         });
-
-        if (!isOverflow()) {
-            $topBarSecond.css('overflow', '');
-            return;
-        }
 
         setTimeout(fixNavigationOverflow, 50);
     };
 
     var fixNavigationOverflow = function () {
         if (!isOverflow()) {
+            $topBarSecond.css('overflow', '');
             return;
         }
 
-        var $topMenuDropdown = $topNav.find('#top-menu-sub').show().find('#top-menu-sub-dropdown');
+        $('#top-menu-sub').show();
+        var $topMenuDropdown = $('#top-menu-sub-dropdown');
 
         while (isOverflow() && moveNextItemToDropDown($topMenuDropdown)) {}
 
         $topBarSecond.css('overflow', '');
         $('#top-menu-sub').find('.dropdown-toggle').dropdown();
-
     };
 
     var moveNextItemToDropDown = function($topMenuDropdown)
@@ -54,3 +56,4 @@ humhub.module('ui.topNavigation', function (module, require, $) {
         sortOrder: 100,
     });
 });
+


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [x] Code style update
- [x ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

Rational:
Humhub is often viewed on a table or phone. Switching between portrait en landscape views is common on this devices.
The menu in Humhub will shrink, but not grow. Switching to a different view-mode, Humhub will stay in the shortest view mode, that is a menu with a pull-down.
This commit resets the menu pull-down after a resize, which gives a much better user experience. The effect is that the menu growth as well.

The extra 3 lines in the on resize function are simple and only depend on the view ids.

Extra changes are:
- Do not find ids, just select them.
- Bring the reset in the resize event.
- Do not chain different ids and classes.
- Do not remove the next dropdown for edge-cases. This breaks the user experience on tablets.

