### PR TITLE
Fix: Test server support to serve `web` module's `/manifest.json`, `/sw.js`, & `/offline.pwa.html`

### DIFF
--- a/CHANGELOG-DEV.md
+++ b/CHANGELOG-DEV.md
@@ -3,6 +3,7 @@ HumHub Changelog
 
 1.15.0 (Unreleased)
 -------------------
+- Fix #6461: Test server support to serve web module's `/manifest.json`, `/sw.js`, & `/offline.pwa.html`
 - Enh #6460: Test server output: print application requests
 - Fix #6423: log.fata in frontend logging is redirected to log.fatal, which did not work
 - Fix #6220: User Soft Delete doesn't remove third party auth references

--- a/index-test.php
+++ b/index-test.php
@@ -13,7 +13,7 @@ if (!in_array(@$_SERVER['REMOTE_ADDR'], ['127.0.0.1', '::1'])) {
     die('You are not allowed to access this file.');
 }
 
-if (isset($_SERVER['REQUEST_URI']) && preg_match('/\.(?:css|json|js|png|jpg|jpeg|gif|ttf|woff|woff2)(\?.+)?$/i', $_SERVER['REQUEST_URI'])) {
+if (isset($_SERVER['REQUEST_URI']) && preg_match('/^[^?]*\.(?:css|(?<!manifest\.)json|(?<!sw\.)js|png|jpg|jpeg|gif|ttf|woff|woff2)(\?.+)?$/i', $_SERVER['REQUEST_URI'])) {
     return false; // serve the requested resource as-is.
 }
 

--- a/protected/humhub/components/Request.php
+++ b/protected/humhub/components/Request.php
@@ -47,6 +47,10 @@ class Request extends \yii\web\Request
         if ($this->cookieValidationKey == '') {
             $this->cookieValidationKey = 'installer';
         }
+
+        if (defined('YII_ENV_TEST') && YII_ENV_TEST && $_SERVER['SCRIPT_FILENAME'] === 'index-test.php' && in_array($_SERVER['SCRIPT_NAME'], ['/sw.js', '/offline.pwa.html', '/manifest.json'], true)) {
+            $this->setScriptUrl('/index.php');
+        }
     }
 
     /**


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- Bugfix

**Does this PR introduce a breaking change?** (check one)

- No

**The PR fulfills these requirements:**

- It's submitted to the `develop` branch
- [x] All tests are passing
- No new/updated tests are included
- [x] Changelog was modified

**Other information:**

During tests, the virtual files `/manifest.json,` `/sw.js`, & `/offline.pwa.html` from the module `web` where not served. This patch allows the test web server to serve them, too.
