### PR TITLE
Fix error when no modules set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ HumHub Changelog
 
 1.13.2 (Unreleased)
 -------------------------
+- Fix #6195: Fix ModuleManager disabling logging when now modules set
 - Fix #5965: Suppress log warning 'Invalid session auth key attempted for user'
 - Fix #6084: Automatic LDAP user registration broken when not all req. attributes provided
 - Fix #6104: Fix update user with not existing group

--- a/protected/humhub/components/ModuleManager.php
+++ b/protected/humhub/components/ModuleManager.php
@@ -70,9 +70,9 @@ class ModuleManager extends Component
      * List of all modules
      * This also contains installed but not enabled modules.
      *
-     * @param array $config moduleId-class pairs
+     * @param array $modules moduleId-class pairs
      */
-    protected $modules;
+    protected $modules = [];
 
     /**
      * List of all enabled module ids


### PR DESCRIPTION
https://docs.humhub.org/docs/admin/requirements lists php 7.4 as minimum requirement. Hence, the array properties should actually be arrays.

This caused log targets to be disabled due to the `ModuleManager::getModules()` throwing an error when `ModuleManager::$modules` would be null.


**What kind of change does this PR introduce?**

- Bugfix

**Does this PR introduce a breaking change?** (check one)

- No, as there is no class that extends `ModuleManager`. Otherwise, the type `array` could be left away but just initializing the `$modules = []`


Do you want me to create an issue for this and adding a changelog entry?