### PR TITLE
Update SortOrderField.php

### DIFF
--- a/protected/humhub/modules/ui/form/widgets/SortOrderField.php
+++ b/protected/humhub/modules/ui/form/widgets/SortOrderField.php
@@ -44,11 +44,15 @@ class SortOrderField extends InputWidget
      */
     public function run()
     {
-        $this->field->label(Yii::t('UiModule.form', 'Sort Order'));
-        $this->field->hint(Yii::t('UiModule.form', 'Values between 0 and 10000, the existing elements usually use steps of 100.'));
-
         $model = $this->model;
         $attribute = $this->attribute;
+
+        if (!$model->getAttributeLabel($attribute)) {
+            $this->field->label(Yii::t('UiModule.form', 'Sort Order'));
+        }
+        if (!$model->getAttributeHint($attribute)) {
+            $this->field->hint(Yii::t('UiModule.form', 'Values between 0 and 10000, the existing elements usually use steps of 100.'));
+        }
 
         if ($this->defaultValue !== null && !is_numeric($model->$attribute)) {
             $model->$attribute = $this->defaultValue;


### PR DESCRIPTION
Allow custom label or hint.
E.g. if an attributeLabels is defined in the model for the `fieldName` attribute, `$form->field($model, 'fieldName')->widget(SortOrderField::class)` should render the label defined in the model and not the default `'Sort Order'`.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included
- [ ] Changelog was modified

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
