### PR TITLE
Fix: Link notification for pending space approval to manage page

### DIFF
--- a/CHANGELOG-DEV.md
+++ b/CHANGELOG-DEV.md
@@ -3,6 +3,7 @@ HumHub Changelog
 
 1.15.0-beta.2 (Unreleased)
 --------------------------
+- Fix #6502: Link notification for pending space approval to manage page
 - Fix #6472: Initialization of account profile field type "Markdown"
 - Fix #6471: Wording "Default Homepage" in Space Default Settings
 - Fix #6468: Module Administration - Marketplace Links broken without Pretty URLs

--- a/protected/humhub/modules/space/notifications/ApprovalRequest.php
+++ b/protected/humhub/modules/space/notifications/ApprovalRequest.php
@@ -104,7 +104,7 @@ class ApprovalRequest extends BaseNotification
 
     public function getUrl()
     {
-        return $this->source->getUrl() . 'space/manage/member/pending-approvals';
+        return $this->source->createUrl('/space/manage/member/pending-approvals');
     }
 
     /**


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Bugfix

**Does this PR introduce a breaking change?**

- No

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [x] fix #6420
- [ ] All tests are passing
- [ ] New/updated tests are included
- [x] Changelog was modified

**Other information:**

The produced URL was:

```
index.php?r=space%2Fspace&cguid=5396d499-20d6-4233-800b-c6c86e5fa34aspace/manage/member/pending-approvals
```

rather than

```
/index.php?r=space%2Fmanage%2Fmember%2Fpending-approvals&cguid=5396d499-20d6-4233-800b-c6c86e5fa34a
```