### PR TITLE
Update wording of password recovery

### DIFF
--- a/protected/humhub/modules/user/models/forms/AccountRecoverPassword.php
+++ b/protected/humhub/modules/user/models/forms/AccountRecoverPassword.php
@@ -69,7 +69,7 @@ class AccountRecoverPassword extends Model
         // This may not possible on e.g. LDAP accounts.
         $passwordAuth = new Password();
         if ($user->auth_mode !== $passwordAuth->getId()) {
-            $this->addError($attribute, Yii::t('UserModule.account', Yii::t('UserModule.account', 'Password recovery is not possible on your account type!')));
+            $this->addError($attribute, Yii::t('UserModule.account', Yii::t('UserModule.account', 'Password recovery disabled. Please contact your system administrator.')));
         }
     }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Wording

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] All tests are passing
- [ ] Changelog was modified

**Other information:**
Issue: https://github.com/humhub/wording/issues/128