### PR TITLE
Fix error when config `defaultReloadableScripts` is not array

### DIFF
--- a/protected/humhub/modules/admin/models/forms/CacheSettingsForm.php
+++ b/protected/humhub/modules/admin/models/forms/CacheSettingsForm.php
@@ -111,7 +111,10 @@ class CacheSettingsForm extends Model
         /* @var $module Module */
         $module = Yii::$app->getModule('admin');
         $instance = new static();
-        $urls = array_merge($instance->getReloadableScriptsAsArray(), $module->defaultReloadableScripts);
+        $urls = $instance->getReloadableScriptsAsArray();
+        if (is_array($module->defaultReloadableScripts)) {
+            $urls = array_merge($urls, $module->defaultReloadableScripts);
+        }
         $event = new FetchReloadableScriptsEvent(['urls' => $urls]);
         $instance->trigger(static::EVENT_FETCH_RELOADABLE_SCRIPTS, $event);
         return $event->urls;


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

**The PR fulfills these requirements:**

- [ ] All tests are passing
- [ ] Changelog was modified

**Other information:**
Issue: https://github.com/humhub/humhub-internal/issues/46