### PR TITLE
Fix registration by link with SSO

### DIFF
--- a/protected/humhub/modules/user/views/registration/byLink.php
+++ b/protected/humhub/modules/user/views/registration/byLink.php
@@ -28,10 +28,6 @@ $this->pageTitle = Yii::t('UserModule.auth', 'Create Account');
                     </div>
                 <?php endif; ?>
 
-                <?php if (AuthChoice::hasClients()): ?>
-                    <?= AuthChoice::widget() ?>
-                <?php endif; ?>
-
                 <?php $form = ActiveForm::begin(['id' => 'registration-form']); ?>
                 <?= $form->field($invite, 'email')->input('email', ['id' => 'register-email', 'placeholder' => $invite->getAttributeLabel('email'), 'aria-label' => $invite->getAttributeLabel('email')])->label(false); ?>
                 <?php if ($invite->showCaptureInRegisterForm()) : ?>


### PR DESCRIPTION
About https://github.com/humhub/humhub/issues/5699

The bug was:
1. get an invitation link from a space
2. go to this URL
3. If the Humhub instance gives the possibility to connect with an SSO, a button was shown
4. If we click on this button, the account is created, but the email was not verified and the user was not added to the space where he was invited

This fix removes the SSO button. Now:
1. get an invitation link from a space
2. go to this URL
3. you need to enter your email
4. An email is sent, you need to click on the button to confirm that your email is valid
5. you can now register with the SSO
6. you are added to the space


**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included
- [ ] Changelog was modified

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
