### PR TITLE
Enh #6363: Add an event in the NotificationManager to allow removing …

### DIFF
--- a/CHANGELOG-DEV.md
+++ b/CHANGELOG-DEV.md
@@ -15,7 +15,7 @@ HumHub Changelog
 - Enh #6236: Logging: Show log entries from migrations with category migration
 - Fix #6216: Spaces icon in admin menu
 - Fix #6229: Bug on saving forms: Zend OPcache API is restricted by "restrict_api"
-- Enh #6240: Add ability to set showAtDashboard in SpaceMembership::addMember method 
+- Enh #6240: Add ability to set showAtDashboard in SpaceMembership::addMember method
 - Enh #6164: Invitation by link: when registering within an SSO, the email should only be requested on the service provider
 - Enh #6240: Add ability to set showAtDashboard in SpaceMembership::addMember method
 - Enh #5668: Allow Admin to sort the Spaces in a custom order
@@ -33,7 +33,7 @@ HumHub Changelog
 - Enh #2590: Possibility to add a dropdown button to upload audio, image or video file type
 - Enh #6298: Move the "Write a new comment" field style to a generic field that can be used by other modules
 - Enh #6310: Module information is localized with `docs/uk/README.md` or `README.uk.md`.
-- Enh #6311: Added {cols, rows} to textarea() control. 
+- Enh #6311: Added {cols, rows} to textarea() control.
 - Enh #6304: Update button title on creating of not published content
 - Enh #6319: Duplicate File Converter Logs
 - Fix #5962: Make top menu shrink and grow on resize window
@@ -41,7 +41,8 @@ HumHub Changelog
 - Enh #6327: PHP error when calling `Password::setPassword` on unsaved User records
 - Enh #2: Store Default Markdown Editor Mode
 - Enh #6355: Fix limit results in People: Country Filter
-- Enh #6327: PHP error when calling `Password::setPassword` on unsaved User records 
+- Enh #6327: PHP error when calling `Password::setPassword` on unsaved User records
 - Enh #6356: Added SqlDataProvider support for `ImageColumn` and `DisplayNameColumn`
 - Enh #6169: Replace deprecated `yii\base\BaseObject::className()`
-- Enh #6361: Use `LongRunningActiveJob` on more active jobs 
+- Enh #6361: Use `LongRunningActiveJob` on more active jobs
+- Enh #6363: Add an event in the NotificationManager to allow removing some notifications categories in the settings

--- a/protected/humhub/modules/notification/components/NotificationManager.php
+++ b/protected/humhub/modules/notification/components/NotificationManager.php
@@ -8,6 +8,8 @@
 
 namespace humhub\modules\notification\components;
 
+use humhub\components\Event;
+use humhub\components\Module;
 use humhub\modules\content\components\ContentContainerActiveRecord;
 use humhub\modules\content\models\Content;
 use humhub\modules\content\models\ContentContainerSetting;
@@ -17,7 +19,6 @@ use humhub\modules\space\models\Space;
 use humhub\modules\user\components\ActiveQueryUser;
 use humhub\modules\user\models\Follow;
 use humhub\modules\user\models\User;
-use humhub\components\Module;
 use Yii;
 
 /**
@@ -30,6 +31,10 @@ use Yii;
  */
 class NotificationManager
 {
+    /**
+     * Sends the notifications categories in the results
+     */
+    public const EVENT_SEARCH_MODULE_NOTIFICATIONS = 'searchModuleNotifications';
 
     /**
      *
@@ -70,8 +75,7 @@ class NotificationManager
 
         $processed = [];
         /** @var User $user */
-        foreach ($userQuery->each() as $user)
-        {
+        foreach ($userQuery->each() as $user) {
             if (in_array($user->id, $processed)) {
                 continue;
             }
@@ -97,7 +101,7 @@ class NotificationManager
                     $target->send($notification, $user);
                 }
             } else {
-                Yii::debug('Could not store notification '.get_class($notification). ' for user '. $user->id);
+                Yii::debug('Could not store notification ' . get_class($notification) . ' for user ' . $user->id);
             }
 
             $processed[] = $user->id;
@@ -131,7 +135,7 @@ class NotificationManager
             $this->_targets = [];
             foreach ($this->targets as $targetClass => $targetConfig) {
                 $targetConfig = is_array($targetConfig) ? $targetConfig : [];
-                if(!isset($targetConfig['class'])) { // Allow class overwrites
+                if (!isset($targetConfig['class'])) { // Allow class overwrites
                     $targetConfig['class'] = $targetClass;
                 }
                 $this->_targets[] = Yii::createObject($targetConfig);
@@ -277,7 +281,7 @@ class NotificationManager
 
         $result = array_merge($memberSpaces, $followSpaces);
 
-        if($this->isUntouchedSettings($user)) {
+        if ($this->isUntouchedSettings($user)) {
             $result = array_merge($result, Space::findAll(['guid' => Yii::$app->getModule('notification')->settings->getSerialized('sendNotificationSpaces')]));
         }
 
@@ -461,7 +465,7 @@ class NotificationManager
 
     /**
      * Searches for all Notifications exported by modules.
-     * @return type
+     * @return array
      * @throws \yii\base\Exception
      */
     protected function searchModuleNotifications()
@@ -472,7 +476,11 @@ class NotificationManager
                 $result = array_merge($result, $this->createNotifications($module->getNotifications()));
             }
         }
-        return $result;
+
+        $evt = new Event(['result' => $result]);
+        Event::trigger($this, static::EVENT_SEARCH_MODULE_NOTIFICATIONS, $evt);
+
+        return $evt->result;
     }
 
     protected function createNotifications($notificationClasses)


### PR DESCRIPTION
Issue: https://github.com/humhub/humhub/issues/6363
Enh #6363: Add an event in the NotificationManager to allow removing some notifications categories in the settings

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [x] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included
- [x] Changelog was modified

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
