### PR TITLE
Update moduleCard.php

### DIFF
--- a/protected/humhub/modules/content/widgets/views/moduleCard.php
+++ b/protected/humhub/modules/content/widgets/views/moduleCard.php
@@ -23,7 +23,7 @@ use humhub\modules\content\widgets\ModuleActionButtons;
         ]) ?>
     </div>
     <div class="card-body">
-        <div class="card-title"><?= $module->getName() ?></div>
+        <div class="card-title"><?= $module->getContentContainerName($contentContainer) ?></div>
     </div>
     <?= ModuleActionButtons::widget([
         'module' => $module,


### PR DESCRIPTION
I think we should show the name of the `getContentContainerName` method as this widget is only for modules in a content container. In addition, this would allow to have the translated name for some modules such as Gallery (https://github.com/humhub-contrib/gallery/blob/master/Module.php#L108-L111) and others.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [X] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included
- [ ] Changelog was modified

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
