### PR TITLE
Fix get activities on content or content addon deletion when a differ…

### DIFF
--- a/protected/humhub/modules/activity/helpers/ActivityHelper.php
+++ b/protected/humhub/modules/activity/helpers/ActivityHelper.php
@@ -3,6 +3,7 @@
 namespace humhub\modules\activity\helpers;
 
 use humhub\components\ActiveRecord;
+use humhub\components\behaviors\PolymorphicRelation;
 use humhub\modules\activity\models\Activity;
 use Yii;
 use yii\db\ActiveQuery;
@@ -25,9 +26,7 @@ class ActivityHelper
 
         return Activity::find()->where([
             'object_id' => $pk,
-            'object_model' => method_exists($record, 'getObjectModel') ?
-                $record::getObjectModel() :
-                get_class($record),
+            'object_model' => PolymorphicRelation::getObjectModel($record),
         ]);
     }
 

--- a/protected/humhub/modules/activity/helpers/ActivityHelper.php
+++ b/protected/humhub/modules/activity/helpers/ActivityHelper.php
@@ -25,7 +25,9 @@ class ActivityHelper
 
         return Activity::find()->where([
             'object_id' => $pk,
-            'object_model' => get_class($record)
+            'object_model' => method_exists($record, 'getObjectModel') ?
+                $record::getObjectModel() :
+                get_class($record),
         ]);
     }
 


### PR DESCRIPTION
Complement to https://github.com/humhub/humhub/issues/6169
Fix get activities on content or content addon deletion when a different class name is defined in `getObjectModel()`.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included
- [ ] Changelog was modified

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
