### PR TITLE
Fix regression with Membership cache

### DIFF
--- a/CHANGELOG-DEV.md
+++ b/CHANGELOG-DEV.md
@@ -10,6 +10,7 @@ HumHub Changelog
 - Fix #112: Reorder Table Rows
 - Fix #6476: Fix module disabling in queue
 - Enh #6469: Implement conditions for `fixed-settings` in config
+- Fix #6457: Regression with membership cache. Also move cache to `Membership::findMembership`.
 
 1.15.0-beta.1 (July 31, 2023)
 -----------------------------

--- a/protected/humhub/modules/live/tests/codeception/unit/LegitimationTest.php
+++ b/protected/humhub/modules/live/tests/codeception/unit/LegitimationTest.php
@@ -42,7 +42,10 @@ class LegitimationTest extends HumHubDbTestCase
         $module = Yii::$app->getModule('live');
         $user = User::findOne(['id' => 1]);
         $space1 = Space::findOne(['id' => 1]);
-        $space1->addMember($user->id);
+
+        static::assertTrue($space1->addMember($user->id));
+        static::assertInstanceOf(Membership::class, Membership::findOne(['user_id' => 1, 'space_id' => 1]));
+
         $legitimations = $module->getLegitimateContentContainerIds($user, false);
 
         static::assertCount(1, $legitimations[Content::VISIBILITY_OWNER]);

--- a/protected/humhub/modules/space/behaviors/SpaceModelMembership.php
+++ b/protected/humhub/modules/space/behaviors/SpaceModelMembership.php
@@ -208,6 +208,7 @@ class SpaceModelMembership extends Behavior
         if ($membership != null) {
             $membership->group_id = Space::USERGROUP_ADMIN;
             $membership->save();
+            Yii::$app->runtimeCache->delete(__CLASS__ . '::getMembership' . $userId . '-' . $this->owner->id);
             return true;
         }
 
@@ -305,6 +306,8 @@ class SpaceModelMembership extends Behavior
 
         $membership->save();
 
+        Yii::$app->runtimeCache->delete(__CLASS__ . '::getMembership' . $userId . '-' . $this->owner->id);
+
         ApprovalRequest::instance()->from($user)->about($this->owner)->withMessage($message)->sendBulk($this->getAdminsQuery());
     }
 
@@ -375,6 +378,8 @@ class SpaceModelMembership extends Behavior
         if (!$membership->save()) {
             throw new Exception('Could not save membership!' . print_r($membership->getErrors(), 1));
         }
+
+        Yii::$app->runtimeCache->delete(__CLASS__ . '::getMembership' . $userId . '-' . $this->owner->id);
 
         if ($sendInviteNotification) {
             $this->sendInviteNotification($userId, $originatorId);
@@ -474,6 +479,8 @@ class SpaceModelMembership extends Behavior
             return false;
         }
 
+        Yii::$app->runtimeCache->delete(__CLASS__ . '::getMembership' . $userId . '-' . $this->owner->id);
+
         MemberEvent::trigger(Membership::class, Membership::EVENT_MEMBER_ADDED, new MemberEvent([
             'space' => $this->owner, 'user' => $user
         ]));
@@ -541,6 +548,8 @@ class SpaceModelMembership extends Behavior
     private function handleRemoveMembershipEvent(Membership $membership, User $user)
     {
         unset($this->_memberships[$user->id]);
+
+        Yii::$app->runtimeCache->delete(__CLASS__ . '::getMembership' . $user->id . '-' . $this->owner->id);
 
         // Get rid of old notifications
         ApprovalRequest::instance()->from($user)->about($this->owner)->delete();

--- a/protected/humhub/modules/space/models/Membership.php
+++ b/protected/humhub/modules/space/models/Membership.php
@@ -62,11 +62,6 @@ class Membership extends ActiveRecord
     const USER_SPACES_CACHE_KEY = 'userSpaces_';
     const USER_SPACEIDS_CACHE_KEY = 'userSpaceIds_';
 
-    /**
-     * @var mixed|null
-     */
-    protected static array $membership_cache = [];
-
 
     /**
      * @inheritdoc
@@ -425,16 +420,11 @@ class Membership extends ActiveRecord
             throw new InvalidArgumentException("Argument #1 (\$user) must be a User object or user ID.");
         }
 
-        // make sure, the space has an entry
-        self::$membership_cache[$spaceId] ??= [];
-
-        return self::$membership_cache[$spaceId][$userId] ??= Yii::$app->runtimeCache->getOrSet(__CLASS__ . "_$spaceId-$userId", fn() => Membership::findOne(['user_id' => $userId, 'space_id' => $spaceId]));
+        return Yii::$app->runtimeCache->getOrSet(__CLASS__ . "_$spaceId-$userId", fn() => Membership::findOne(['user_id' => $userId, 'space_id' => $spaceId]));
     }
 
     public static function unsetCache(int $spaceId, int $userId)
     {
-        unset(self::$membership_cache[$spaceId][$userId]);
-
         Yii::$app->runtimeCache->delete(__CLASS__ . "_$spaceId-$userId");
         Yii::$app->cache->delete(Module::$legitimateCachePrefix . $userId);
     }

--- a/protected/humhub/modules/space/models/Membership.php
+++ b/protected/humhub/modules/space/models/Membership.php
@@ -10,6 +10,7 @@ namespace humhub\modules\space\models;
 
 use humhub\components\ActiveRecord;
 use humhub\modules\content\models\Content;
+use humhub\modules\live\Module;
 use humhub\modules\user\models\User;
 use InvalidArgumentException;
 use Yii;
@@ -435,5 +436,6 @@ class Membership extends ActiveRecord
         unset(self::$membership_cache[$spaceId][$userId]);
 
         Yii::$app->runtimeCache->delete(__CLASS__ . "_$spaceId-$userId");
+        Yii::$app->cache->delete(Module::$legitimateCachePrefix . $userId);
     }
 }

--- a/protected/humhub/modules/space/models/forms/InviteForm.php
+++ b/protected/humhub/modules/space/models/forms/InviteForm.php
@@ -136,10 +136,7 @@ class InviteForm extends Model
         // Allow users to perform this action if this is allowed by config file
         // Pre-check if user is member of the space in question
         if (Yii::$app->getModule('space')->membersCanAddWithoutInvite === true) {
-            $membership = Membership::findOne([
-                'space_id' => $this->space->id,
-                'user_id' => Yii::$app->user->identity->id,
-            ]);
+            $membership = Membership::findMembership($this->space->id, Yii::$app->user->identity->id);
 
             if ($membership && $membership->status == Membership::STATUS_MEMBER) {
                 return true;
@@ -216,13 +213,9 @@ class InviteForm extends Model
      */
     private function addUserToInviteList(User $user): bool
     {
-        $membership = Membership::findOne([
-            'space_id' => $this->space->id,
-            'user_id' => $user->id,
-            'status' => Membership::STATUS_MEMBER,
-        ]);
+        $membership = Membership::findMembership($this->space->id, $user->id);
 
-        if ($membership) {
+        if ($membership && (int)$membership->status === Membership::STATUS_MEMBER) {
             return false;
         }
 

--- a/protected/humhub/modules/space/modules/manage/controllers/MemberController.php
+++ b/protected/humhub/modules/space/modules/manage/controllers/MemberController.php
@@ -53,7 +53,7 @@ class MemberController extends Controller
         // User Group Change
         if (Yii::$app->request->post('dropDownColumnSubmit')) {
             Yii::$app->response->format = 'json';
-            $membership = Membership::findOne(['space_id' => $space->id, 'user_id' => Yii::$app->request->post('user_id')]);
+            $membership = Membership::findMembership($space->id, Yii::$app->request->post('user_id'));
             if ($membership === null) {
                 throw new HttpException(404, 'Could not find membership!');
             }

--- a/protected/humhub/modules/space/tests/codeception/unit/InviteTest.php
+++ b/protected/humhub/modules/space/tests/codeception/unit/InviteTest.php
@@ -23,6 +23,12 @@ class InviteTest extends HumHubDbTestCase
         $this->assertMailSent(1, 'Approval notification admin mail');
         $this->assertHasNotification(\humhub\modules\space\notifications\Invite::class, $space, Yii::$app->user->id, 'Invite Request Notification');
 
+        // check cached version
+        $membership = \humhub\modules\space\models\Membership::findMembership(1, 2);
+        $this->assertNotNull($membership);
+        $this->assertEquals($membership->status, \humhub\modules\space\models\Membership::STATUS_INVITED);
+
+        // check uncached version
         $membership = \humhub\modules\space\models\Membership::findOne(['space_id' => 1, 'user_id' => 2]);
         $this->assertNotNull($membership);
         $this->assertEquals($membership->status, \humhub\modules\space\models\Membership::STATUS_INVITED);
@@ -45,6 +51,12 @@ class InviteTest extends HumHubDbTestCase
         $this->assertMailSent(1, 'Approval notification admin mail');
         $this->assertHasNotification(\humhub\modules\space\notifications\Invite::class, $space, Yii::$app->user->id, 'Invite Request Notification');
 
+        // check cached version
+        $membership = \humhub\modules\space\models\Membership::findMembership(1, 2);
+        $this->assertNotNull($membership);
+        $this->assertEquals($membership->status, \humhub\modules\space\models\Membership::STATUS_INVITED);
+
+        // check uncached version
         $membership = \humhub\modules\space\models\Membership::findOne(['space_id' => 1, 'user_id' => 2]);
         $this->assertNotNull($membership);
         $this->assertEquals($membership->status, \humhub\modules\space\models\Membership::STATUS_INVITED);

--- a/protected/humhub/modules/space/tests/codeception/unit/MembershipTest.php
+++ b/protected/humhub/modules/space/tests/codeception/unit/MembershipTest.php
@@ -25,6 +25,12 @@ class MembershipTest extends HumHubDbTestCase
         $this->assertHasNotification(\humhub\modules\space\notifications\ApprovalRequest::class, $space,
             Yii::$app->user->id, 'Approval Request Notification');
 
+        // check cached version
+        $membership = Membership::findMembership(1, Yii::$app->user->id);
+        $this->assertNotNull($membership);
+        $this->assertEquals($membership->status, Membership::STATUS_APPLICANT);
+
+        // check uncached version
         $membership = Membership::findOne(['space_id' => 1, 'user_id' => Yii::$app->user->id]);
         $this->assertNotNull($membership);
         $this->assertEquals($membership->status, Membership::STATUS_APPLICANT);
@@ -61,6 +67,12 @@ class MembershipTest extends HumHubDbTestCase
         $this->assertHasNotification(\humhub\modules\space\notifications\ApprovalRequest::class, $space,
             Yii::$app->user->id, 'Approval Request Notification');
 
+        // check cached version
+        $membership = Membership::findMembership(1, Yii::$app->user->id);
+        $this->assertNotNull($membership);
+        $this->assertEquals($membership->status, Membership::STATUS_APPLICANT);
+
+        // check uncached version
         $membership = Membership::findOne(['space_id' => 1, 'user_id' => Yii::$app->user->id]);
         $this->assertNotNull($membership);
         $this->assertEquals($membership->status, Membership::STATUS_APPLICANT);
@@ -75,7 +87,7 @@ class MembershipTest extends HumHubDbTestCase
 
     public function testChangeRoleMembership()
     {
-        $membership = Membership::findOne(['space_id' => 3, 'user_id' => 2]);
+        $membership = Membership::findMembership(3, 2);
 
         \humhub\modules\space\notifications\ChangedRolesMembership::instance()
             ->about($membership)


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- Bugfix for regression introduced in [Performance Improvements](https://github.com/humhub/humhub/commit/9fabc0e2d40b580527a57eb32f3a4a29903ca3f2#diff-784788c31ac7b8ee4174e073efbfc818d7791d600260533363a35a5548670685R233-R235)  (#6375)

Requesting space membership does work, but the buttons on the space list are not updated. Therefore, the issue only happens in case the space membership is requested from the spaces list
http://humhub.local/index.php?r=space%2Fspaces


**Does this PR introduce a breaking change?** (check one)

- No

**The PR fulfills these requirements:**

- It's submitted to the `develop` branch
- All tests are passing -> **This regression is not covered by a test**
- [x] New/updated tests are included
  - **to be done:** testing the request to space membership not only from the space page, but also from the spaces list. See `RequestMembershipCest`. => #6477
- [x] Changelog was modified

