### PR TITLE
Fix Date and Datetime profile field type with null values on PHP 8.1+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ HumHub Changelog
 - Fix #6142: Fix saving empty values in admin settings
 - Fix #6145: Fix duplicate people cards on sort
 - Fix #6152: Avoid duplicate container(Space/User) tags on save
+- Fix #6182: Fix Date and Datetime profile field type with null values on PHP 8.1+
 
 1.13.1 (January 25, 2023)
 -------------------------

--- a/protected/humhub/modules/user/models/fieldtype/Date.php
+++ b/protected/humhub/modules/user/models/fieldtype/Date.php
@@ -78,7 +78,7 @@ class Date extends BaseType
     public function getUserValue(User $user, $raw = true): ?string
     {
         $internalName = $this->profileField->internal_name;
-        $date = \DateTime::createFromFormat('Y-m-d', $user->profile->$internalName,
+        $date = \DateTime::createFromFormat('Y-m-d', $user->profile->$internalName ?? '',
             new \DateTimeZone(Yii::$app->formatter->timeZone));
 
         if ($date === false)

--- a/protected/humhub/modules/user/models/fieldtype/DateTime.php
+++ b/protected/humhub/modules/user/models/fieldtype/DateTime.php
@@ -109,7 +109,8 @@ class DateTime extends BaseType
     public function getUserValue(User $user, $raw = true): ?string
     {
         $internalName = $this->profileField->internal_name;
-        $date = \DateTime::createFromFormat('Y-m-d H:i:s', $user->profile->$internalName,
+
+        $date = \DateTime::createFromFormat('Y-m-d H:i:s', $user->profile->$internalName ?? '',
             new \DateTimeZone(Yii::$app->formatter->timeZone));
 
         if ($date === false)


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

**The PR fulfills these requirements:**

- [ ] All tests are passing
- [ ] Changelog was modified

**Other information:**
For PHP 8.1+: Fix the "About" profile page when fields Date or Dateime is not filled.