### PR TITLE
Add pseudo test class to allow population of DB with standard test data

### DIFF
--- a/CHANGELOG-DEV.md
+++ b/CHANGELOG-DEV.md
@@ -3,6 +3,7 @@ HumHub Changelog
 
 1.15.0-beta.2 (Unreleased)
 --------------------------
+- Enh #6478: Add pseudo test class to allow population of DB with standard test data
 - Enh #6480: Convert assert* and db* methods to static, in line with general usage pattern
 - Enh #6505: Introduce Application interface; now also fire the `onInit` event when the web application has initialized
 - Fix #6502: Link notification for pending space approval to manage page

--- a/protected/humhub/tests/codeception/unit/LoadDbTest.php
+++ b/protected/humhub/tests/codeception/unit/LoadDbTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * @link      https://www.humhub.org/
+ * @copyright Copyright (c) 2023 HumHub GmbH & Co. KG
+ * @license   https://www.humhub.com/licences
+ */
+
+namespace humhub\tests\codeception\unit;
+
+use Codeception\Exception\InjectionException;
+use Codeception\Exception\ModuleException;
+use Codeception\Lib\Console\Output;
+use Codeception\Lib\ModuleContainer;
+use Codeception\Module\Yii2;
+use Codeception\Test\Metadata;
+use tests\codeception\_support\HumHubDbTestCase;
+use Yii;
+use humhub\modules\queue\models\QueueExclusive;
+
+/**
+ * Test Debugging DbLoad Helper
+ *
+ * Use this test to fill up the database with fixture test data to manually debug
+ *
+ * Example usage:
+ * ```
+ * HUMHUB_DB_INITIALIZE= php $HUMHUB_VENDOR_BIN/codecept run unit LoadDbTest
+ * ```
+ *
+ * @since 1.15
+ */
+class LoadDbTest extends HumHubDbTestCase
+{
+    protected bool $humhubLoadDb = false;
+    protected static Output $humhubConsole;
+
+    public function _fixtures(...$args): array
+    {
+        if (false !== getenv('HUMHUB_DB_INITIALIZE') || in_array('--load', $_SERVER['argv'], true)) {
+            $this->humhubLoadDb = true;
+            $this->fixtureConfig = ['default'];
+
+            foreach (['queue', QueueExclusive::tableName()] as $table) {
+                self::dbDelete($table);
+            }
+
+            self::$humhubConsole->writeln(sprintf(' - Going to load fixtures: %s ...', implode(', ', $this->fixtureConfig)));
+        }
+
+        return parent::_fixtures();
+    }
+
+
+    public static function setUpBeforeClass(...$args): void
+    {
+        self::$humhubConsole = new Output([]);
+
+        parent::setUpBeforeClass();
+    }
+
+    /**
+     * @throws InjectionException
+     * @throws ModuleException
+     */
+    public function testLoadFixtures()
+    {
+        /**
+         * @var Yii2 $yii2
+         * @var Metadata $metadata
+         * @var ModuleContainer $service
+         */
+        $metadata = $this->getMetadata();
+        $service = $metadata->getService('modules');
+        $yii2 = $service->getModule('Yii2');
+
+        if ($this->humhubLoadDb) {
+            static::assertNotEmpty($yii2->loadedFixtures);
+
+            // prevent fixtures from being unloaded
+            $yii2->loadedFixtures = [];
+        } else {
+            static::assertEmpty($yii2->loadedFixtures);
+        }
+    }
+}


### PR DESCRIPTION
**What kind of change does this PR introduce?** 

- Other, please describe:

Create an easy way to populate the database with the standard test data set, without clearing it afterwards.

Normal use will not do anything other than succeed and hence not consume any time
```
php $HUMHUB_VENDOR_BIN/codecept run unit LoadDbTest
```

However, if run with the environment variable HUMHUB_DB_INITIALIZE set, then the default fixtures will be loaded and not unloaded after the test.
```
HUMHUB_DB_INITIALIZE= php $HUMHUB_VENDOR_BIN/codecept run unit LoadDbTest
```

This class could also be extended and then the data only loaded for certain tests within the class. But for now it helps to test the codebase from the web-interface easily.


**Does this PR introduce a breaking change?** (check one)

- No


**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [x] All tests are passing
- [x] New/updated tests are included
- [x] Changelog was modified
