### PR TITLE
Fix default dropdown select2 options

### DIFF
--- a/CHANGELOG-DEV.md
+++ b/CHANGELOG-DEV.md
@@ -76,3 +76,4 @@ HumHub Changelog
 - Fix #6418: Fix login from modal window
 - Fix #6415: Fix caching keys on space directory
 - Fix #6424: Fix width of select2 dropdown inputs
+- Fix #6425: Fix default dropdown select2 options

--- a/protected/humhub/libs/Html.php
+++ b/protected/humhub/libs/Html.php
@@ -241,6 +241,12 @@ class Html extends \yii\bootstrap\Html
             $minimumResultsForSearch++;
         }
 
+        if ($minimumResultsForSearch > 0 && isset($options['data-ui-select2-allow-new'])) {
+            // Don't use this limit when new item is allowed for adding,
+            // otherwise a new item input is hidden by Select2 JS code
+            $minimumResultsForSearch = 0;
+        }
+
         return ArrayHelper::merge([
             'data-ui-select2' => true,
             'style' => 'width:100%',


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] All tests are passing
- [x] Changelog was modified

**Other information:**
Detected during checking tests here https://github.com/humhub/team_tasks/issues/284#issuecomment-1627735453.

Missed input for add new task list on creating a Task in the module "Tasks":
![missed_input](https://github.com/humhub/humhub/assets/6995524/0c528af1-31c4-49b3-a28f-275179460d53)

Expected input:
![expected](https://github.com/humhub/humhub/assets/6995524/eee3107c-264e-41b6-b0c2-f003a603dbd3) 