### PR TITLE
[Enh] Introduce Archiveable, Deletable, Editable, Readable, & Viewable Interfaces

### DIFF
--- a/CHANGELOG-DEV.md
+++ b/CHANGELOG-DEV.md
@@ -5,6 +5,7 @@ HumHub Changelog
 -------------------
 - Fix #6461: Test server support to serve web module's `/manifest.json`, `/sw.js`, & `/offline.pwa.html`
 - Enh #6460: Test server output: print application requests
+- Enh #6451: Introduce Archiveable, Deletable, Editable, Readable, & Viewable Interfaces
 - Fix #6423: log.fata in frontend logging is redirected to log.fatal, which did not work
 - Fix #6220: User Soft Delete doesn't remove third party auth references
 - Enh #6270: Add tests for SettingsManager

--- a/MIGRATE-DEV.md
+++ b/MIGRATE-DEV.md
@@ -43,3 +43,15 @@ Version 1.15 (Unreleased)
 - `humhub\widgets\MarkdownFieldModals`
 - `humhub\modules\ui\form\widgets\Markdown`
 - 
+
+Version 1.16 (Unreleased)
+-------------------------
+
+### Deprecations
+- `\humhub\modules\content\components\ContentAddonActiveRecord::canWrite()`
+
+### Type restrictions
+- `\humhub\modules\comment\models\Comment` on `canDelete()`
+- `\humhub\modules\content\components\ContentAddonActiveRecord` on `canDelete()`, `canRead()`, `canWrite()`, `canEdit()`
+- `\humhub\modules\content\models\Content` on `canEdit()`, `canView()`
+- `\humhub\modules\file\models\File` on `canRead()`, `canDelete()`

--- a/protected/humhub/interfaces/ArchiveableInterface.php
+++ b/protected/humhub/interfaces/ArchiveableInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * @link      https://www.humhub.org/
+ * @copyright Copyright (c) 2023 HumHub GmbH & Co. KG
+ * @license   https://www.humhub.com/licences
+ */
+
+namespace humhub\interfaces;
+
+use humhub\modules\user\models\User;
+
+interface ArchiveableInterface
+{
+    /**
+     * Checks if the given user can edit/create this element.
+     *
+     * @param User|integer $user user instance or user id
+     *
+     * @return bool can edit/create this element
+     * @since 1.15
+     */
+    public function canArchive($user = null): bool;
+
+    public function archive(): bool;
+
+    public function unarchive(): bool;
+}

--- a/protected/humhub/interfaces/DeletableInterface.php
+++ b/protected/humhub/interfaces/DeletableInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * @link      https://www.humhub.org/
+ * @copyright Copyright (c) 2023 HumHub GmbH & Co. KG
+ * @license   https://www.humhub.com/licences
+ */
+
+namespace humhub\interfaces;
+
+interface DeletableInterface
+{
+    /**
+     * Checks if given item can be deleted.
+     */
+    public function canDelete($userId = null);
+
+    public function delete();
+}

--- a/protected/humhub/interfaces/EditableInterface.php
+++ b/protected/humhub/interfaces/EditableInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * @link      https://www.humhub.org/
+ * @copyright Copyright (c) 2023 HumHub GmbH & Co. KG
+ * @license   https://www.humhub.com/licences
+ */
+
+namespace humhub\interfaces;
+
+use humhub\modules\user\models\User;
+use Throwable;
+
+interface EditableInterface
+{
+
+    /**
+     * Checks if the given user can edit/create this element.
+     *
+     * @param User|integer $user user instance or user id
+     *
+     * @return bool can edit/create this element
+     * @since 1.15
+     */
+    public function canEdit($user = null): bool;
+
+}

--- a/protected/humhub/interfaces/ReadableInterface.php
+++ b/protected/humhub/interfaces/ReadableInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * @link      https://www.humhub.org/
+ * @copyright Copyright (c) 2023 HumHub GmbH & Co. KG
+ * @license   https://www.humhub.com/licences
+ */
+
+namespace humhub\interfaces;
+
+use humhub\modules\user\models\User;
+
+interface ReadableInterface
+{
+    /**
+     * Checks if given element can be read.
+     *
+     * @param string|User $userId
+     *
+     * @return bool
+     */
+    public function canRead($userId = ""): bool;
+}

--- a/protected/humhub/interfaces/ViewableInterface.php
+++ b/protected/humhub/interfaces/ViewableInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * @link      https://www.humhub.org/
+ * @copyright Copyright (c) 2023 HumHub GmbH & Co. KG
+ * @license   https://www.humhub.com/licences
+ */
+
+namespace humhub\interfaces;
+
+use humhub\modules\user\models\User;
+use Throwable;
+
+interface ViewableInterface
+{
+    /**
+     * Checks if user can view this element.
+     *
+     * @param User|integer $user
+     *
+     * @return boolean can view this element
+     * @throws Throwable
+     * @since 1.15
+     */
+    public function canView($user = null);
+
+}

--- a/protected/humhub/modules/comment/models/Comment.php
+++ b/protected/humhub/modules/comment/models/Comment.php
@@ -343,7 +343,7 @@ class Comment extends ContentAddonActiveRecord
         return $this->message;
     }
 
-    public function canDelete($userId = '')
+    public function canDelete($userId = ''): bool
     {
 
         if ($userId == '') {

--- a/protected/humhub/modules/content/components/ContentAddonActiveRecord.php
+++ b/protected/humhub/modules/content/components/ContentAddonActiveRecord.php
@@ -9,6 +9,9 @@
 namespace humhub\modules\content\components;
 
 use humhub\components\ActiveRecord;
+use humhub\interfaces\DeletableInterface;
+use humhub\interfaces\EditableInterface;
+use humhub\interfaces\ReadableInterface;
 use humhub\modules\content\interfaces\ContentOwner;
 use humhub\modules\content\models\Content;
 use humhub\modules\content\Module;
@@ -36,9 +39,8 @@ use yii\base\Exception;
  * @package humhub.components
  * @since 0.5
  */
-class ContentAddonActiveRecord extends ActiveRecord implements ContentOwner
+class ContentAddonActiveRecord extends ActiveRecord implements ContentOwner, ReadableInterface, EditableInterface, DeletableInterface
 {
-
     /**
      * @var boolean also update underlying contents last update stream sorting
      */
@@ -136,9 +138,10 @@ class ContentAddonActiveRecord extends ActiveRecord implements ContentOwner
      * Checks if the given / or current user can delete this content.
      * Currently only the creator can remove.
      *
+     * @param null $userId
      * @return boolean
      */
-    public function canDelete()
+    public function canDelete($userId = null): bool
     {
         if ($this->created_by == Yii::$app->user->id) {
             return true;
@@ -150,11 +153,12 @@ class ContentAddonActiveRecord extends ActiveRecord implements ContentOwner
     /**
      * Check if current user can read this object
      *
+     * @param string $userId
      * @return boolean
      */
-    public function canRead()
+    public function canRead($userId = ""): bool
     {
-        return $this->content->canView();
+        return $this->content->canView($userId);
     }
 
     /**
@@ -162,24 +166,27 @@ class ContentAddonActiveRecord extends ActiveRecord implements ContentOwner
      *
      * @return boolean
      * @deprecated since 1.4
+     * @see static::canEdit()
      */
-    public function canWrite()
+    public function canWrite($userId = "")
     {
-        return $this->canEdit();
+        return $this->canEdit($userId);
     }
 
     /**
      * Checks if this record can be edited
      *
-     * @param User|null $user the user
+     * @param User|int|null $user the user
      * @return boolean
      * @since 1.4
      */
-    public function canEdit(User $user = null)
+    public function canEdit($user = null): bool
     {
         if ($user === null && Yii::$app->user->isGuest) {
             return false;
-        } elseif ($user === null) {
+        }
+
+        if ($user === null) {
             /** @var User $user */
             try {
                 $user = Yii::$app->user->getIdentity();
@@ -189,7 +196,11 @@ class ContentAddonActiveRecord extends ActiveRecord implements ContentOwner
             }
         }
 
-        if ($this->created_by == $user->id) {
+        if (!$user instanceof User && !($user = User::findOne(['id' => $user]))) {
+            return false;
+        }
+
+        if ($this->created_by === $user->id) {
             return true;
         }
 

--- a/protected/humhub/modules/file/models/File.php
+++ b/protected/humhub/modules/file/models/File.php
@@ -11,6 +11,7 @@ namespace humhub\modules\file\models;
 use humhub\components\behaviors\GUID;
 use humhub\components\behaviors\PolymorphicRelation;
 use humhub\components\ActiveRecord;
+use humhub\interfaces\ViewableInterface;
 use humhub\modules\content\components\ContentActiveRecord;
 use humhub\modules\content\components\ContentAddonActiveRecord;
 use humhub\modules\user\models\User;
@@ -52,7 +53,7 @@ use yii\web\UploadedFile;
  *
  * @since 0.5
  */
-class File extends FileCompat
+class File extends FileCompat implements ViewableInterface
 {
     /**
      * @event Event that is triggered after a new file content has been stored.
@@ -191,10 +192,15 @@ class File extends FileCompat
      *
      * If the file is not an instance of HActiveRecordContent or HActiveRecordContentAddon
      * the file is readable for all.
+     *
      * @param string|User $userId
+     *
      * @return bool
+     * @throws IntegrityException
+     * @throws Throwable
+     * @throws \yii\base\Exception
      */
-    public function canRead($userId = "")
+    public function canRead($userId = ""): bool
     {
         $object = $this->getPolymorphicRelation();
         if ($object !== null && ($object instanceof ContentActiveRecord || $object instanceof ContentAddonActiveRecord)) {
@@ -204,13 +210,26 @@ class File extends FileCompat
         return true;
     }
 
+    public function canView($user = null): bool
+    {
+        return $this->canRead($user);
+    }
+
     /**
-     * Checks if given file can deleted.
+     * Checks if given file can be deleted.
      *
      * If the file is not an instance of ContentActiveRecord or ContentAddonActiveRecord
      * the file is readable for all unless there is method canEdit or canDelete implemented.
+     *
+     * @param null $userId
+     *
+     * @return bool
+     * @throws IntegrityException
+     * @throws InvalidConfigException
+     * @throws Throwable
+     * @throws \yii\base\Exception
      */
-    public function canDelete($userId = null)
+    public function canDelete($userId = null): bool
     {
         $object = $this->getPolymorphicRelation();
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Feature
- Refactor

The PR is an attempt to standardize a number of functions to get information about a specific record as [been suggested in the code](https://github.com/metaworx/humhub/blob/1b0700deedde89b5dd3faed4920830f796834c2e/protected/humhub/modules/content/models/Content.php#L898).

- `canArchive($user = null): bool`
- `canEdit($user = null): bool`
- `canDelete($user = null): bool`
- `canRead($user = null): bool`
- `canView($user = null): bool`

A prerequisite for PR #6408

**Does this PR introduce a breaking change?** (check one)

- Potentially. Not in the core. But yes, modules which derive from affected classes and do implement one of the above methods, need to adhere to the new interface


**The PR fulfills these requirements:**

- It's submitted to the `develop` branch
- [x] All tests are passing
- No new/updated tests are included
- [ ] Changelog was modified
