### PR TITLE
Fix event trigger for `Content::EVENT_STATE_CHANGED`; Implement new `ContentActiveRecord->afterStateChange()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ HumHub Changelog
 1.14.1 (Unreleased)
 -------------------
 - Fix #6251: Emulate execution on `readable()` content 
+- Fix #6252: Fix event trigger for `Content::EVENT_STATE_CHANGED`
 
 1.14.0 (April 20, 2023)
 -----------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ HumHub Changelog
 1.14.1 (Unreleased)
 -------------------
 - Fix #6251: Emulate execution on `readable()` content 
-- Fix #6252: Fix event trigger for `Content::EVENT_STATE_CHANGED`
+- Enh #6252: Implement new method to handle changing of content active record state
 
 1.14.0 (April 20, 2023)
 -----------------------

--- a/protected/humhub/modules/content/components/ContentActiveRecord.php
+++ b/protected/humhub/modules/content/components/ContentActiveRecord.php
@@ -455,6 +455,16 @@ class ContentActiveRecord extends ActiveRecord implements ContentOwner, Movable,
     }
 
     /**
+     * This method is called after state of the Content of this Active Record has been changed
+     *
+     * @param int|null $newState
+     * @param int|null $previousState
+     */
+    public function afterStateChange(?int $newState, ?int $previousState): void
+    {
+    }
+
+    /**
      * Returns the class used in the polymorphic content relation.
      * By default this function will return the static class.
      *

--- a/protected/humhub/modules/content/models/Content.php
+++ b/protected/humhub/modules/content/models/Content.php
@@ -244,11 +244,13 @@ class Content extends ActiveRecord implements Movable, ContentOwner, SoftDeletab
                 $changedAttributes['state'] == Content::STATE_DRAFT
             )) {
             $this->processNewContent();
+        }
 
+        if ($insert || array_key_exists('state', $changedAttributes)) {
             $this->trigger(self::EVENT_STATE_CHANGED, new ContentStateEvent([
                 'content' => $this,
                 'newState' => $this->state,
-                'previousState' => (isset($changedAttributes['state'])) ? $changedAttributes['state'] : null,
+                'previousState' => $changedAttributes['state'] ?? null
             ]));
         }
 

--- a/protected/humhub/modules/content/models/Content.php
+++ b/protected/humhub/modules/content/models/Content.php
@@ -247,11 +247,17 @@ class Content extends ActiveRecord implements Movable, ContentOwner, SoftDeletab
         }
 
         if ($insert || array_key_exists('state', $changedAttributes)) {
+            $previousState = $changedAttributes['state'] ?? null;
             $this->trigger(self::EVENT_STATE_CHANGED, new ContentStateEvent([
                 'content' => $this,
                 'newState' => $this->state,
-                'previousState' => $changedAttributes['state'] ?? null
+                'previousState' => $previousState
             ]));
+
+            $model = $this->getPolymorphicRelation();
+            if ($model instanceof ContentActiveRecord) {
+                $model->afterStateChange($this->state, $previousState);
+            }
         }
 
         if ($this->state === static::STATE_PUBLISHED) {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

**The PR fulfills these requirements:**

- [ ] All tests are passing
- [ ] Changelog was modified

**Other information:**
Issue: https://github.com/humhub/humhub-internal/issues/31#issuecomment-1519610001:

> I see we already have the event `Content::EVENT_STATE_CHANGED` here https://github.com/humhub/humhub/blob/master/protected/humhub/modules/content/models/Content.php#L248-L252, but I think the condition for calling of this event is not correct, because we should call it on every changing of a state and not only when a record is published as it works now.

https://github.com/humhub/humhub-internal/issues/31#issuecomment-1520049130:

> Then let go with the method `afterStateChange(int $newState, int $previousState): void` and keep the existing `Content::EVENT_STATE_CHANGED` to allow other modules to observe state changes.