### PR TITLE
Admin menu : set active entry by searching by ID instead of by URL

### DIFF
--- a/protected/humhub/modules/admin/views/layouts/setting.php
+++ b/protected/humhub/modules/admin/views/layouts/setting.php
@@ -1,5 +1,5 @@
 <?php
-\humhub\modules\admin\widgets\AdminMenu::markAsActive(['/admin/setting']);
+\humhub\modules\admin\widgets\AdminMenu::markAsActive('settings');
 ?>
 
 <?php $this->beginContent('@admin/views/layouts/main.php') ?>

--- a/protected/humhub/modules/admin/views/layouts/space.php
+++ b/protected/humhub/modules/admin/views/layouts/space.php
@@ -1,5 +1,5 @@
 <?php
-\humhub\modules\admin\widgets\AdminMenu::markAsActive('space');
+\humhub\modules\admin\widgets\AdminMenu::markAsActive('spaces');
 ?>
 
 <?php $this->beginContent('@admin/views/layouts/main.php') ?>

--- a/protected/humhub/modules/admin/views/layouts/space.php
+++ b/protected/humhub/modules/admin/views/layouts/space.php
@@ -1,5 +1,5 @@
 <?php
-\humhub\modules\admin\widgets\AdminMenu::markAsActive(['/admin/space']);
+\humhub\modules\admin\widgets\AdminMenu::markAsActive('space');
 ?>
 
 <?php $this->beginContent('@admin/views/layouts/main.php') ?>


### PR DESCRIPTION
In the admin layouts, for the Spaces and Settings menu entries of the main Admin menu, the related menu entry is marked as active.
The entry is searched by URL.
I suggest to search it by ID (see [here](https://github.com/humhub/humhub/blob/develop/protected/humhub/modules/admin/widgets/AdminMenu.php#L82)).

For Humhub, while URL are not changed, this PR won't change anything.
But it would be useful for modules, if the URL is changed.

Thanks!

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included
- [ ] Changelog was modified

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
