### PR TITLE
Fix log.fata in frontend logging

### DIFF
--- a/CHANGELOG-DEV.md
+++ b/CHANGELOG-DEV.md
@@ -3,6 +3,7 @@ HumHub Changelog
 
 1.15.0 (Unreleased)
 -------------------
+- Fix #6423: log.fata in frontend logging is redirected to log.fatal, which did not work
 - Fix #6220: User Soft Delete doesn't remove third party auth references
 - Enh #6270: Add tests for SettingsManager
 - Enh #6272: Always return integer from settings, if value can be converted

--- a/static/js/humhub/humhub.log.js
+++ b/static/js/humhub/humhub.log.js
@@ -213,6 +213,12 @@ humhub.module('log', function (module, require, $) {
         module.getRootLogger().fatal(msg, error, setStatus);
     };
 
+    var fata = function (msg, error, setStatus) {
+        let logger = module.getRootLogger();
+        logger.warn("log.fata is deprecated since 1.15. Please correct to log.fatal!");
+        logger.fatal(msg, error, setStatus);
+    };
+
     module.export({
         init: init,
         sortOrder: 100,
@@ -225,7 +231,8 @@ humhub.module('log', function (module, require, $) {
         success: success,
         warn: warn,
         error: error,
-        fata: fatal,
+        fatal: fatal,
+        fata: fata,
         TRACE_TRACE: TRACE_TRACE,
         TRACE_DEBUG: TRACE_DEBUG,
         TRACE_INFO: TRACE_INFO,


### PR DESCRIPTION
Fix #6423 `log.fata` in frontend logging is redirected to `log.fatal`, which did not work.

**What kind of change does this PR introduce?** (check at least one)

- Bugfix

**Does this PR introduce a breaking change?** (check one)

- No

**The PR fulfills these requirements:**

- It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- All tests are passing
- No new/updated tests are included
- Changelog was modified

