### PR TITLE
Avoid double call of `afterSave` on creating of a published content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ HumHub Changelog
 1.14.3 (Unreleased)
 ----------------------
 - Fix #6345: Fix updating of post on wall stream
-- Fix #6351: Error when config `defaultReloadableScripts` is not array 
+- Fix #6351: Error when config `defaultReloadableScripts` is not array
+- Fix #6359: Avoid double call of `afterSave` on creating of a published content
 
 1.14.2 (May 22, 2023)
 ----------------------

--- a/protected/humhub/modules/content/models/Content.php
+++ b/protected/humhub/modules/content/models/Content.php
@@ -241,9 +241,10 @@ class Content extends ActiveRecord implements Movable, ContentOwner, SoftDeletab
             if ($this->getStateService()->isPublished()) {
                 // Run process for new content(Send notifications) only after publishing the Content
                 $this->processNewContent();
-                // Also run process for parent object in order to send notifications like mentioning users
-                if ($model instanceof ActiveRecord) {
-                    $model->afterSave($insert, $changedAttributes);
+                // Also run process for parent object in order to send notifications like mentioning users,
+                // for case when it was not published on creating
+                if (!$insert && $model instanceof ActiveRecord) {
+                    $model->afterSave(false, []);
                 }
             }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

**The PR fulfills these requirements:**

- [ ] All tests are passing
- [x] Changelog was modified

**Other information:**
Fix issue https://github.com/humhub/humhub/issues/6344 that was created in the PR https://github.com/humhub/humhub/pull/6288 here: https://github.com/humhub/humhub/commit/6d65da3#diff-b3de8a7bb84547e2de7081f31795f491fb051a7df7042d02d991041ee0235a51R245-R247.