### PR TITLE
Fix #6192: Where Group::getAdminGroupId() would sometimes return int, sometimes string

### DIFF
--- a/CHANGELOG-DEV.md
+++ b/CHANGELOG-DEV.md
@@ -3,6 +3,7 @@ HumHub Changelog
 
 1.15.0 (Unreleased)
 -------------------
+- Fix #6192: Where Group::getAdminGroupId() would sometimes return int, sometimes string
 - Enh #6260: Improve migration class
 - Fix #6199: Module manager Add types to properties
 - Enh #6236: Logging: Show log entries from migrations with category migration

--- a/protected/humhub/modules/user/models/Group.php
+++ b/protected/humhub/modules/user/models/Group.php
@@ -231,10 +231,10 @@ class Group extends ActiveRecord
         return self::findOne(['is_admin_group' => '1']);
     }
 
-    public static function getAdminGroupId()
+    public static function getAdminGroupId(): int
     {
         $adminGroupId = Yii::$app->getModule('user')->settings->get('group.adminGroupId');
-        if ($adminGroupId == null) {
+        if ($adminGroupId === null) {
             $adminGroupId = self::getAdminGroup()->id;
             Yii::$app->getModule('user')->settings->set('group.adminGroupId', $adminGroupId);
         }

--- a/protected/humhub/modules/user/tests/codeception/unit/models/GroupTest.php
+++ b/protected/humhub/modules/user/tests/codeception/unit/models/GroupTest.php
@@ -73,7 +73,10 @@ class GroupTest extends HumHubDbTestCase
     public function testReturnAdminGroupId()
     {
         $group = Group::findOne(['name' => 'Administrator']);
-        static::assertEquals($group->id, Group::getAdminGroupId());
+        // check for the uncached value
+        static::assertSame($group->id, Group::getAdminGroupId());
+        // now check again for the cached value
+        static::assertSame($group->id, Group::getAdminGroupId());
     }
 
     public function testCheckIfGroupHasManager()


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Bugfix
- Refactor

**Does this PR introduce a breaking change?**

- Yes, potentially for external module developers who extended `\humhub\modules\user\models\Group`
- No for this repository

**The PR fulfills these requirements:**

- It's submitted to the `develop` branch
- Fix #6192 
- [ ] All tests are passing
- New/updated tests are included
- Changelog was modified

