### PR TITLE
Use class names for default logging targets in default common config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 HumHub Changelog
 ================
 
+1.14.0 (Unreleased)
+-------------------------
+- Fix #6196: Use class names for default logging targets in default common config
+
 1.13.2 (March 27, 2023)
 -----------------------
 - Fix #5965: Suppress log warning 'Invalid session auth key attempted for user'

--- a/protected/humhub/config/common.php
+++ b/protected/humhub/config/common.php
@@ -54,7 +54,7 @@ $config = [
         'log' => [
             'traceLevel' => YII_DEBUG ? 3 : 0,
             'targets' => [
-                [
+                \yii\log\FileTarget::class => [
                     'class' => \yii\log\FileTarget::class,
                     'levels' => ['error', 'warning'],
                     'except' => [
@@ -64,7 +64,7 @@ $config = [
                     ],
                     'logVars' => ['_GET', '_SERVER'],
                 ],
-                [
+                \yii\log\DbTarget::class =>[
                     'class' => \yii\log\DbTarget::class,
                     'levels' => ['error', 'warning'],
                     'except' => [


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Bugfix
- Feature

**Does this PR introduce a breaking change?** (check one)

- No (unless someone would already have used the class name as a target key ...)

**The PR fulfills these requirements:**

- It's submitted to the `develop` branch
- Fix #6196
- [ ] All tests are passing
- No New/updated tests are included
- Changelog was modified
