### PR TITLE
Enh: Introduce FindInstanceInterface with methods to get (cached) instances - Part 1

### DIFF
--- a/CHANGELOG-DEV.md
+++ b/CHANGELOG-DEV.md
@@ -6,10 +6,11 @@ HumHub Changelog
 - Fix #6472: Initialization of account profile field type "Markdown"
 - Fix #6471: Wording "Default Homepage" in Space Default Settings
 - Fix #6468: Module Administration - Marketplace Links broken without Pretty URLs
-- Enh #6469: Added Info text for Marketplace page 
+- Enh #6469: Added Info text for Marketplace page
 - Fix #112: Reorder Table Rows
 - Fix #6476: Fix module disabling in queue
 - Enh #6469: Implement conditions for `fixed-settings` in config
+- Enh #68: Online Indicator Position
 - Fix #6492: Fix module form "Set as default"
 - Fix #6457: Regression with membership cache. Also move cache to `Membership::findMembership`.
 

--- a/CHANGELOG-DEV.md
+++ b/CHANGELOG-DEV.md
@@ -10,6 +10,7 @@ HumHub Changelog
 - Fix #112: Reorder Table Rows
 - Fix #6476: Fix module disabling in queue
 - Enh #6469: Implement conditions for `fixed-settings` in config
+- Fix #6492: Fix module form "Set as default"
 - Fix #6457: Regression with membership cache. Also move cache to `Membership::findMembership`.
 
 1.15.0-beta.1 (July 31, 2023)

--- a/protected/humhub/components/CacheableActiveQuery.php
+++ b/protected/humhub/components/CacheableActiveQuery.php
@@ -1,0 +1,115 @@
+<?php
+
+/*
+ * @link      https://www.humhub.org/
+ * @copyright Copyright (c) 2017-2023 HumHub GmbH & Co. KG
+ * @license   https://www.humhub.com/licences
+ */
+
+namespace humhub\components;
+
+use humhub\exceptions\InvalidArgumentTypeException;
+use Yii;
+use yii\db\ActiveQuery;
+use yii\db\ActiveRecord;
+
+/**
+ * ActiveQueryContent is an enhanced ActiveQuery with additional selectors for especially content.
+ *
+ * @inheritdoc
+ */
+class CacheableActiveQuery extends ActiveQuery
+{
+    public function findFor($name, $model)
+    {
+        $result = parent::findFor($name, $model);
+
+        if (!$result instanceof ActiveRecord) {
+            return $result;
+        }
+
+        static::cacheProcessVariants('set', $result);
+
+        return $result;
+    }
+
+    public static function normaliseObjectIdentifier($classOrObject, $id = null, ?string &$idWasUsed = null): string
+    {
+        if (is_object($classOrObject)) {
+            $classOrObject = get_class($classOrObject);
+        } elseif (!is_string($classOrObject)) {
+            throw new InvalidArgumentTypeException(
+                __METHOD__,
+                [1 => '$classOrObject'],
+                ['object', 'string'],
+                $classOrObject
+            );
+        }
+
+        $idWasUsed = '';
+        $id = $id === 0 || !empty($id) ? "__" . ($idWasUsed = implode('_', (array)$id)) : '';
+
+        return str_replace('\\', '_', ltrim($classOrObject, '\\')) . $id;
+    }
+
+    /**
+     * @param string $action
+     * @param ActiveRecord $record
+     * @param array $properties
+     *
+     * @return void
+     */
+    public static function cacheProcessVariants(string $action, ActiveRecord $record, array $properties = ['id', 'guid']): void
+    {
+        static $runtimeCache;
+
+        $runtimeCache ??= Yii::$app->runtimeCache;
+
+        $done = [];
+        $class = get_class($record);
+
+        $pk = $record->getPrimaryKey(true);
+
+        $runtimeCache->$action(self::normaliseObjectIdentifier($class, $pk, $identifier), $record);
+
+        $done[] = $identifier;
+
+        foreach ($properties as $identifier) {
+            if ($record->hasAttribute($identifier)) {
+                $identifier = (string)$record->$identifier;
+                if (!in_array($identifier, $done, true)) {
+                    $runtimeCache->$action(self::normaliseObjectIdentifier($class, $identifier, $identifier), $record);
+                    $done[] = $identifier;
+                }
+            }
+        }
+
+        /**
+         * Check if we have the related record cached in the polymorphic behavior, so we can delete the cache by ID.
+         * (This is not fully bullet-proof, as the object might still be saved in the cache, but only under the guid key.)
+         */
+        if ($action !== 'delete' || !$record->hasMethod('getPolymorphicRelation')) {
+            return;
+        }
+
+        if ($model = $record->getPolymorphicRelation(false) ?? $runtimeCache->get(self::normaliseObjectIdentifier($record->{$record->classAttribute}, $record->{$record->pkAttribute}))) {
+            static::cacheProcessVariants($action, $model, $properties);
+        }
+    }
+
+    public static function cacheDeleteByClass($class, $condition)
+    {
+        $cache = Yii::$app->runtimeCache;
+
+        if (is_array($condition) && $class::isPrimaryKey(array_keys($condition))) {
+            $key = self::normaliseObjectIdentifier($class, $condition);
+
+            if ($record = $cache->get($key)) {
+                self::cacheProcessVariants('delete', $record);
+                $cache->delete($key);
+            }
+        } else {
+            $cache->flush();
+        }
+    }
+}

--- a/protected/humhub/components/FindInstanceTrait.php
+++ b/protected/humhub/components/FindInstanceTrait.php
@@ -1,0 +1,218 @@
+<?php
+
+/*
+ * @link      https://www.humhub.org/
+ * @copyright Copyright (c) 2023 HumHub GmbH & Co. KG
+ * @license   https://www.humhub.com/licences
+ */
+
+namespace humhub\components;
+
+use humhub\exceptions\InvalidArgumentTypeException;
+use humhub\exceptions\InvalidConfigTypeException;
+use humhub\interfaces\FindInstanceInterface;
+use Throwable;
+use Yii;
+
+/**
+ * Helper trait for implementing FindInstanceInterface
+ *
+ * @since 1.15
+ * @see FindInstanceInterface
+ */
+trait FindInstanceTrait
+{
+    public static function find()
+    {
+        return Yii::createObject(CacheableActiveQuery::class, [static::class]);
+    }
+
+    /**
+     * @param self|int|string|array|null $identifier User or User ID. Null for current user
+     * @param array $config = [
+     *     'cached' => true,                    // use cached results
+     *     'onEmpty' => null,                   // if provided, use this value in case of empty $identifier
+     *     'exceptionMessageSuffix' => '',      // message used to append to the InvalidArgumentTypeException
+     *     'intKey' => 'id',
+     *     'stringKey' => string,               // If provided, this key will be used to look up string keys, e.g. 'guid'
+     *     'exception' => Throwable,            // throw this exception rather than InvalidArgumentTypeException
+     *     ]
+     * @param iterable $simpleCondition = [ 'field' => 'value' ] // filter to ble applied on the resulting record, otherwise return 'onEmpty'
+     *
+     * @return self|null
+     *
+     * @throws InvalidArgumentTypeException|InvalidConfigTypeException
+     * @see FindInstanceInterface::findInstance
+     * @noinspection PhpDocMissingThrowsInspection
+     */
+    protected static function findInstanceHelper($identifier, array $config = [], iterable $simpleCondition = []): ?self
+    {
+        $filter = static function ($identifier) use (&$config, &$simpleCondition) {
+            if (is_object($identifier)) {
+                foreach ($simpleCondition as $field => $value) {
+                    if ($identifier->$field != $value) {
+                        return $config['onEmpty'] ?? null;
+                    }
+                }
+            }
+            return $identifier;
+        };
+
+        if ($identifier instanceof static) {
+            return $filter($identifier);
+        }
+
+        if (is_string($identifier)) {
+            $identifier = trim($identifier);
+        }
+
+        if (array_key_exists('onEmpty', $config) && empty($identifier) && $identifier !== 0 && $identifier !== '0') {
+            return $config['onEmpty'];
+        }
+
+        if (
+            is_int($id = $identifier)
+            || null !== $id = filter_var($identifier, FILTER_VALIDATE_INT, FILTER_NULL_ON_FAILURE)
+        ) {
+            $criteria = [$config['intKey'] ?? 'id' => $id];
+        } elseif (is_string($identifier) && ($stringKey = $config['stringKey'] ?? null)) {
+            $criteria = [$stringKey => $identifier];
+        } elseif (is_array($identifier)) {
+            $criteria = $identifier;
+        } else {
+            $criteria = null;
+        }
+
+        if ($criteria) {
+            /**
+             * @return self|array|null
+             */
+            $find = static fn(): ?self => static::find()->where($criteria)->one();
+
+            if ($config['cached'] ?? true) {
+                $identifier = Yii::$app->runtimeCache->getOrSet(CacheableActiveQuery::normaliseObjectIdentifier(static::class, $criteria), $find);
+            } else {
+                $identifier = $find();
+                Yii::$app->runtimeCache->set(CacheableActiveQuery::normaliseObjectIdentifier(static::class, $criteria), $identifier);
+            }
+
+            return $filter($identifier);
+        }
+
+        // error handling
+
+        $exception = $config['exception'] ?? null;
+
+        if ($exception instanceof Throwable) {
+            /** @noinspection PhpUnhandledExceptionInspection */
+            throw $exception;
+        }
+
+        $x = new InvalidArgumentTypeException(
+            str_replace(__CLASS__, static::class, __METHOD__),
+            [1 => '$identifier'],
+            [self::class, 'int', ($config['stringKey'] ?? null) === null ? '(int)string' : 'string'],
+            $identifier,
+            array_key_exists('onEmpty', $config),
+            $config['exceptionMessageSuffix'] ?? ''
+        );
+
+        if ($exception === null) {
+            throw $x;
+        }
+
+        if (!is_string($exception)) {
+            /** @noinspection PhpUnhandledExceptionInspection */
+            throw new InvalidConfigTypeException(
+                __METHOD__,
+                "exception",
+                [Throwable::class],
+                $exception,
+                true,
+                '',
+                0,
+                $x
+            );
+        }
+
+        if (is_subclass_of($exception, Throwable::class)) {
+            /** @noinspection PhpUnhandledExceptionInspection */
+            throw new $exception();
+        }
+
+        /** @noinspection PhpUnhandledExceptionInspection */
+        throw new InvalidConfigTypeException(
+            __METHOD__,
+            "exception",
+            [Throwable::class],
+            $exception,
+            true,
+            '',
+            0,
+            $x
+        );
+    }
+
+    public static function findInstanceAsId($identifier, array $config = []): ?int
+    {
+        return static::findInstance($identifier, $config)->id ?? null;
+    }
+
+    public function hasOneCached(string $class, array $condition, array $identifiers = [])
+    {
+        $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 3);
+        $trace = array_column($trace, 'function');
+
+        if ($trace[2] === 'getRelation') {
+            return $this->hasOne($class, $condition);
+        }
+
+        $fields = array_flip($condition);
+
+        foreach ($fields as $field => &$value) {
+            $value = $this->$field;
+        }
+        unset($value);
+
+        $identifier = CacheableActiveQuery::normaliseObjectIdentifier($class, $identifiers + $fields, $idUsed);
+
+        return (!$idUsed || empty($record = Yii::$app->runtimeCache->get($identifier)))
+            ? $this->hasOne($class, $condition)
+            : $record;
+    }
+
+    public function afterDelete()
+    {
+        CacheableActiveQuery::cacheProcessVariants('delete', $this);
+
+        parent::afterDelete();
+    }
+
+    public function afterSave($insert, $changedAttributes)
+    {
+        CacheableActiveQuery::cacheProcessVariants('delete', $this);
+
+        parent::afterSave($insert, $changedAttributes);
+    }
+
+    public static function deleteAll($condition = null, $params = [])
+    {
+        CacheableActiveQuery::cacheDeleteByClass(static::class, $condition);
+
+        return parent::deleteAll($condition, $params);
+    }
+
+    public static function updateAll($attributes, $condition = '', $params = [])
+    {
+        CacheableActiveQuery::cacheDeleteByClass(static::class, $condition);
+
+        return parent::updateAll($attributes, $condition, $params);
+    }
+
+    public static function updateAllCounters($counters, $condition = '', $params = [])
+    {
+        CacheableActiveQuery::cacheDeleteByClass(static::class, $condition);
+
+        return parent::updateAllCounters($counters, $condition, $params);
+    }
+}

--- a/protected/humhub/components/FindInstanceTrait.php
+++ b/protected/humhub/components/FindInstanceTrait.php
@@ -28,7 +28,7 @@ trait FindInstanceTrait
     }
 
     /**
-     * @param self|int|string|array|null $identifier User or User ID. Null for current user
+     * @param self|int|string|null $identifier User or User ID. Null for current user
      * @param array $config = [
      *     'cached' => true,                    // use cached results
      *     'onEmpty' => null,                   // if provided, use this value in case of empty $identifier
@@ -45,7 +45,7 @@ trait FindInstanceTrait
      * @see FindInstanceInterface::findInstance
      * @noinspection PhpDocMissingThrowsInspection
      */
-    protected static function findInstanceHelper($identifier, array $config = [], iterable $simpleCondition = []): ?self
+    protected static function findInstanceHelper($identifier, ?array $config = [], iterable $simpleCondition = []): ?self
     {
         $filter = static function ($identifier) use (&$config, &$simpleCondition) {
             if (is_object($identifier)) {
@@ -57,6 +57,8 @@ trait FindInstanceTrait
             }
             return $identifier;
         };
+
+        $config ??= [];
 
         if ($identifier instanceof static) {
             return $filter($identifier);

--- a/protected/humhub/exceptions/InvalidArgumentException.php
+++ b/protected/humhub/exceptions/InvalidArgumentException.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * @link      https://www.humhub.org/
+ * @copyright Copyright (c) 2023 HumHub GmbH & Co. KG
+ * @license   https://www.humhub.com/licences
+ */
+
+namespace humhub\exceptions;
+
+use yii\base\InvalidArgumentException as BaseInvalidArgumentException;
+
+class InvalidArgumentException extends BaseInvalidArgumentException
+{
+    use InvalidArgumentExceptionTrait;
+
+    protected function formatPrologue(array $constructArguments): string
+    {
+        $argumentName = is_array($this->parameter)
+            ? reset($this->parameter)
+            : null;
+
+        $argumentNumber = is_array($this->parameter)
+            ? key($this->parameter)
+            : $this->parameter;
+
+        if (null === $int = filter_var($argumentNumber, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE)) {
+            $argumentName = $argumentNumber;
+            $argumentNumber = '';
+        } else {
+            $argumentNumber = "#$int";
+        }
+
+        $argumentName = $argumentName === null
+            ? ''
+            : " \$" . ltrim($argumentName, '$');
+
+        return sprintf('Argument %s%s', $argumentNumber, $argumentName);
+    }
+}

--- a/protected/humhub/exceptions/InvalidArgumentExceptionTrait.php
+++ b/protected/humhub/exceptions/InvalidArgumentExceptionTrait.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * @link      https://www.humhub.org/
+ * @copyright Copyright (c) 2023 HumHub GmbH & Co. KG
+ * @license   https://www.humhub.com/licences
+ */
+
+namespace humhub\exceptions;
+
+trait InvalidArgumentExceptionTrait
+{
+    //  public properties
+
+    public string $methodName;
+    public $parameter;
+
+    public array $valid = [];
+
+    /**
+     * @var mixed|null
+     */
+    public $given;
+
+    /**
+     * @param string $method
+     * @param int|array $parameter = [
+     *                                     int => string,       // position, or [ position => name ] of the  argument
+     *                                     ]
+     * @param null $given
+     */
+    public function __construct(
+        $method = '',
+        $parameter = null,
+        $valid = [],
+        $given = null,
+        $suffix = null,
+        $code = 0,
+        $previous = null
+    ) {
+        $this->methodName = $method;
+        $this->parameter = $parameter;
+        $this->valid = (array)$valid;
+        $this->given = $given;
+
+        if (is_int($suffix)) {
+            $code = $suffix;
+            $previous = $code;
+            $suffix = '';
+        } elseif ($suffix) {
+            $suffix = " $suffix";
+        }
+
+        $message = sprintf(
+            '%s passed to %s must be %s%s - %s given.',
+            $this->formatPrologue(func_get_args()),
+            $this->methodName,
+            $this->formatValid(),
+            $suffix,
+            $given
+        );
+
+        parent::__construct($message, $code, $previous);
+    }
+
+    protected function formatValid(): string
+    {
+        return (count($this->valid) > 1
+                ? 'one of '
+                : '') . implode(', ', $this->valid);
+    }
+
+    public function getName(): string
+    {
+        if (method_exists(parent::class, 'getName')) {
+            return parent::getName() . " Type";
+        }
+
+        return 'Invalid Type';
+    }
+
+    abstract protected function formatPrologue(array $constructArguments): string;
+}

--- a/protected/humhub/exceptions/InvalidConfigTypeException.php
+++ b/protected/humhub/exceptions/InvalidConfigTypeException.php
@@ -19,6 +19,6 @@ class InvalidConfigTypeException extends InvalidConfigException
 
     protected function formatPrologue(array $constructArguments): string
     {
-        return "Parameter $this->parameter of configuration";
+        return "Parameter '$this->parameter' of configuration";
     }
 }

--- a/protected/humhub/exceptions/InvalidTypeExceptionTrait.php
+++ b/protected/humhub/exceptions/InvalidTypeExceptionTrait.php
@@ -38,6 +38,7 @@ trait InvalidTypeExceptionTrait
         $validType = [],
         $givenValue = null,
         $nullable = false,
+        $suffix = null,
         $code = 0,
         $previous = null
     ) {
@@ -51,11 +52,20 @@ trait InvalidTypeExceptionTrait
             $this->validType[] = 'null';
         }
 
+        if (is_int($suffix)) {
+            $code = $suffix;
+            $previous = $code;
+            $suffix = '';
+        } elseif ($suffix) {
+            $suffix = " $suffix";
+        }
+
         $message = sprintf(
-            '%s passed to %s must be of type %s, %s given.',
+            '%s passed to %s must be of type %s%s - %s given.',
             $this->formatPrologue(func_get_args()),
             $this->methodName,
             implode(', ', $this->validType),
+            $suffix,
             get_debug_type($this->givenValue)
         );
 

--- a/protected/humhub/interfaces/FindInstanceInterface.php
+++ b/protected/humhub/interfaces/FindInstanceInterface.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * @link      https://www.humhub.org/
+ * @copyright Copyright (c) 2023 HumHub GmbH & Co. KG
+ * @license   https://www.humhub.com/licences
+ */
+
+namespace humhub\interfaces;
+
+use humhub\exceptions\InvalidArgumentTypeException;
+use humhub\exceptions\InvalidConfigTypeException;
+
+interface FindInstanceInterface
+{
+    /**
+     * Returns a specific instance of the class identified by the PK (or unique identifier in some instances). If the
+     * record cannot be found, null is returned. Special inout is null, where a default instance may be returned.
+     *
+     * @param self|int|string|array|null $identifier Object identifying information. Can be an instance of self (which
+     *        will be simply returned), a one-dimensional PK as int or string, or an array of pk information.
+     *        If null, the default instance (e.g., active User) would be returned.
+     * @param array $config = [
+     *     'cached' => true,                    // use cached results
+     *     'nullable' => false,                 // allow null values on for $identifier
+     *     'onEmpty' => null,                   // if provided, use this value in case of empty $identifier
+     *     'exceptionMessageSuffix' => '',      // message used to append to the InvalidArgumentTypeException
+     *     'intKey' => 'id',
+     *     'stringKey' => string,               // If provided, this key will be used to look up string keys, e.g. 'guid'
+     *     'exception' => Throwable,            // throw this exception rather than InvalidArgumentTypeException
+     *     ]
+     *
+     * @return self|null
+     *
+     * @throws InvalidArgumentTypeException|InvalidConfigTypeException
+     */
+    public static function findInstance($identifier, array $config = []): ?self;
+
+    /**
+     * @param self|int|string|null $identifier User or User ID. Null for current user
+     * @param array $config = [
+     *     'cached' => true,                    // use cached results
+     *     'nullable' => false,                 // allow null values on for $identifier
+     *     'onEmpty' => null,                   // if provided, use this value in case of empty $identifier
+     *     'exceptionMessageSuffix' => '',      // message used to append to the InvalidArgumentTypeException
+     *     'intKey' => 'id',
+     *     'stringKey' => string,               // If provided, this key will be used to look up string keys, e.g. 'guid'
+     *     'exception' => Throwable,            // throw this exception rather than InvalidArgumentTypeException
+     *     ]
+     *
+     * @return self|null
+     *
+     * @return int|array|null (Return type MUST be ?int or ?array on the implementing function!)
+     *
+     * @throws InvalidArgumentTypeException|InvalidConfigTypeException
+     * @noinspection PhpMissingReturnTypeInspection
+     */
+    public static function findInstanceAsId($identifier, array $config = []);
+}

--- a/protected/humhub/interfaces/FindInstanceInterface.php
+++ b/protected/humhub/interfaces/FindInstanceInterface.php
@@ -20,7 +20,7 @@ interface FindInstanceInterface
      * @param self|int|string|array|null $identifier Object identifying information. Can be an instance of self (which
      *        will be simply returned), a one-dimensional PK as int or string, or an array of pk information.
      *        If null, the default instance (e.g., active User) would be returned.
-     * @param array $config = [
+     * @param null|array $config = [
      *     'cached' => true,                    // use cached results
      *     'nullable' => false,                 // allow null values on for $identifier
      *     'onEmpty' => null,                   // if provided, use this value in case of empty $identifier
@@ -29,12 +29,15 @@ interface FindInstanceInterface
      *     'stringKey' => string,               // If provided, this key will be used to look up string keys, e.g. 'guid'
      *     'exception' => Throwable,            // throw this exception rather than InvalidArgumentTypeException
      *     ]
+     * @param iterable $simpleCondition         // ['field' => 'value']-filter to be applied on the resulting object,
+     *                                             otherwise return $config['onEmpty'] or null
      *
      * @return self|null
      *
-     * @throws InvalidArgumentTypeException|InvalidConfigTypeException
+     * @throws InvalidArgumentTypeException
+     * @throws InvalidConfigTypeException
      */
-    public static function findInstance($identifier, array $config = []): ?self;
+    public static function findInstance($identifier, ?array $config = [], iterable $simpleCondition = []): ?self;
 
     /**
      * @param self|int|string|null $identifier User or User ID. Null for current user

--- a/protected/humhub/modules/admin/resources/js/humhub.admin.js
+++ b/protected/humhub/modules/admin/resources/js/humhub.admin.js
@@ -2,6 +2,7 @@ humhub.module('admin', function (module, require, $) {
     var client = require('client');
     var modal = require('ui.modal');
     var additions = require('ui.additions');
+    var status = require('ui.status');
 
     /**
      * Action will delete the current page logo.
@@ -146,9 +147,10 @@ humhub.module('admin', function (module, require, $) {
     };
 
     var moduleSetAsDefault = function(event) {
-        modal.footerLoader();
+        modal.footerLoader(event);
         client.submit(event).then(function(response) {
             modal.setContent(response.data);
+            status.success(module.require('log').config.text['success.saved']);
         });
     };
 

--- a/protected/humhub/modules/content/components/AbstractActiveQueryContentContainer.php
+++ b/protected/humhub/modules/content/components/AbstractActiveQueryContentContainer.php
@@ -2,6 +2,7 @@
 
 namespace humhub\modules\content\components;
 
+use humhub\components\CacheableActiveQuery;
 use humhub\modules\user\models\User;
 use yii\db\ActiveQuery;
 
@@ -10,7 +11,7 @@ use yii\db\ActiveQuery;
  *
  * @since 1.13.1
  */
-abstract class AbstractActiveQueryContentContainer extends ActiveQuery
+abstract class AbstractActiveQueryContentContainer extends CacheableActiveQuery
 {
     /**
      * Query keywords will be broken down into array needles with this length

--- a/protected/humhub/modules/content/components/ActiveQueryContent.php
+++ b/protected/humhub/modules/content/components/ActiveQueryContent.php
@@ -8,6 +8,7 @@
 
 namespace humhub\modules\content\components;
 
+use humhub\components\CacheableActiveQuery;
 use humhub\modules\content\models\Content;
 use humhub\modules\content\models\ContentTag;
 use humhub\modules\content\models\ContentTagRelation;
@@ -15,7 +16,6 @@ use humhub\modules\space\models\Space;
 use humhub\modules\user\helpers\AuthHelper;
 use humhub\modules\user\models\User;
 use Yii;
-use yii\db\ActiveQuery;
 use yii\db\Expression;
 
 /**
@@ -25,7 +25,7 @@ use yii\db\Expression;
  *
  * @author luke
  */
-class ActiveQueryContent extends ActiveQuery
+class ActiveQueryContent extends CacheableActiveQuery
 {
     /**
      * Own content scope for userRelated

--- a/protected/humhub/modules/content/components/ContentActiveRecord.php
+++ b/protected/humhub/modules/content/components/ContentActiveRecord.php
@@ -9,6 +9,8 @@
 namespace humhub\modules\content\components;
 
 use humhub\components\ActiveRecord;
+use humhub\components\FindInstanceTrait;
+use humhub\interfaces\FindInstanceInterface;
 use humhub\libs\BasePermission;
 use humhub\modules\activity\helpers\ActivityHelper;
 use humhub\modules\activity\models\Activity;
@@ -31,6 +33,7 @@ use yii\base\Exception;
 use yii\base\InvalidConfigException;
 use yii\base\ModelEvent;
 use yii\db\ActiveQuery;
+use yii\db\ActiveQueryInterface;
 
 /**
  * ContentActiveRecord is the base ActiveRecord [[\yii\db\ActiveRecord]] for Content.
@@ -67,11 +70,17 @@ use yii\db\ActiveQuery;
  * @mixin Followable
  * @property User $createdBy
  * @property User $owner
+ * @property-read string $contentName
+ * @property-read null|string $icon
+ * @property-read null|WallEntry|WallStreamEntryWidget $wallEntryWidget
+ * @property-read string $contentDescription
  * @property-read File[] $files
  * @author Luke
  */
-class ContentActiveRecord extends ActiveRecord implements ContentOwner, Movable, SoftDeletable
+class ContentActiveRecord extends ActiveRecord implements ContentOwner, FindInstanceInterface, Movable, SoftDeletable
 {
+    use FindInstanceTrait;
+
     /**
      * @see StreamEntryWidget
      * @var string the StreamEntryWidget widget class
@@ -384,7 +393,7 @@ class ContentActiveRecord extends ActiveRecord implements ContentOwner, Movable,
     {
         if (is_subclass_of($this->wallEntryClass, StreamEntryWidget::class, true)) {
             $params['model'] = $this;
-        } else if (!empty($this->wallEntryClass)) {
+        } elseif (!empty($this->wallEntryClass)) {
             $params['contentObject'] = $this; // legacy WallEntry widget
         }
 
@@ -407,7 +416,7 @@ class ContentActiveRecord extends ActiveRecord implements ContentOwner, Movable,
 
         if (is_subclass_of($this->wallEntryClass, WallEntry::class)) {
             $class = $this->wallEntryClass;
-            $widget = new $class;
+            $widget = new $class();
             $widget->contentObject = $this;
             return $widget;
         }
@@ -442,22 +451,24 @@ class ContentActiveRecord extends ActiveRecord implements ContentOwner, Movable,
      */
     public function afterSave($insert, $changedAttributes)
     {
-        // Auto follow this content
+        $content = $this->content;
+
+        // Auto-follow this content
         if ($this->autoFollow) {
-            $this->follow($this->content->created_by);
+            $this->follow($content->created_by);
         }
 
         // Set polymorphic relation
         if ($insert) {
-            $this->content->object_model = static::getObjectModel();
-            $this->content->object_id = $this->getPrimaryKey();
+            $content->object_model = static::getObjectModel();
+            $content->object_id = $this->getPrimaryKey();
         }
 
-        if (!$insert || $this->content->isNewRecord) {
+        if (!$insert || $content->isNewRecord) {
             // Save a Content only on each update of this Record or when the Content is creating first time.
             // Don't update the Content twice during inserting of this Record
             //   in order to don't touch the column `updated_at` when action is "creating" really.
-            $this->content->save();
+            $content->save();
         }
 
         parent::afterSave($insert, $changedAttributes);
@@ -608,8 +619,13 @@ class ContentActiveRecord extends ActiveRecord implements ContentOwner, Movable,
      */
     public function getContent()
     {
-        return $this->hasOne(Content::class, ['object_id' => 'id'])
-            ->andWhere(['content.object_model' => static::getObjectModel()]);
+        $getObjectModel = static::getObjectModel();
+        $content = $this->hasOneCached(Content::class, ['object_id' => 'id'], ['content.object_model' => $getObjectModel]);
+
+        return $content instanceof ActiveQueryInterface
+            ? $content
+                ->andWhere(['content.object_model' => $getObjectModel])
+            : $content;
     }
 
     public function getFiles()
@@ -638,6 +654,15 @@ class ContentActiveRecord extends ActiveRecord implements ContentOwner, Movable,
     public static function find()
     {
         return new ActiveQueryContent(static::class);
+    }
+
+    /**
+     * @since 1.15
+     * @inheritdoc
+     **/
+    public static function findInstance($identifier, ?array $config = [], iterable $simpleCondition = []): ?self
+    {
+        return self::findInstanceHelper($identifier, $config, $simpleCondition);
     }
 
     /**

--- a/protected/humhub/modules/content/models/Content.php
+++ b/protected/humhub/modules/content/models/Content.php
@@ -11,8 +11,10 @@ namespace humhub\modules\content\models;
 use humhub\components\ActiveRecord;
 use humhub\components\behaviors\GUID;
 use humhub\components\behaviors\PolymorphicRelation;
+use humhub\components\CacheableActiveQuery;
+use humhub\components\FindInstanceTrait;
 use humhub\components\Module;
-use humhub\modules\activity\models\Activity;
+use humhub\interfaces\FindInstanceInterface;
 use humhub\modules\admin\permissions\ManageUsers;
 use humhub\modules\content\components\ContentActiveRecord;
 use humhub\modules\content\components\ContentContainerActiveRecord;
@@ -36,7 +38,7 @@ use humhub\modules\user\helpers\AuthHelper;
 use humhub\modules\user\models\User;
 use Yii;
 use yii\base\Exception;
-use yii\base\InvalidArgumentException;
+use yii\db\ActiveQueryInterface;
 use yii\db\IntegrityException;
 use yii\helpers\Url;
 
@@ -83,8 +85,10 @@ use yii\helpers\Url;
  * @mixin GUID
  * @since 0.5
  */
-class Content extends ActiveRecord implements Movable, ContentOwner, SoftDeletable
+class Content extends ActiveRecord implements FindInstanceInterface, Movable, ContentOwner, SoftDeletable
 {
+    use FindInstanceTrait;
+
     /**
      * The default stream channel.
      * @since 1.6
@@ -206,6 +210,13 @@ class Content extends ActiveRecord implements Movable, ContentOwner, SoftDeletab
         return $this->getPolymorphicRelation();
     }
 
+    public static function findInstance($identifier, ?array $config = [], iterable $simpleCondition = []): ?self
+    {
+        $config['stringKey'] ??= 'guid';
+
+        return static::findInstanceHelper($identifier, $config, $simpleCondition);
+    }
+
     /**
      * @inheritdoc
      */
@@ -238,6 +249,8 @@ class Content extends ActiveRecord implements Movable, ContentOwner, SoftDeletab
      */
     public function afterSave($insert, $changedAttributes)
     {
+        CacheableActiveQuery::cacheProcessVariants('delete', $this);
+
         if (array_key_exists('state', $changedAttributes)) {
             // Run process for new content(Send notifications) only after changing state
             $this->processNewContent();
@@ -367,7 +380,9 @@ class Content extends ActiveRecord implements Movable, ContentOwner, SoftDeletab
      */
     public function afterDelete()
     {
-        // Try delete the underlying object (Post, Question, Task, ...)
+        CacheableActiveQuery::cacheProcessVariants('delete', $this);
+
+        // Try to delete the underlying object (Post, Question, Task, ...)
         $this->resetPolymorphicRelation();
 
         /** @var ContentActiveRecord $record */
@@ -767,8 +782,8 @@ class Content extends ActiveRecord implements Movable, ContentOwner, SoftDeletab
             return $this->_container;
         }
 
-        if ($this->contentContainer !== null) {
-            $this->_container = $this->contentContainer->getPolymorphicRelation();
+        if (($contentContainer = $this->contentContainer) instanceof ContentContainer) {
+            $this->_container = $contentContainer->getPolymorphicRelation();
         }
 
         return $this->_container;
@@ -778,12 +793,12 @@ class Content extends ActiveRecord implements Movable, ContentOwner, SoftDeletab
      * Relation to ContentContainer model
      * Note: this is not a Space or User instance!
      *
-     * @return \yii\db\ActiveQuery
+     * @return \yii\db\ActiveQuery|ContentContainer
      * @since 1.1
      */
     public function getContentContainer()
     {
-        return $this->hasOne(ContentContainer::class, ['id' => 'contentcontainer_id']);
+        return $this->hasOneCached(ContentContainer::class, ['id' => 'contentcontainer_id']);
     }
 
     /**
@@ -857,11 +872,7 @@ class Content extends ActiveRecord implements Movable, ContentOwner, SoftDeletab
             return false;
         }
 
-        if ($user === null) {
-            $user = Yii::$app->user->getIdentity();
-        } else if (!($user instanceof User)) {
-            $user = User::findOne(['id' => $user]);
-        }
+        $user = User::findIdentity($user);
 
         // Only owner can edit his content
         if ($user !== null && $this->created_by == $user->id) {
@@ -947,11 +958,7 @@ class Content extends ActiveRecord implements Movable, ContentOwner, SoftDeletab
      */
     public function canView($user = null)
     {
-        if (!$user && !Yii::$app->user->isGuest) {
-            $user = Yii::$app->user->getIdentity();
-        } else if (!$user instanceof User) {
-            $user = User::findOne(['id' => $user]);
-        }
+        $user = User::findInstance($user);
 
         // Check global content visibility, private global content is visible for all users
         if (empty($this->contentcontainer_id) && !Yii::$app->user->isGuest) {

--- a/protected/humhub/modules/content/models/ContentContainer.php
+++ b/protected/humhub/modules/content/models/ContentContainer.php
@@ -9,8 +9,11 @@
 namespace humhub\modules\content\models;
 
 use humhub\components\behaviors\PolymorphicRelation;
+use humhub\components\FindInstanceTrait;
+use humhub\interfaces\FindInstanceInterface;
 use humhub\modules\content\components\ContentContainerActiveRecord;
 use humhub\modules\space\models\Space;
+use Yii;
 use yii\db\ActiveRecord;
 
 /**
@@ -24,8 +27,9 @@ use yii\db\ActiveRecord;
  * @property string $tags_cached readonly, a comma separted list of assigned tags
  * @mixin PolymorphicRelation
  */
-class ContentContainer extends ActiveRecord
+class ContentContainer extends ActiveRecord implements FindInstanceInterface
 {
+    use FindInstanceTrait;
 
     /**
      * @inheritdoc
@@ -76,6 +80,13 @@ class ContentContainer extends ActiveRecord
                 'pkAttribute' => 'pk'
             ]
         ];
+    }
+
+    public static function findInstance($identifier, ?array $config = [], iterable $simpleCondition = []): ?self
+    {
+        $config['stringKey'] ??= 'guid';
+
+        return static::findInstanceHelper($identifier, $config, $simpleCondition);
     }
 
     /**

--- a/protected/humhub/modules/space/behaviors/SpaceModelMembership.php
+++ b/protected/humhub/modules/space/behaviors/SpaceModelMembership.php
@@ -49,15 +49,15 @@ class SpaceModelMembership extends Behavior
     public function isMember($userId = '')
     {
         // Take current userid if none is given
-        if ($userId == '' && !Yii::$app->user->isGuest) {
-            $userId = Yii::$app->user->id;
-        } elseif ($userId == '' && Yii::$app->user->isGuest) {
+        $userId = User::findInstance($userId);
+
+        if (Yii::$app->user->isGuest) {
             return false;
         }
 
         $membership = $this->getMembership($userId);
 
-        if ($membership != null && $membership->status == Membership::STATUS_MEMBER) {
+        if ($membership !== null && $membership->status == Membership::STATUS_MEMBER) {
             return true;
         }
 

--- a/protected/humhub/modules/space/behaviors/SpaceModelMembership.php
+++ b/protected/humhub/modules/space/behaviors/SpaceModelMembership.php
@@ -38,26 +38,27 @@ use yii\validators\EmailValidator;
 class SpaceModelMembership extends Behavior
 {
 
-    private $_spaceOwner = null;
+    private ?User $_spaceOwner = null;
 
     /**
-     * Checks if given userId is Member of this Space.
+     * Checks if given userId is a Member of this Space.
      *
-     * @param integer $userId
+     * @param User|int|string|null $user
+     *
      * @return boolean
      */
-    public function isMember($userId = '')
+    public function isMember($user = null): bool
     {
         // Take current userid if none is given
-        $userId = User::findInstance($userId);
+        $user = User::findInstance($user);
 
-        if (Yii::$app->user->isGuest) {
+        if ($user === null && Yii::$app->user->isGuest) {
             return false;
         }
 
-        $membership = $this->getMembership($userId);
+        $membership = $this->getMembership($user);
 
-        if ($membership !== null && $membership->status == Membership::STATUS_MEMBER) {
+        if ($membership !== null && (int)$membership->status === Membership::STATUS_MEMBER) {
             return true;
         }
 
@@ -68,19 +69,15 @@ class SpaceModelMembership extends Behavior
      * Checks if a given Userid is allowed to leave this space.
      * A User is allowed to leave, if the can_cancel_membership flag in the space_membership table is 1. If it is 2, the decision is delegated to the space.
      *
-     * @param number $userId , if empty hte currently logged in user is taken.
+     * @param User|int|string|null $user User to check for. If empty, the currently logged-in user is used.
+     *
      * @return bool
      */
-    public function canLeave($userId = '')
+    public function canLeave($user = null): bool
     {
-        // Take current userid if none is given
-        if ($userId == '') {
-            $userId = Yii::$app->user->id;
-        }
+        $membership = $this->getMembership($user);
 
-        $membership = $this->getMembership($userId);
-
-        if ($membership != null && !empty($membership->can_cancel_membership)) {
+        if ($membership !== null && !empty($membership->can_cancel_membership)) {
             return $membership->can_cancel_membership === 1 || ($membership->can_cancel_membership === 2 && !empty($this->owner->members_can_leave));
         }
 
@@ -92,26 +89,22 @@ class SpaceModelMembership extends Behavior
      *
      * If no UserId is given, current UserId will be used
      *
-     * @param User|integer|null $user User instance or userId
+     * @param User|int|string|null $user User instance or userId
      * @return boolean
      */
-    public function isAdmin($user = null)
+    public function isAdmin($user = null): bool
     {
-        $userId = ($user instanceof User) ? $user->id : $user;
+        $user = User::findInstance($user);
 
-        if (empty($userId) && Yii::$app->user->can(new ManageSpaces())) {
+        if ($user === null) {
+            return Yii::$app->user->can(new ManageSpaces());
+        }
+
+        if ($this->isSpaceOwner($user)) {
             return true;
         }
 
-        if (!$userId) {
-            $userId = Yii::$app->user->id;
-        }
-
-        if ($this->isSpaceOwner($userId)) {
-            return true;
-        }
-
-        $membership = $this->getMembership($userId);
+        $membership = $this->getMembership($user);
 
         return ($membership && $membership->group_id == Space::USERGROUP_ADMIN && $membership->status == Membership::STATUS_MEMBER);
     }
@@ -119,22 +112,16 @@ class SpaceModelMembership extends Behavior
     /**
      * Sets Owner for this workspace
      *
-     * @param User|integer|null $userId
+     * @param User|int|string|null $user
      * @return boolean
      */
-    public function setSpaceOwner($user = null)
+    public function setSpaceOwner($user = null): bool
     {
-        $userId = ($user instanceof User) ? $user->id : $user;
+        $user = User::findInstance($user);
 
-        if ($userId instanceof User) {
-            $userId = $userId->id;
-        } elseif (!$userId || $userId == 0) {
-            $userId = Yii::$app->user->id;
-        }
+        $this->setAdmin($user);
 
-        $this->setAdmin($userId);
-
-        $this->owner->created_by = $userId;
+        $this->owner->created_by = $user->id;
         $this->owner->update(false, ['created_by']);
 
         $this->_spaceOwner = null;
@@ -145,15 +132,15 @@ class SpaceModelMembership extends Behavior
     /**
      * Gets Owner for this workspace
      *
-     * @return User
+     * @return User|null
      */
-    public function getSpaceOwner()
+    public function getSpaceOwner(): ?User
     {
-        if ($this->_spaceOwner != null) {
+        if ($this->_spaceOwner !== null) {
             return $this->_spaceOwner;
         }
 
-        $this->_spaceOwner = User::findOne(['id' => $this->owner->created_by]);
+        $this->_spaceOwner = User::findInstance($this->owner->created_by);
 
         return $this->_spaceOwner;
     }
@@ -168,39 +155,34 @@ class SpaceModelMembership extends Behavior
     }
 
     /**
-     * Is given User owner of this Space
-     * @param User|int|null $userId
+     * Is the given User owner of this Space
+     *
+     * @param User|int|string|null $user
+     *
      * @return bool
      */
-    public function isSpaceOwner($userId = null)
+    public function isSpaceOwner($user = null): bool
     {
-        if (empty($userId) && Yii::$app->user->isGuest) {
+        $user = User::findInstanceAsId($user);
+
+        if ($user === null && Yii::$app->user->isGuest) {
             return false;
-        } elseif ($userId instanceof User) {
-            $userId = $userId->id;
-        } elseif (empty($userId)) {
-            $userId = Yii::$app->user->id;
         }
 
-        return $this->owner->created_by == $userId;
+        return (int)$this->owner->created_by === $user;
     }
 
     /**
      * Sets Owner for this workspace
      *
-     * @param integer $userId
+     * @param User|int|string|null $user
      * @return boolean
      */
-    public function setAdmin($userId = null)
+    public function setAdmin($user = null)
     {
-        if ($userId instanceof User) {
-            $userId = $userId->id;
-        } elseif (!$userId || $userId == 0) {
-            $userId = Yii::$app->user->id;
-        }
+        $membership = $this->getMembership($user);
 
-        $membership = $this->getMembership($userId);
-        if ($membership != null) {
+        if ($membership !== null) {
             $membership->group_id = Space::USERGROUP_ADMIN;
             $membership->save();
             return true;
@@ -218,7 +200,7 @@ class SpaceModelMembership extends Behavior
      */
     public function getMembership($userId = null): ?Membership
     {
-        return Membership::findMembership($this->owner->id, $userId);
+        return Membership::findInstance([$this->owner->id, $userId]);
     }
 
     /**

--- a/protected/humhub/modules/space/models/Space.php
+++ b/protected/humhub/modules/space/models/Space.php
@@ -362,29 +362,25 @@ class Space extends ContentContainerActiveRecord implements FindInstanceInterfac
     /**
      * Indicates that this user can join this workspace
      *
-     * @param User|int|string $userId User ID of User
+     * @param User|int|string|null $user User ID of User
      */
-    public function canJoin($userId = '')
+    public function canJoin($user = null): bool
     {
         if (Yii::$app->user->isGuest) {
             return false;
         }
 
         // Take current userId if none is given
-        $userId = User::findInstanceAsId($userId);
+        $user = User::findInstance($user);
 
         // Checks if User is already a member
-        if ($this->isMember($userId)) {
+        if ($this->isMember($user)) {
             return false;
         }
 
         if ($this->join_policy == self::JOIN_POLICY_NONE) {
             return false;
         }
-
-        $user = Yii::$app->runtimeCache->getOrSet(User::class . '#' . $userId, function() use ($userId) {
-            return User::findOne($userId);
-        });
 
         if ($this->isBlockedForUser($user)) {
             return false;
@@ -394,20 +390,14 @@ class Space extends ContentContainerActiveRecord implements FindInstanceInterfac
     }
 
     /**
-     * Indicates that this user can join this workspace w
-     * ithout permission
+     * Indicates that this user can join this workspace without permission
      *
-     * @param $userId User Id of User
+     * @param User|int|string|null $user User ID of User
      */
-    public function canJoinFree($userId = '')
+    public function canJoinFree($user = null): bool
     {
-        // Take current userid if none is given
-        if ($userId == '') {
-            $userId = Yii::$app->user->id;
-        }
-
         // Checks if User is already member
-        if ($this->isMember($userId)) {
+        if ($this->isMember($user)) {
             return false;
         }
 

--- a/protected/humhub/modules/space/models/Space.php
+++ b/protected/humhub/modules/space/models/Space.php
@@ -9,6 +9,9 @@
 namespace humhub\modules\space\models;
 
 use humhub\components\behaviors\GUID;
+use humhub\components\CacheableActiveQuery;
+use humhub\components\FindInstanceTrait;
+use humhub\interfaces\FindInstanceInterface;
 use humhub\modules\content\components\ContentContainerActiveRecord;
 use humhub\modules\content\components\ContentContainerSettingsManager;
 use humhub\modules\content\models\Content;
@@ -60,8 +63,9 @@ use Yii;
  * @mixin \humhub\modules\space\behaviors\SpaceModelMembership
  * @mixin \humhub\modules\user\behaviors\Followable
  */
-class Space extends ContentContainerActiveRecord implements Searchable
+class Space extends ContentContainerActiveRecord implements FindInstanceInterface, Searchable
 {
+    use FindInstanceTrait;
 
     // Join Policies
     const JOIN_POLICY_NONE = 0; // No Self Join Possible
@@ -251,6 +255,8 @@ class Space extends ContentContainerActiveRecord implements Searchable
      */
     public function afterSave($insert, $changedAttributes)
     {
+        CacheableActiveQuery::cacheProcessVariants('delete', $this);
+
         parent::afterSave($insert, $changedAttributes);
 
         Yii::$app->queue->push(new UpdateDocument([
@@ -258,7 +264,7 @@ class Space extends ContentContainerActiveRecord implements Searchable
             'primaryKey' => $this->id
         ]));
 
-        $user = User::findOne(['id' => $this->created_by]);
+        $user = User::findInstance($this->created_by);
 
         if ($insert) {
             // Auto add creator as admin
@@ -335,14 +341,28 @@ class Space extends ContentContainerActiveRecord implements Searchable
      */
     public static function find()
     {
-        return new ActiveQuerySpace(get_called_class());
+        return new ActiveQuerySpace(static::class);
     }
 
+    /**
+     * @param Space|int|string $identifier Space object, Space ID, or Space GUID.
+     *
+     * @inheritdoc
+     * @since 1.15
+     */
+    public static function findInstance($identifier, ?array $config = [], iterable $simpleCondition = []): ?self
+    {
+        $config['exceptionMessageSuffix'] ??= '(must be a Space object or Space ID)';
+        $config['stringKey'] = 'guid';
+        $config['onEmpty'] = null;
+
+        return self::findInstanceHelper($identifier, $config, $simpleCondition);
+    }
 
     /**
      * Indicates that this user can join this workspace
      *
-     * @param $userId User Id of User
+     * @param User|int|string $userId User ID of User
      */
     public function canJoin($userId = '')
     {
@@ -351,11 +371,9 @@ class Space extends ContentContainerActiveRecord implements Searchable
         }
 
         // Take current userId if none is given
-        if ($userId == '') {
-            $userId = Yii::$app->user->id;
-        }
+        $userId = User::findInstanceAsId($userId);
 
-        // Checks if User is already member
+        // Checks if User is already a member
         if ($this->isMember($userId)) {
             return false;
         }

--- a/protected/humhub/modules/space/models/forms/InviteForm.php
+++ b/protected/humhub/modules/space/models/forms/InviteForm.php
@@ -136,7 +136,7 @@ class InviteForm extends Model
         // Allow users to perform this action if this is allowed by config file
         // Pre-check if user is member of the space in question
         if (Yii::$app->getModule('space')->membersCanAddWithoutInvite === true) {
-            $membership = Membership::findMembership($this->space->id, Yii::$app->user->identity->id);
+            $membership = Membership::findInstance([$this->space->id, Yii::$app->user->identity->id]);
 
             if ($membership && $membership->status == Membership::STATUS_MEMBER) {
                 return true;
@@ -213,7 +213,7 @@ class InviteForm extends Model
      */
     private function addUserToInviteList(User $user): bool
     {
-        $membership = Membership::findMembership($this->space->id, $user->id);
+        $membership = Membership::findInstance([$this->space->id, $user->id]);
 
         if ($membership && (int)$membership->status === Membership::STATUS_MEMBER) {
             return false;

--- a/protected/humhub/modules/space/modules/manage/controllers/MemberController.php
+++ b/protected/humhub/modules/space/modules/manage/controllers/MemberController.php
@@ -53,7 +53,7 @@ class MemberController extends Controller
         // User Group Change
         if (Yii::$app->request->post('dropDownColumnSubmit')) {
             Yii::$app->response->format = 'json';
-            $membership = Membership::findMembership($space->id, Yii::$app->request->post('user_id'));
+            $membership = Membership::findInstance([$space->id, Yii::$app->request->post('user_id')]);
             if ($membership === null) {
                 throw new HttpException(404, 'Could not find membership!');
             }

--- a/protected/humhub/modules/space/tests/codeception/unit/InviteTest.php
+++ b/protected/humhub/modules/space/tests/codeception/unit/InviteTest.php
@@ -24,7 +24,7 @@ class InviteTest extends HumHubDbTestCase
         $this->assertHasNotification(\humhub\modules\space\notifications\Invite::class, $space, Yii::$app->user->id, 'Invite Request Notification');
 
         // check cached version
-        $membership = \humhub\modules\space\models\Membership::findMembership(1, 2);
+        $membership = \humhub\modules\space\models\Membership::findInstance([1, 2]);
         $this->assertNotNull($membership);
         $this->assertEquals($membership->status, \humhub\modules\space\models\Membership::STATUS_INVITED);
 
@@ -52,7 +52,7 @@ class InviteTest extends HumHubDbTestCase
         $this->assertHasNotification(\humhub\modules\space\notifications\Invite::class, $space, Yii::$app->user->id, 'Invite Request Notification');
 
         // check cached version
-        $membership = \humhub\modules\space\models\Membership::findMembership(1, 2);
+        $membership = \humhub\modules\space\models\Membership::findInstance([1, 2]);
         $this->assertNotNull($membership);
         $this->assertEquals($membership->status, \humhub\modules\space\models\Membership::STATUS_INVITED);
 

--- a/protected/humhub/modules/space/tests/codeception/unit/MembershipTest.php
+++ b/protected/humhub/modules/space/tests/codeception/unit/MembershipTest.php
@@ -26,7 +26,7 @@ class MembershipTest extends HumHubDbTestCase
             Yii::$app->user->id, 'Approval Request Notification');
 
         // check cached version
-        $membership = Membership::findMembership(1, Yii::$app->user->id);
+        $membership = Membership::findInstance([1, Yii::$app->user->id]);
         $this->assertNotNull($membership);
         $this->assertEquals($membership->status, Membership::STATUS_APPLICANT);
 
@@ -68,7 +68,7 @@ class MembershipTest extends HumHubDbTestCase
             Yii::$app->user->id, 'Approval Request Notification');
 
         // check cached version
-        $membership = Membership::findMembership(1, Yii::$app->user->id);
+        $membership = Membership::findInstance([1, Yii::$app->user->id]);
         $this->assertNotNull($membership);
         $this->assertEquals($membership->status, Membership::STATUS_APPLICANT);
 
@@ -87,7 +87,7 @@ class MembershipTest extends HumHubDbTestCase
 
     public function testChangeRoleMembership()
     {
-        $membership = Membership::findMembership(3, 2);
+        $membership = Membership::findInstance([3, 2]);
 
         \humhub\modules\space\notifications\ChangedRolesMembership::instance()
             ->about($membership)

--- a/protected/humhub/modules/user/components/User.php
+++ b/protected/humhub/modules/user/components/User.php
@@ -8,6 +8,7 @@
 
 namespace humhub\modules\user\components;
 
+use humhub\libs\BasePermission;
 use humhub\modules\user\events\UserEvent;
 use humhub\modules\user\helpers\AuthHelper;
 use humhub\modules\user\models\User as UserModel;

--- a/protected/humhub/modules/user/models/Group.php
+++ b/protected/humhub/modules/user/models/Group.php
@@ -9,6 +9,8 @@
 namespace humhub\modules\user\models;
 
 use humhub\components\ActiveRecord;
+use humhub\components\FindInstanceTrait;
+use humhub\interfaces\FindInstanceInterface;
 use humhub\modules\admin\notifications\ExcludeGroupNotification;
 use humhub\modules\admin\notifications\IncludeGroupNotification;
 use humhub\modules\admin\permissions\ManageGroups;
@@ -42,10 +44,14 @@ use Yii;
  * @property GroupUser[] groupUsers
  * @property GroupSpace[] groupSpaces
  */
-class Group extends ActiveRecord
+class Group extends ActiveRecord implements FindInstanceInterface
 {
+    use FindInstanceTrait {
+        afterDelete as __FindInstanceTrait_afterDelete;
+        afterSave as __FindInstanceTrait_afterSave;
+    }
 
-    const SCENARIO_EDIT = 'edit';
+    public const SCENARIO_EDIT = 'edit';
 
     /**
      * @inheritdoc
@@ -67,6 +73,11 @@ class Group extends ActiveRecord
             ['show_at_registration', 'validateShowAtRegistration'],
             ['is_default_group', 'validateIsDefaultGroup'],
         ];
+    }
+
+    public static function findInstance($identifier, ?array $config = [], iterable $simpleCondition = []): ?self
+    {
+        return self::findInstanceHelper($identifier, $config, $simpleCondition);
     }
 
     /**
@@ -179,13 +190,11 @@ class Group extends ActiveRecord
     public function afterSave($insert, $changedAttributes)
     {
         if ($this->is_default_group) {
-            // Only single group can be default:
-            Group::updateAll(['is_default_group' => '0'], ['!=', 'id', $this->id]);
+            // Only one single group can be default:
+            self::updateAll(['is_default_group' => '0'], ['!=', 'id', $this->id]);
         }
 
-        parent::afterSave($insert, $changedAttributes);
-
-
+        $this->__FindInstanceTrait_afterSave($insert, $changedAttributes);
     }
 
     /**
@@ -199,7 +208,7 @@ class Group extends ActiveRecord
             $defaultGroup->assignDefaultGroup();
         }
 
-        parent::afterDelete();
+        $this->__FindInstanceTrait_afterDelete();
     }
 
     /**

--- a/protected/humhub/modules/user/models/Invite.php
+++ b/protected/humhub/modules/user/models/Invite.php
@@ -10,6 +10,8 @@ namespace humhub\modules\user\models;
 
 use humhub\components\access\ControllerAccess;
 use humhub\components\ActiveRecord;
+use humhub\components\FindInstanceTrait;
+use humhub\interfaces\FindInstanceInterface;
 use humhub\modules\space\models\Space;
 use humhub\modules\user\Module;
 use Yii;
@@ -36,14 +38,15 @@ use yii\helpers\Url;
  *
  * @property Space $space
  */
-class Invite extends ActiveRecord
+class Invite extends ActiveRecord implements FindInstanceInterface
 {
+    use FindInstanceTrait;
 
-    const SOURCE_SELF = 'self';
-    const SOURCE_INVITE = 'invite';
-    const SOURCE_INVITE_BY_LINK = 'invite_by_link';
-    const EMAIL_TOKEN_LENGTH = 12;
-    const LINK_TOKEN_LENGTH = 14; // Should be different that EMAIL_TOKEN_LENGTH
+    public const SOURCE_SELF = 'self';
+    public const SOURCE_INVITE = 'invite';
+    public const SOURCE_INVITE_BY_LINK = 'invite_by_link';
+    public const EMAIL_TOKEN_LENGTH = 12;
+    public const LINK_TOKEN_LENGTH = 14; // Should be different that EMAIL_TOKEN_LENGTH
 
     public $captcha;
 
@@ -106,6 +109,15 @@ class Invite extends ActiveRecord
             'language' => Yii::t('base', 'Language'),
         ];
     }
+
+    public static function findInstance($identifier, ?array $config = [], iterable $simpleCondition = []): ?self
+    {
+        $config['stringKey'] ??= 'email';
+        $config['onEmpty'] = null;
+
+        return self::findInstanceHelper($identifier, $config, $simpleCondition);
+    }
+
 
     /**
      * @inheritdoc

--- a/protected/humhub/modules/user/services/IsOnlineService.php
+++ b/protected/humhub/modules/user/services/IsOnlineService.php
@@ -35,9 +35,12 @@ class IsOnlineService
         }
     }
 
-    public function getStatus(): bool
+    public function getStatus(bool $showSelfStatus = false): bool
     {
-        return $this->isEnabled() && Yii::$app->cache->exists($this->getCacheKey());
+        return
+            $this->isEnabled()
+            && Yii::$app->cache->exists($this->getCacheKey())
+            && ($showSelfStatus || $this->user->id !== Yii::$app->user->id);
     }
 
     public function isEnabled(): bool

--- a/protected/humhub/modules/user/widgets/Image.php
+++ b/protected/humhub/modules/user/widgets/Image.php
@@ -34,6 +34,8 @@ class Image extends BaseImage
 
     public bool $hideOnlineStatus = false;
 
+    public bool $showSelfOnlineStatus = false;
+
     /**
      * @inheritdoc
      */
@@ -72,7 +74,7 @@ class Image extends BaseImage
             } else {
                 Html::addCssClass($this->htmlOptions, ['has-online-status', $imgSize]);
             }
-            $userIsOnline = $isOnlineService->getStatus();
+            $userIsOnline = $isOnlineService->getStatus($this->showSelfOnlineStatus);
             $html .= Html::tag('span', '', [
                 'class' => ['tt user-online-status', $userIsOnline ? 'user-is-online' : 'user-is-offline'],
                 'title' => $userIsOnline ?

--- a/protected/humhub/modules/user/widgets/views/accountTopMenu.php
+++ b/protected/humhub/modules/user/widgets/views/accountTopMenu.php
@@ -44,7 +44,7 @@ $userModel = Yii::$app->user->identity;
                 'link' => false,
                 'width' => 32,
                 'htmlOptions' => ['id' => 'user-account-image'],
-                'hideOnlineStatus' => true,
+                'showSelfOnlineStatus' => true,
             ]) ?>
 
             <b class="caret"></b>

--- a/protected/humhub/tests/codeception/unit/components/FindInstanceCache.php
+++ b/protected/humhub/tests/codeception/unit/components/FindInstanceCache.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * @link      https://www.humhub.org/
+ * @copyright Copyright (c) 2023 HumHub GmbH & Co. KG
+ * @license   https://www.humhub.com/licences
+ */
+
+namespace humhub\tests\codeception\unit\components;
+
+use humhub\components\FindInstanceTrait;
+use humhub\interfaces\FindInstanceInterface;
+use yii\caching\ArrayCache;
+
+use function PHPUnit\Framework\callback;
+
+class FindInstanceCache extends ArrayCache
+{
+    public ?string $cacheRead = null;
+    public ?string $cacheWritten = null;
+
+    /**
+     * @var object|null|false
+     */
+    public $valueRetrieved = false;
+
+    private $callback;
+    public string $lastKey = '';
+
+    public function buildKey($key)
+    {
+        return $this->lastKey = parent::buildKey($key);
+    }
+
+    public function getOrSet($key, $callable, $duration = null, $dependency = null)
+    {
+        $this->callback = $callable;
+
+        return parent::getOrSet($key, [$this, 'callCallback'], $duration, $dependency);
+    }
+    public function getValue($key)
+    {
+        $this->cacheRead = $key;
+        return parent::getValue($key);
+    }
+
+    protected function setValue($key, $value, $duration)
+    {
+        $this->cacheWritten = $key;
+
+        return parent::setValue($key, $value, $duration);
+    }
+
+    public function callCallback(...$args)
+    {
+        return $this->valueRetrieved = call_user_func($this->callback, ...$args);
+    }
+
+    /**
+     * @return bool
+     */
+    public function flushValues(): bool
+    {
+        $this->resetState();
+
+        return $this->flush();
+    }
+
+    public function resetState()
+    {
+        $this->callback = null;
+        $this->cacheRead = null;
+        $this->cacheWritten = null;
+        $this->valueRetrieved = false;
+    }
+}

--- a/protected/humhub/tests/codeception/unit/components/FindInstanceMock.php
+++ b/protected/humhub/tests/codeception/unit/components/FindInstanceMock.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * @link      https://www.humhub.org/
+ * @copyright Copyright (c) 2023 HumHub GmbH & Co. KG
+ * @license   https://www.humhub.com/licences
+ */
+
+namespace humhub\tests\codeception\unit\components;
+
+use humhub\components\FindInstanceTrait;
+use humhub\interfaces\FindInstanceInterface;
+
+class FindInstanceMock implements FindInstanceInterface
+{
+    use FindInstanceTrait;
+
+    public array $args;
+
+    public function __construct(...$args)
+    {
+        $this->args = $args;
+    }
+
+    public static function find()
+    {
+        return new static();
+    }
+
+    public function where($criteria)
+    {
+        $this->args[] = $criteria;
+        return $this;
+    }
+
+    public function one()
+    {
+        return $this;
+    }
+
+    public static function findOne($condition): ?self
+    {
+        return new static($condition);
+    }
+
+    public static function findInstance($identifier, ?array $config = [], iterable $simpleCondition = []): ?self
+    {
+        return static::findInstanceHelper($identifier, $config, $simpleCondition);
+    }
+}

--- a/protected/humhub/tests/codeception/unit/components/FindInstanceTest.php
+++ b/protected/humhub/tests/codeception/unit/components/FindInstanceTest.php
@@ -1,0 +1,195 @@
+<?php
+
+/*
+ * @link      https://www.humhub.org/
+ * @copyright Copyright (c) 2023 HumHub GmbH & Co. KG
+ * @license   https://www.humhub.com/licences
+ */
+
+/**
+ * @noinspection PhpUnhandledExceptionInspection
+ */
+
+namespace humhub\tests\codeception\unit\components;
+
+use Exception;
+use humhub\exceptions\InvalidArgumentTypeException;
+use humhub\exceptions\InvalidConfigTypeException;
+use humhub\interfaces\FindInstanceInterface;
+use tests\codeception\_support\HumHubDbTestCase;
+use Yii;
+use yii\base\BaseObject;
+use yii\web\HttpException;
+
+class FindInstanceTest extends HumHubDbTestCase
+{
+    public function testCreateTestInstance()
+    {
+        static::assertInstanceOf(FindInstanceInterface::class, $instance = new FindInstanceMock(1, [2]));
+        static::assertEquals(1, $instance->args[0], 'First argument does not match!');
+        static::assertEquals([2], $instance->args[1], 'Second argument does not match!');
+    }
+
+    public function testSelfIdentifier()
+    {
+        $instance = new FindInstanceMock();
+
+        static::assertInstanceOf(FindInstanceInterface::class, $instance2 = FindInstanceMock::findInstance($instance));
+        static::assertEquals($instance, $instance2);
+    }
+
+    public function testOnEmptyConfig()
+    {
+        $instance = new FindInstanceMock();
+
+        static::assertEquals(null, FindInstanceMock::findInstance(null, ['onEmpty' => null]));
+        static::assertEquals($instance, FindInstanceMock::findInstance(null, ['onEmpty' => $instance]));
+
+        static::assertEquals(null, FindInstanceMock::findInstance('', ['onEmpty' => null]));
+        static::assertEquals($instance, FindInstanceMock::findInstance('', ['onEmpty' => $instance]));
+
+        static::assertEquals(null, FindInstanceMock::findInstance([], ['onEmpty' => null]));
+        static::assertEquals($instance, FindInstanceMock::findInstance([], ['onEmpty' => $instance]));
+
+        static::assertInstanceOf(FindInstanceInterface::class, FindInstanceMock::findInstance(0, ['onEmpty' => null]));
+        static::assertInstanceOf(FindInstanceInterface::class, FindInstanceMock::findInstance('0', ['onEmpty' => null]));
+
+        static::assertInstanceOf(FindInstanceInterface::class, FindInstanceMock::findInstance(108, ['onEmpty' => null]));
+        static::assertInstanceOf(FindInstanceInterface::class, FindInstanceMock::findInstance('108', ['onEmpty' => null]));
+    }
+
+    public function testIntKeyConfig()
+    {
+        static::assertInstanceOf(FindInstanceInterface::class, $instance = FindInstanceMock::findInstance(1, ['intKey' => null]));
+        static::assertEquals(['id' => 1], $instance->args[0]);
+
+        static::assertInstanceOf(FindInstanceInterface::class, $instance = FindInstanceMock::findInstance(1, ['intKey' => 'guid']));
+        static::assertEquals(['guid' => 1], $instance->args[0]);
+
+        $this->expectException(InvalidArgumentTypeException::class);
+        $this->expectExceptionMessage('Argument #1 $identifier passed to humhub\components\FindInstanceTrait::findInstanceHelper must be of type humhub\tests\codeception\unit\components\FindInstanceMock, int, (int)string - string given.');
+
+        FindInstanceMock::findInstance('test', ['intKey' => 'guid']);
+    }
+
+    public function testStringKeyConfig()
+    {
+        static::assertInstanceOf(FindInstanceInterface::class, $instance = FindInstanceMock::findInstance(1, ['stringKey' => null]));
+        static::assertEquals(['id' => 1], $instance->args[0]);
+
+        static::assertInstanceOf(FindInstanceInterface::class, $instance = FindInstanceMock::findInstance(1, ['stringKey' => 'guid']));
+        static::assertEquals(['id' => 1], $instance->args[0]);
+
+        static::assertInstanceOf(FindInstanceInterface::class, $instance = FindInstanceMock::findInstance('test', ['stringKey' => 'guid']));
+        static::assertEquals(['guid' => 'test'], $instance->args[0]);
+    }
+
+    public function testExceptionOnNullIdentifier()
+    {
+        $this->expectException(InvalidArgumentTypeException::class);
+        $this->expectExceptionMessage('Argument #1 $identifier passed to humhub\components\FindInstanceTrait::findInstanceHelper must be of type humhub\tests\codeception\unit\components\FindInstanceMock, int, (int)string - null given.');
+
+        FindInstanceMock::findInstance(null);
+    }
+
+    public function testExceptionOnEmptyStringIdentifier()
+    {
+        $this->expectException(InvalidArgumentTypeException::class);
+        $this->expectExceptionMessage('Argument #1 $identifier passed to humhub\components\FindInstanceTrait::findInstanceHelper must be of type humhub\tests\codeception\unit\components\FindInstanceMock, int, (int)string - string given.');
+
+        FindInstanceMock::findInstance('');
+    }
+
+    public function testExceptionOnEmptyArrayIdentifier()
+    {
+        $this->expectException(InvalidArgumentTypeException::class);
+        $this->expectExceptionMessage('Argument #1 $identifier passed to humhub\components\FindInstanceTrait::findInstanceHelper must be of type humhub\tests\codeception\unit\components\FindInstanceMock, int, (int)string - array given.');
+
+        FindInstanceMock::findInstance([]);
+    }
+
+    public function testCustomExceptionInstance()
+    {
+        $e = new HttpException(404);
+        $this->expectException(HttpException::class);
+        $this->expectExceptionMessage('');
+
+        FindInstanceMock::findInstance(null, ['exception' => $e]);
+    }
+
+    public function testCustomExceptionClass()
+    {
+        $e = Exception::class;
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('');
+
+        FindInstanceMock::findInstance(null, ['exception' => $e]);
+    }
+
+    public function testInvalidCustomExceptionClass()
+    {
+        $e = BaseObject::class;
+        $this->expectException(InvalidConfigTypeException::class);
+        $this->expectExceptionMessage('Parameter \'exception\' of configuration passed to humhub\components\FindInstanceTrait::findInstanceHelper must be of type Throwable, null - string given.');
+
+        FindInstanceMock::findInstance(null, ['exception' => $e]);
+    }
+
+    public function testInvalidCustomExceptionConfigType()
+    {
+        $e = [];
+        $this->expectException(InvalidConfigTypeException::class);
+        $this->expectExceptionMessage('Parameter \'exception\' of configuration passed to humhub\components\FindInstanceTrait::findInstanceHelper must be of type Throwable, null - array given.');
+
+        FindInstanceMock::findInstance(null, ['exception' => $e]);
+    }
+
+    public function testCache()
+    {
+        $currentCache = Yii::$app->runtimeCache;
+        Yii::$app->set('runtimeCache', $cache = new FindInstanceCache(['serializer' => false]));
+        static::assertNull($cache->cacheRead);
+        static::assertNull($cache->cacheWritten);
+        static::assertFalse($cache->valueRetrieved);
+
+        // get non-cached object
+        static::assertInstanceOf(FindInstanceInterface::class, $instance = FindInstanceMock::findInstance(1));
+        static::assertNotNull($cache->cacheRead);
+        static::assertNotNull($cache->cacheWritten);
+        static::assertEquals($instance, $cache->valueRetrieved);
+
+        $cache->resetState();
+
+        // get the same object from cache
+        static::assertInstanceOf(FindInstanceInterface::class, $instance2 = FindInstanceMock::findInstance(1));
+        static::assertNotNull($cache->cacheRead);
+        static::assertNull($cache->cacheWritten);
+        static::assertFalse($cache->valueRetrieved);
+        static::assertEquals($instance, $cache->get('humhub_tests_codeception_unit_components_FindInstanceMock__1'));
+        static::assertEquals(spl_object_id($instance2), spl_object_id($cache->get('humhub_tests_codeception_unit_components_FindInstanceMock__1')));
+        static::assertEquals(spl_object_id($instance), spl_object_id($cache->get('humhub_tests_codeception_unit_components_FindInstanceMock__1')));
+
+        $cache->resetState();
+
+        // get an un-cached object (new object from "db") and store it in cache
+        static::assertInstanceOf(FindInstanceInterface::class, $instance2 = FindInstanceMock::findInstance(1, ['cached' => false]));
+        static::assertNull($cache->cacheRead);
+        static::assertNotNull($cache->cacheWritten);
+        static::assertFalse($cache->valueRetrieved);
+
+        // check it's like the object from the cache
+        static::assertEquals($instance2, $cache->get('humhub_tests_codeception_unit_components_FindInstanceMock__1'));
+
+        // check it *is* the object from the cache
+        static::assertEquals(spl_object_id($instance2), spl_object_id($cache->get('humhub_tests_codeception_unit_components_FindInstanceMock__1')));
+
+        // check if it looks like our original object
+        static::assertEquals($instance2, $instance);
+
+        // check that it is however *not* the same object
+        static::assertNotEquals(spl_object_id($instance), spl_object_id($instance2));
+
+        // restore original cache
+        Yii::$app->set('runtimeCache', $currentCache);
+    }
+}

--- a/static/js/humhub/humhub.client.js
+++ b/static/js/humhub/humhub.client.js
@@ -101,7 +101,7 @@ humhub.module('client', function (module, require, $) {
     };
 
     var submit = function ($form, cfg, originalEvent) {
-        if ($form instanceof $.Event && $form.$form && $form.length) {
+        if ($form instanceof $.Event && $form.$form && ($form.length || $form.$form.length)) {
             originalEvent = $form;
             $form = $form.$form;
         } else if ($form instanceof $.Event && $form.$trigger) {

--- a/static/js/humhub/humhub.ui.modal.js
+++ b/static/js/humhub/humhub.ui.modal.js
@@ -131,7 +131,10 @@ humhub.module('ui.modal', function (module, require, $) {
     /**
      * Sets the loader to footer in order to inactivate the action buttons
      */
-    Modal.prototype.footerLoader = function () {
+    Modal.prototype.footerLoader = function (evt) {
+        if (evt instanceof $.Event) {
+            evt.$form = evt.$trigger.closest('form');
+        }
         loader.set(this.getFooter(), {css: {padding: '13px 0 14px'}});
     }
 
@@ -763,8 +766,8 @@ humhub.module('ui.modal', function (module, require, $) {
         };
     };
 
-    const footerLoader = function () {
-        module.global.footerLoader();
+    const footerLoader = function (evt) {
+        module.global.footerLoader(evt);
     }
 
     const setContent = function (html) {

--- a/static/less/topbar.less
+++ b/static/less/topbar.less
@@ -94,6 +94,10 @@
             span {
                 font-size: 12px;
             }
+
+            #user-account-image {
+                margin-bottom: 0;
+            }
         }
     }
 
@@ -209,13 +213,16 @@
 
     .dropdown-footer {
         margin: 10px 10px 5px;
+
         .btn.btn-default {
             border: 1px solid @default;
             box-shadow: none;
+
             &:hover {
                 border-color: @background3;
                 background: @background3;
             }
+
             &:active {
                 border-color: @text-color-secondary;
                 background: white;

--- a/themes/HumHub/css/theme.css
+++ b/themes/HumHub/css/theme.css
@@ -1,1 +1,5936 @@
-:root{--default:#f3f3f3;--primary:#435f6f;--info:#21A1B3;--success:#97d271;--warning:#FFC107;--danger:#FC4A64;--link:#21A1B3;--text-color-main:#555;--text-color-secondary:#7a7a7a;--text-color-highlight:#000;--text-color-soft:#555555;--text-color-soft2:#aeaeae;--text-color-soft3:#bac2c7;--text-color-contrast:#fff;--background-color-main:#fff;--background-color-secondary:#f8f8f8;--background-color-page:#ededed;--background-color-highlight:#daf0f3;--background-color-highlight-soft:#f2f9fb;--background3:#d7d7d7;--background4:#b2b2b2;--background-color-success:#f7fbf4;--text-color-success:#84be5e;--border-color-success:#97d271;--background-color-warning:#fffbf7;--text-color-warning:#e9b168;--border-color-warning:#fdd198;--background-color-danger:#fff6f6;--text-color-danger:#ff8989;--border-color-danger:#ff8989;--mail-font-family:'Open Sans',Arial,Tahoma,Helvetica,sans-serif}.colorDefault{color:#f3f3f3}.backgroundDefault{background:#f3f3f3}.borderDefault{border-color:#f3f3f3}.colorPrimary{color:#435f6f !important}.backgroundPrimary{background:#435f6f !important}.borderPrimary{border-color:#435f6f !important}.colorInfo{color:#21A1B3 !important}.backgroundInfo{background:#21A1B3 !important}.borderInfo{border-color:#21A1B3 !important}.colorLink{color:#21A1B3 !important}.colorSuccess{color:#97d271 !important}.backgroundSuccess{background:#97d271 !important}.borderSuccess{border-color:#97d271 !important}.colorWarning{color:#FFC107 !important}.backgroundWarning{background:#FFC107 !important}.borderWarning{border-color:#FFC107 !important}.colorDanger{color:#FC4A64 !important}.backgroundDanger{background:#FC4A64 !important}.borderDanger{border-color:#FC4A64 !important}.colorFont1{color:#bac2c7 !important}.colorFont2{color:#7a7a7a !important}.colorFont3{color:#000 !important}.colorFont4{color:#555555 !important}.colorFont5{color:#aeaeae !important}.heading{font-size:16px;font-weight:300;color:#000;background-color:white;border:none;padding:10px}.text-center{text-align:center !important}.text-break{word-wrap:break-word;overflow-wrap:break-word;word-break:break-word;hyphens:auto}.img-rounded{border-radius:3px}body{word-wrap:break-word;overflow-wrap:break-word;word-break:break-word;hyphens:auto;padding-top:130px;background-color:#ededed;color:#555;font-family:'Open Sans',sans-serif}body a,body a:hover,body a:focus,body a:active,body a.active{color:#000;text-decoration:none}a:hover{text-decoration:none}hr{margin-top:10px;margin-bottom:10px}.col-md-1,.col-md-2,.col-md-3,.col-md-4,.col-md-5,.col-md-6,.col-md-7,.col-md-8,.col-md-9,.col-md-10,.col-md-11,.col-md-12{position:inherit}.layout-nav-container{padding:0 0 0 15px}.layout-sidebar-container{padding:0 15px 0 0}@media (max-width:768px){.layout-nav-container{padding:0 15px}.layout-nav-container .left-navigation{margin-bottom:0}}h4{font-weight:300;font-size:150%}input[type=text],input[type=password],input[type=select]{appearance:none}.powered,.powered a{color:#b8c7d3 !important}.langSwitcher{display:inline-block}[data-ui-show-more]{overflow:hidden}@media (min-width:768px) and (max-width:991px){.layout-nav-container{padding:0 15px}body{padding-top:120px}}@media print{#topbar-first,#topbar-second{display:none}}span.likeLinkContainer .like.disabled,span.likeLinkContainer .unlike.disabled{pointer-events:none;cursor:default;text-decoration:none;color:lightgrey}.panel-body a[data-toggle],.modal-body a[data-toggle]{color:#21A1B3}.showMore{font-size:13px}.table-responsive{word-wrap:normal;overflow-wrap:normal;word-break:normal;hyphens:none}.topbar{position:fixed;display:block;height:50px;width:100%;padding-left:15px;padding-right:15px}.topbar ul.nav{float:left}.topbar ul.nav>li{float:left}.topbar ul.nav>li>a{padding-top:15px;padding-bottom:15px;line-height:20px}.topbar .dropdown-footer{margin:10px}.topbar .dropdown-header{font-size:16px;padding:3px 10px;margin-bottom:10px;font-weight:300;color:#555555}.topbar .dropdown-header .dropdown-header-link{position:absolute;top:2px;right:10px}.topbar .dropdown-header .dropdown-header-link a{color:#21A1B3 !important;font-size:12px;font-weight:normal}.topbar .dropdown-header:hover{color:#555555}#topbar-first{background-color:#435f6f;top:0;z-index:1030;color:white}#topbar-first a.navbar-brand{height:50px;padding:5px}#topbar-first a.navbar-brand img#img-logo{max-height:40px}#topbar-first a.navbar-brand-text{padding-top:15px}#topbar-first .nav>li>a:hover,#topbar-first .nav>.open>a{background-color:#567a8f}#topbar-first .nav>.account{height:50px;margin-left:20px}#topbar-first .nav>.account img{margin-left:10px}#topbar-first .nav>.account .dropdown-toggle{padding:10px 5px 8px;line-height:1.1em;text-align:left}#topbar-first .nav>.account .dropdown-toggle span{font-size:12px}#topbar-first .topbar-brand{position:relative;z-index:2}#topbar-first .topbar-actions{position:relative;z-index:3}#topbar-first .notifications{position:absolute;left:0;right:0;text-align:center;z-index:1}#topbar-first .notifications .btn-group{position:relative;text-align:left}#topbar-first .notifications .btn-group>a{padding:5px 10px;margin:10px 2px;display:inline-block;border-radius:2px;text-decoration:none;text-align:left}#topbar-first .notifications .btn-group>.label{position:absolute;top:4px;right:-2px}#topbar-first .notifications .arrow:after{position:absolute;display:block;width:0;height:0;border-color:transparent;border-style:solid;border-width:10px;content:" ";top:1px;margin-left:-10px;border-top-width:0;border-bottom-color:#fff;z-index:1035}#topbar-first .notifications .arrow{position:absolute;display:block;width:0;height:0;border-color:transparent;border-style:solid;z-index:1001;border-width:11px;left:50%;margin-left:-18px;border-top-width:0;border-bottom-color:rgba(0,0,0,0.15);top:-19px;z-index:1035}#topbar-first .notifications .dropdown-menu{width:350px;margin-left:-148px}#topbar-first .notifications .dropdown-menu ul.media-list{max-height:400px;overflow:auto}#topbar-first .notifications .dropdown-menu li{position:relative}#topbar-first .notifications .dropdown-menu li i.approval{position:absolute;left:2px;top:36px;font-size:14px}#topbar-first .notifications .dropdown-menu li i.accepted{color:#5cb85c}#topbar-first .notifications .dropdown-menu li i.declined{color:#d9534f}#topbar-first .notifications .dropdown-menu li .media{position:relative}#topbar-first .notifications .dropdown-menu li .media .img-space{position:absolute;top:14px;left:14px}#topbar-first .dropdown-footer{margin:10px 10px 5px}#topbar-first .dropdown-footer .btn.btn-default{border:1px solid #f3f3f3;box-shadow:none}#topbar-first .dropdown-footer .btn.btn-default:hover{border-color:#d7d7d7;background:#d7d7d7}#topbar-first .dropdown-footer .btn.btn-default:active{border-color:#7a7a7a;background:white}#topbar-first a{color:white}#topbar-first .caret{border-top-color:#fff}#topbar-first .btn-group>a{background-color:#4d6d7f}#topbar-first .btn-enter{background-color:#4d6d7f;margin:6px 0}#topbar-first .btn-enter:hover{background-color:#527588}#topbar-first .media-list a{color:#000;padding:0}#topbar-first .media-list li{color:#000}#topbar-first .media-list li i.accepted{color:#21A1B3 !important}#topbar-first .media-list li i.declined{color:#FC4A64 !important}#topbar-first .media-list li.placeholder{border-bottom:none}#topbar-first .media-list .media .media-body .label{padding:.1em .5em}#topbar-first .account .user-title{text-align:right}#topbar-first .account .user-title span{color:#d7d7d7}#topbar-first .dropdown.account>a,#topbar-first .dropdown.account.open>a,#topbar-first .dropdown.account>a:hover,#topbar-first .dropdown.account.open>a:hover{background-color:#435f6f}#topbar-second{top:50px;background-color:#fff;z-index:1029;background-image:none;box-shadow:0 1px 10px rgba(0,0,0,0.1);border-bottom:1px solid #d4d4d4}#topbar-second .dropdown-menu{padding-top:0;padding-bottom:0}#topbar-second .dropdown-menu .divider{margin:0}#topbar-second #space-menu-dropdown,#topbar-second #search-menu-dropdown{width:400px}#topbar-second #space-menu-dropdown .media-list,#topbar-second #search-menu-dropdown .media-list{max-height:400px;overflow:auto}@media screen and (max-width:768px){#topbar-second #space-menu-dropdown .media-list,#topbar-second #search-menu-dropdown .media-list{max-height:200px}}#topbar-second #space-menu-dropdown form,#topbar-second #search-menu-dropdown form{margin:10px}#topbar-second #space-menu-dropdown .search-reset,#topbar-second #search-menu-dropdown .search-reset{position:absolute;color:#BFBFBF;margin:7px;top:0px;right:40px;z-index:10;display:none;cursor:pointer}#topbar-second .nav>li>a{padding:7px 13px 0;text-decoration:none;text-shadow:none;font-weight:600;font-size:10px;min-height:50px;text-transform:uppercase;text-align:center}#topbar-second .nav>li>a:hover,#topbar-second .nav>li>a:active,#topbar-second .nav>li>a:focus{border-bottom:3px solid #21A1B3;background-color:#f8f8f8;color:#000;text-decoration:none}#topbar-second .nav>li>a i{font-size:14px}#topbar-second .nav>li>a .caret{border-top-color:#7a7a7a}#topbar-second .nav>li.active>a{min-height:47px}#topbar-second .nav>li>ul>li>a{border-left:3px solid #fff;background-color:#fff;color:#000}#topbar-second .nav>li>ul>li>a:hover,#topbar-second .nav>li>ul>li>a.active{border-left:3px solid #21A1B3;background-color:#f8f8f8;color:#000}#topbar-second .nav>li>a#space-menu{padding-right:13px;border-right:1px solid #ededed}#topbar-second .nav>li>a#search-menu{padding-top:15px}#topbar-second .nav>li>a:hover,#topbar-second .nav>li.active{border-bottom:3px solid #21A1B3;background-color:#f8f8f8;color:#000}#topbar-second .nav>li.active>a:hover,#topbar-second .nav>li.active>a:focus{border-bottom:none}#topbar-second #space-menu-dropdown li>ul>li>a>.media .media-body p{color:#555555;font-size:11px;margin:0;font-weight:400}@media (max-width:767px){.topbar{padding-left:0;padding-right:0}}.login-container{background-color:#435f6f;background-image:linear-gradient(to right, #435f6f 0%, #567a8f 50%, #567a8f 100%),linear-gradient(to right, #4d6d7f 0%, #7fa0b2 51%, #7094a8 100%);background-size:100% 100%;position:relative;padding-top:40px}.login-container #img-logo{max-width:100%}.login-container .text{color:#fff;font-size:12px;margin-bottom:15px}.login-container .text a{color:#fff;text-decoration:underline}.login-container .panel a{color:#21A1B3}.login-container h1,.login-container h2{color:#fff !important}.login-container .panel{box-shadow:0 0 15px #627d92}.login-container .panel .panel-heading,.login-container .panel .panel-body{padding:15px}.login-container .panel h1,.login-container .panel h2{color:#555 !important}.login-container select{color:#000}#account-login-form .form-group{margin-bottom:10px}.dropdown-menu li a i{margin-right:5px;font-size:14px;display:inline-block;width:14px}.dropdown-menu li a:hover,.dropdown-menu li a:visited,.dropdown-menu li a:hover,.dropdown-menu li a:focus{background:none;cursor:pointer}.dropdown-menu li:hover,.dropdown-menu li.selected{color:#000}.dropdown-menu li:first-child{margin-top:3px}.dropdown-menu li:last-child{margin-bottom:3px}.modal .dropdown-menu,.panel .dropdown-menu,.nav-tabs .dropdown-menu{border:1px solid #d7d7d7}.modal .dropdown-menu li.divider,.panel .dropdown-menu li.divider,.nav-tabs .dropdown-menu li.divider{background-color:#f8f8f8;border-bottom:none;margin:9px 1px !important}.modal .dropdown-menu li,.panel .dropdown-menu li,.nav-tabs .dropdown-menu li{border-left:3px solid white}.modal .dropdown-menu li a,.panel .dropdown-menu li a,.nav-tabs .dropdown-menu li a{color:#000;font-size:13px;font-weight:600;padding:4px 15px}.modal .dropdown-menu li a i,.panel .dropdown-menu li a i,.nav-tabs .dropdown-menu li a i{margin-right:5px}.modal .dropdown-menu li a:hover,.panel .dropdown-menu li a:hover,.nav-tabs .dropdown-menu li a:hover{background:none}.modal .dropdown-menu li:hover:not(.divider),.panel .dropdown-menu li:hover:not(.divider),.nav-tabs .dropdown-menu li:hover:not(.divider),.modal .dropdown-menu li.selected,.panel .dropdown-menu li.selected,.nav-tabs .dropdown-menu li.selected{border-left:3px solid #21A1B3;background-color:#f8f8f8 !important}ul.contextMenu{border:1px solid #d7d7d7}ul.contextMenu li.divider{background-color:#f8f8f8;border-bottom:none;margin:9px 1px !important}ul.contextMenu li{border-left:3px solid white}ul.contextMenu li a{color:#000;font-size:14px;font-weight:400;padding:4px 15px}ul.contextMenu li a i{margin-right:5px}ul.contextMenu li a:hover{background:none}ul.contextMenu li:hover,ul.contextMenu li.selected{border-left:3px solid #21A1B3;background-color:#f8f8f8 !important}.media-list li{padding:10px;border-bottom:1px solid #eee;position:relative;border-left:3px solid white;font-size:12px}.media-list li a{color:#555}.media-list .badge-space-type{background-color:#f8f8f8;border:1px solid #d7d7d7;color:#b2b2b2;padding:3px 3px 2px 3px}.media-list li.new{border-left:3px solid #21A1B3;background-color:#c5eff4}.media-list li:hover,.media-list li.selected{background-color:#f8f8f8;border-left:3px solid #21A1B3}.media-list li.placeholder{font-size:14px !important;border-bottom:none}.media-list li.placeholder:hover{background:none !important;border-left:3px solid white}.media-left,.media>.pull-left{padding-right:0;margin-right:10px}.media:after{content:'';clear:both;display:block}.media .time{font-size:11px;color:#555555}.media .img-space{position:absolute;top:35px;left:35px}.media .media-body{overflow:hidden !important;font-size:13px;white-space:normal;word-wrap:break-word;overflow-wrap:break-word;word-break:break-word;hyphens:auto}.media .media-body h4.media-heading{font-size:14px;font-weight:500;color:#000}.media .media-body h4.media-heading a{color:#000}.media .media-body h4.media-heading small,.media .media-body h4.media-heading small a{font-size:11px;color:#555555}.media .media-body h4.media-heading .content{margin-right:35px}.media .media-body .content a{word-break:break-all}.media .media-body strong{color:#000}.media .media-body h5{color:#aeaeae;font-weight:300;margin-top:5px;margin-bottom:5px;min-height:15px}.media .media-body .module-controls{font-size:85%}.media .media-body .module-controls a{color:#21A1B3}.media .content a{color:#21A1B3}.media .content .files a{color:#000}.content span{word-wrap:break-word;overflow-wrap:break-word;word-break:break-word;hyphens:auto}#blueimp-gallery .slide img{max-height:80%}audio,canvas,progress,video{display:inline-block;vertical-align:baseline;max-width:100%;height:auto}img{image-orientation:from-image}.has-online-status{position:relative;display:inline-block;margin-bottom:10px}.has-online-status .user-online-status{aspect-ratio:1 / 1;width:30%;border-radius:100%;position:absolute;right:-10%;bottom:-10%;border:1px solid transparent}.has-online-status .user-online-status.user-is-online{border-color:#fff;background-color:#97d271}.has-online-status.img-size-small{margin-bottom:5px}.has-online-status.img-size-small .user-online-status{width:10px;right:-3px;bottom:-3px}.has-online-status.img-size-large .user-online-status{width:20px;right:-5px;bottom:-5px;border-width:2px}.panel{word-wrap:break-word;overflow-wrap:break-word;word-break:break-word;hyphens:auto;border:none;background-color:#fff;box-shadow:0 0 3px #dadada;border-radius:4px;position:relative;margin-bottom:15px}.panel h1{font-size:16px;font-weight:300;margin-top:0;color:#000}.panel .panel-heading{font-size:16px;font-weight:300;color:#000;background-color:white;border:none;padding:10px;border-radius:4px}.panel .panel-heading .heading-link{color:#6fdbe8 !important;font-size:.8em}.panel .panel-body{padding:10px;font-size:13px}.panel .panel-body p{color:#555}.panel .panel-body p a{color:#21A1B3}.panel .panel-body .usersearch-statuses,.panel .panel-body .spacesearch-visibilities{padding-top:5px;padding-bottom:5px}@media (min-width:992px){.panel .panel-body .usersearch-statuses,.panel .panel-body .spacesearch-visibilities{padding-top:0;padding-bottom:0;padding-left:0}}.panel .statistics .entry{margin-left:20px;font-size:12px;color:#000}.panel .statistics .entry .count{color:#21A1B3;font-weight:600;font-size:20px;line-height:.8em}.panel h3.media-heading small{font-size:75%}.panel h3.media-heading small a{color:#21A1B3}.panel-danger{border:2px solid #FC4A64}.panel-danger .panel-heading{color:#FC4A64}.panel-success{border:2px solid #97d271}.panel-success .panel-heading{color:#97d271}.panel-warning{border:2px solid #FFC107}.panel-warning .panel-heading{color:#FFC107}.panel-info{border:2px solid #21A1B3}.panel-info .panel-heading{color:#21A1B3}.panel-primary{border:2px solid #435f6f}.panel-primary .panel-heading{color:#435f6f}.panel.profile{position:relative}.panel.profile .controls{position:absolute;top:10px;right:10px}.panel.groups .panel-body a img,.panel.spaces .panel-body a img{margin-bottom:5px}.panel-profile .panel-profile-header{position:relative;border:3px solid #fff;border-top-right-radius:3px;border-top-left-radius:3px}.panel-profile .panel-profile-header .img-profile-header-background{border-radius:3px;min-height:110px}.panel-profile .panel-profile-header .img-profile-data{position:absolute;height:100px;width:100%;bottom:0;left:0;padding-left:180px;padding-top:30px;border-bottom-right-radius:3px;border-bottom-left-radius:3px;color:#fff;pointer-events:none;background:linear-gradient(to bottom, rgba(0,0,0,0) 0%, rgba(0,0,0,0) 1%, rgba(0,0,0,0.38) 100%)}.panel-profile .panel-profile-header .img-profile-data h1{font-size:30px;font-weight:100;margin-bottom:7px;color:#fff;max-width:600px;white-space:nowrap;text-overflow:ellipsis}.panel-profile .panel-profile-header .img-profile-data h2{font-size:16px;font-weight:400;margin-top:0}.panel-profile .panel-profile-header .img-profile-data h1.space{font-size:30px;font-weight:700}.panel-profile .panel-profile-header .img-profile-data h2.space{font-size:13px;font-weight:300;max-width:600px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}.panel-profile .panel-profile-header .profile-user-photo-container{position:absolute;bottom:-60px;left:15px}.panel-profile .panel-profile-header .profile-user-photo-container .profile-user-photo{border:3px solid #fff;border-radius:5px}.panel-profile .panel-profile-controls{padding-left:160px}.panel.pulse,.panel.fadeIn{animation-duration:200ms}@media (max-width:767px){.panel-profile-controls{padding-left:0 !important;padding-top:50px}.panel-profile .panel-profile-header .img-profile-data h1{font-size:20px !important;margin-bottom:2px}}.panel-body>.tab-menu{margin-left:-10px;margin-right:-10px}.installer .logo{text-align:center}.installer h2{font-weight:100}.installer .panel{margin-top:50px}.installer .panel h3{margin-top:0}.installer .powered,.installer .powered a{color:#bac2c7 !important;margin-top:10px;font-size:12px}.installer .fa{width:18px}.installer .check-ok{color:#97d271}.installer .check-warning{color:#FFC107}.installer .check-error{color:#FC4A64}.installer .prerequisites-list ul{list-style:none;padding-left:15px}.installer .prerequisites-list ul li{padding-bottom:5px}.pagination-container{text-align:center}.pagination>.active>a,.pagination>.active>span,.pagination>.active>a:hover,.pagination>.active>span:hover,.pagination>.active>a:focus,.pagination>.active>span:focus{background-color:#435f6f;border-color:#435f6f}.pagination>li>a,.pagination>li>span,.pagination>li>a:hover,.pagination>li>a:active,.pagination>li>a:focus{color:#000;cursor:pointer}.well-small{padding:10px;border-radius:3px}.well{border:none;box-shadow:none;background-color:#f5f5f5;margin-bottom:1px}.well hr{margin:10px 0;border-top:1px solid #d9d9d9}.well table>thead{font-size:11px}.tab-sub-menu{padding-left:10px}.tab-sub-menu li>a:hover,.tab-sub-menu li>a:focus{background-color:#f8f8f8;border-bottom-color:#ddd}.tab-sub-menu li.active>a{background-color:#fff;border-bottom-color:transparent}.nav-tabs>li>a,.nav-tabs>li>a[data-toggle]{color:#555}.nav-tabs>li.active>a,.nav-tabs>li.active>a:hover,.nav-tabs>li.active>a:focus,.nav-tabs>li>a:hover,.nav-tabs>li>a:focus{color:#000}.tab-menu{padding-top:10px;background-color:#fff}.tab-menu .nav-tabs{padding-left:10px}.tab-menu .nav-tabs li>a{padding-top:12px;border-color:#ddd;border-bottom:1px solid #ddd;background-color:#f8f8f8;max-height:41px;outline:none}.tab-menu .nav-tabs li>a:hover,.tab-menu .nav-tabs li>a:focus{padding-top:10px;border-top:3px solid #ddd}.tab-menu .nav-tabs li>a:hover{background-color:#f8f8f8}.tab-menu .nav-tabs li.active>a,.tab-menu .nav-tabs li.active>a:hover{padding-top:10px;border-top:3px solid #21A1B3}.tab-menu .nav-tabs li.active>a{background-color:#fff;border-bottom-color:transparent}ul.tab-menu{padding-top:10px;background-color:#fff;padding-left:10px}ul.tab-menu-settings li>a{padding-top:12px;border-color:#ddd;border-bottom:1px solid #ddd;background-color:#f8f8f8;max-height:41px;outline:none}ul.tab-menu-settings li>a:hover,ul.tab-menu-settings li>a:focus{padding-top:10px;border-top:3px solid #ddd !important}ul.tab-menu-settings li>a:hover{background-color:#f8f8f8}ul.tab-menu-settings li.active>a,ul.tab-menu-settings li.active>a:hover,ul.tab-menu-settings li.active>a:focus{padding-top:10px;border-top:3px solid #21A1B3 !important}ul.tab-menu-settings li.active>a{background-color:#fff;border-bottom-color:transparent !important}.nav-pills .dropdown-menu,.nav-tabs .dropdown-menu,.account .dropdown-menu{background-color:#435f6f;border:none}.nav-pills .dropdown-menu li.divider,.nav-tabs .dropdown-menu li.divider,.account .dropdown-menu li.divider{background-color:#39515f;border-bottom:none;margin:9px 1px !important}.nav-pills .dropdown-menu li,.nav-tabs .dropdown-menu li,.account .dropdown-menu li{border-left:3px solid #435f6f}.nav-pills .dropdown-menu li a,.nav-tabs .dropdown-menu li a,.account .dropdown-menu li a{color:white;font-weight:400;font-size:13px;padding:4px 15px}.nav-pills .dropdown-menu li a i,.nav-tabs .dropdown-menu li a i,.account .dropdown-menu li a i{margin-right:0;font-size:14px;display:inline-block;width:19px;text-align:center}.nav-pills .dropdown-menu li a:hover,.nav-tabs .dropdown-menu li a:hover,.account .dropdown-menu li a:hover,.nav-pills .dropdown-menu li a:visited,.nav-tabs .dropdown-menu li a:visited,.account .dropdown-menu li a:visited,.nav-pills .dropdown-menu li a:hover,.nav-tabs .dropdown-menu li a:hover,.account .dropdown-menu li a:hover,.nav-pills .dropdown-menu li a:focus,.nav-tabs .dropdown-menu li a:focus,.account .dropdown-menu li a:focus{background:none}.nav-pills .dropdown-menu li:hover:not(.divider),.nav-tabs .dropdown-menu li:hover:not(.divider),.account .dropdown-menu li:hover:not(.divider),.nav-pills .dropdown-menu li.selected,.nav-tabs .dropdown-menu li.selected,.account .dropdown-menu li.selected{border-left:3px solid #21A1B3;color:#fff !important;background-color:#39515f !important}.nav-pills.preferences .dropdown .dropdown-toggle i{color:#21A1B3;font-size:15px;font-weight:600}.nav-pills.preferences .dropdown.open .dropdown-toggle,.nav-pills.preferences .dropdown.open .dropdown-toggle:hover{background-color:#435f6f}.nav-pills.preferences .dropdown.open .dropdown-toggle i,.nav-pills.preferences .dropdown.open .dropdown-toggle:hover i{color:#fff}.nav-pills.preferences li.divider:last-of-type{display:none}.nav-pills>li.active>a,.nav-pills>li.active>a:hover,.nav-pills>li.active>a:focus{background-color:#435f6f}.nav-tabs{margin-bottom:10px}.list-group a [class^="fa-"],.list-group a [class*=" fa-"]{display:inline-block;width:18px}.nav-pills.preferences{position:absolute;right:10px;top:10px}.nav-pills.preferences .dropdown .dropdown-toggle{padding:2px 5px}.nav-pills.preferences .dropdown.open .dropdown-toggle,.nav-pills.preferences .dropdown.open .dropdown-toggle:hover{color:white}.nav-tabs li{font-weight:600;font-size:12px}.tab-content .tab-pane a{color:#21A1B3}.tab-content .tab-pane .form-group{margin-bottom:5px}.nav-tabs.tabs-center li{float:none;display:inline-block}.nav-tabs.tabs-small li>a{padding:5px 7px}.nav .caret,.nav .caret:hover,.nav .caret:active{border-top-color:#000;border-bottom-color:#000;height:6.928px}.nav li.dropdown>a:hover .caret,.nav li.dropdown>a:active .caret{border-top-color:#000;border-bottom-color:#000}.nav .open>a .caret,.nav .open>a:hover .caret,.nav .open>a:focus .caret{border-top-color:#000;border-bottom-color:#000}.nav .open>a,.nav .open>a:hover,.nav .open>a:focus{border-color:#ededed;color:#000}.nav .open>a .caret,.nav .open>a:hover .caret,.nav .open>a:focus .caret{color:#000}.footer-nav{filter:opacity(.6);font-size:12px;text-align:center}@media (max-width:991px){.controls-header{text-align:left !important}}#contentFormMenu{display:none}#contentFormMenu.menu-without-form a{border-radius:4px}#contentFormMenu .nav-tabs{margin-bottom:0;border:none;float:right}#contentFormMenu .nav-tabs>li>a,#contentFormMenu .nav-tabs>li.active>a{color:#7A7A7A;background:#fff;border-color:#fff}#contentFormMenu .nav-tabs>li>a:hover,#contentFormMenu .nav-tabs>li.active>a:hover,#contentFormMenu .nav-tabs>li>a.active,#contentFormMenu .nav-tabs>li.active>a.active{z-index:1;color:#333}#contentFormMenu:after{content:" ";clear:both;display:block}#contentFormMenu .content-create-menu-more>i{border-radius:4px 4px 0 0;background:#fff;margin-right:3px;padding:10px 15px 11px;font-size:18px}#contentFormMenu .content-create-menu-more>i:hover{color:#333}#contentFormMenu .content-create-menu-more .dropdown-menu{background-color:#fff;border:1px solid #D7D7D7;border-radius:4px}#contentFormMenu .content-create-menu-more .dropdown-menu li{border-left-color:#fff}#contentFormMenu .content-create-menu-more .dropdown-menu li a{color:#000}#contentFormMenu .content-create-menu-more .dropdown-menu li:hover,#contentFormMenu .content-create-menu-more .dropdown-menu li.selected{color:#000;border-left-color:#21A1B3;background-color:#f8f8f8 !important}@media (max-width:480px){#contentFormMenu .nav-tabs{display:flex;width:100%}#contentFormMenu .nav-tabs>li{flex-grow:1;text-align:center}#contentFormMenu .nav-tabs>li.content-create-menu-more{flex-grow:.3}#contentFormMenu .nav-tabs>li.content-create-menu-more>i.fa{width:100%}}.btn{float:none;border:none;box-shadow:none;background-image:none;text-shadow:none;border-radius:3px;outline:none !important;margin-bottom:0;font-size:14px;font-weight:600;padding:8px 16px}.btn:not(.btn-icon-only) i.fa{margin-right:4px}.input.btn{outline:none}.btn-lg{padding:16px 28px}.btn-sm{padding:4px 8px;font-size:12px}.btn-sm i{font-size:14px}.btn-xs{padding:1px 5px;font-size:12px}.btn-default{background:#f3f3f3;color:#7a7a7a !important}.btn-default:hover,.btn-default:focus{background:#eee;text-decoration:none;color:#7a7a7a}.btn-default:active,.btn-default.active{outline:0;background:#e6e6e6}.btn-default[disabled],.btn-default.disabled{background:#f8f8f8}.btn-default[disabled]:hover,.btn-default.disabled:hover,.btn-default[disabled]:focus,.btn-default.disabled:focus{background:#f8f8f8}.btn-default[disabled]:active,.btn-default.disabled:active,.btn-default[disabled].active,.btn-default.disabled.active{background:#f8f8f8}.btn-primary{background:#435f6f;color:#fff !important}.btn-primary:hover,.btn-primary:focus{background:#39515f;text-decoration:none}.btn-primary:active,.btn-primary.active{outline:0;border:1px solid #435f6f;padding:7px 15px;color:#435f6f !important;background:#fff !important;box-shadow:none}.btn-primary:active.btn-sm,.btn-primary.active.btn-sm{padding:3px 7px}.btn-primary:active.btn-xs,.btn-primary.active.btn-xs{padding:0 4px}.btn-primary.active:hover,.btn-primary.active:focus{border:1px solid #39515f;color:#39515f !important}.btn-primary[disabled],.btn-primary.disabled{background:#4d6d7f}.btn-primary[disabled]:hover,.btn-primary.disabled:hover,.btn-primary[disabled]:focus,.btn-primary.disabled:focus{background:#4d6d7f}.btn-primary[disabled]:active,.btn-primary.disabled:active,.btn-primary[disabled].active,.btn-primary.disabled.active{background:#4d6d7f !important}.btn-info{background:#21A1B3;color:#fff !important}.btn-info:hover,.btn-info:focus{background:#1d8e9d !important;text-decoration:none}.btn-info:active,.btn-info.active{outline:0;border:1px solid #21A1B3;padding:7px 15px;color:#21A1B3 !important;background:#fff !important;box-shadow:none}.btn-info:active.btn-sm,.btn-info.active.btn-sm{padding:3px 7px}.btn-info:active.btn-xs,.btn-info.active.btn-xs{padding:0 4px}.btn-info.active:hover,.btn-info.active:focus{border:1px solid #1d8e9d;color:#1d8e9d !important}.btn-info[disabled],.btn-info.disabled{background:#25b4c9}.btn-info[disabled]:hover,.btn-info.disabled:hover,.btn-info[disabled]:focus,.btn-info.disabled:focus{background:#25b4c9}.btn-info[disabled]:active,.btn-info.disabled:active,.btn-info[disabled].active,.btn-info.disabled.active{background:#25b4c9 !important}.btn-danger{background:#FC4A64;color:#fff !important}.btn-danger:hover,.btn-danger:focus{background:#fc314f;text-decoration:none}.btn-danger:active,.btn-danger.active{outline:0;background:#fc314f !important}.btn-danger[disabled],.btn-danger.disabled{background:#fc6379}.btn-danger[disabled]:hover,.btn-danger.disabled:hover,.btn-danger[disabled]:focus,.btn-danger.disabled:focus{background:#fc6379}.btn-danger[disabled]:active,.btn-danger.disabled:active,.btn-danger[disabled].active,.btn-danger.disabled.active{background:#fc6379 !important}.btn-success{background:#97d271;color:#fff !important}.btn-success:hover,.btn-success:focus{background:#89cc5e;text-decoration:none}.btn-success:active,.btn-success.active{outline:0;background:#89cc5e !important}.btn-success[disabled],.btn-success.disabled{background:#a5d884}.btn-success[disabled]:hover,.btn-success.disabled:hover,.btn-success[disabled]:focus,.btn-success.disabled:focus{background:#a5d884}.btn-success[disabled]:active,.btn-success.disabled:active,.btn-success[disabled].active,.btn-success.disabled.active{background:#a5d884 !important}.btn-warning{background:#FFC107;color:#fff !important}.btn-warning:hover,.btn-warning:focus{background:#fcbd00;text-decoration:none}.btn-warning:active,.btn-warning.active{outline:0;background:#fcbd00 !important}.btn-warning[disabled],.btn-warning.disabled{background:#ffc721}.btn-warning[disabled]:hover,.btn-warning.disabled:hover,.btn-warning[disabled]:focus,.btn-warning.disabled:focus{background:#ffc721}.btn-warning[disabled]:active,.btn-warning.disabled:active,.btn-warning[disabled].active,.btn-warning.disabled.active{background:#ffc721 !important}.btn-link{color:#21A1B3 !important}.btn-link:hover,.btn-link:focus{color:#1f99aa;text-decoration:none}.btn-link:active,.btn-link.active{outline:0;color:#1f99aa !important}.btn-link[disabled],.btn-link.disabled{color:#25b4c9}.btn-link[disabled]:hover,.btn-link.disabled:hover,.btn-link[disabled]:focus,.btn-link.disabled:focus{color:#25b4c9}.btn-link[disabled]:active,.btn-link.disabled:active,.btn-link[disabled].active,.btn-link.disabled.active{color:#25b4c9 !important}.radio,.checkbox{margin-top:5px !important;margin-bottom:0}div.required>label:after{content:" *";color:#21A1B3}div.required.has-error>label:after{content:" *";color:#FC4A64}.radio label,.checkbox label{padding-left:10px}.form-control{border:2px solid #ededed;box-shadow:none;min-height:35px}.form-control:focus{border:2px solid #21A1B3;outline:0;box-shadow:none}.form-control.form-search{border-radius:30px;padding-left:34px}.form-group-search{position:relative}.form-group-search:before{font:14px FontAwesome;content:"\f002";color:#ededed;position:absolute;top:10px;left:13px}.form-group-search .form-button-search{position:absolute;top:4px;right:4px;border-radius:30px}textarea{resize:none;height:1.5em}select.form-control:not([multiple]){appearance:none;background-image:url("../img/select_arrow.png") !important;background-repeat:no-repeat;background-position:right 16px;overflow:hidden}label{font-weight:normal}div.PendingRegistrations thead>tr>th>label,div.PendingRegistrations tbody>tr>td>label{margin-bottom:0;height:17px}label.control-label{font-weight:bold}::placeholder{color:#bac2c7 !important}input::-ms-clear,input::-ms-reveal{display:none}.placeholder{padding:10px}input.placeholder,textarea.placeholder{padding:0 0 0 10px;color:#999}.help-block-error{font-size:12px}.help-block:not(.help-block-error){color:#555555;font-size:13px}.panel-body>.help-block{padding-right:20px;margin-bottom:20px}.hint-block{color:#aeaeae !important;font-size:12px}.hint-block:hover{color:#7a7a7a !important;font-size:12px}.input-group-addon{border:none}a.input-field-addon{font-size:12px;float:right;margin-top:-10px}a.input-field-addon-sm{font-size:11px;float:right;margin-top:-10px}.timeZoneInputContainer{padding-top:10px}.timeZoneInputContainer~.help-block{margin:0}.radio input[type=radio],.radio-inline input[type=radio],.checkbox input[type=checkbox],.checkbox-inline input[type=checkbox]{position:relative;margin-left:0}input[type=checkbox],input[type=radio]{-webkit-appearance:none;position:relative;display:inline-block;width:auto;height:auto;min-height:auto;padding:7px;margin:-4px 2px 0 0;vertical-align:middle;background:white;border:2px solid #ccc;border-radius:3px}input[type=checkbox]:disabled,input[type=radio]:disabled{background:#d7d7d7 !important;border:2px solid #d7d7d7 !important;cursor:not-allowed}input[type=checkbox]:focus{border:2px solid #000 !important;outline:none}input[type=checkbox]:checked{border:2px solid #21A1B3;background:#21A1B3;color:white}input[type=checkbox]:checked::after{content:'\2714';font-size:14px;position:absolute;top:-3px;left:1px;color:white}input[type=radio]{border-radius:50%}input[type=radio]:checked{border:2px solid #d7d7d7;color:#99a1a7}input[type=radio]:checked::after{content:' ';width:8px;height:8px;border-radius:50%;position:absolute;top:3px;background:#21A1B3;text-shadow:none;left:3px;font-size:32px}div.form-group div.checkbox .help-block{margin-left:33px}div.form-group div.checkbox .help-block.help-block-error:empty{display:none}.errorMessage{color:#FC4A64;padding:10px 0}.error{border-color:#FC4A64 !important}.has-error .help-block,.has-error .control-label,.has-error .radio,.has-error .checkbox,.has-error .radio-inline,.has-error .checkbox-inline{color:#FC4A64 !important}.has-error .form-control,.has-error .form-control:focus{border-color:#FC4A64;box-shadow:none}.has-success .help-block,.has-success .control-label,.has-success .radio,.has-success .checkbox,.has-success .radio-inline,.has-success .checkbox-inline{color:#97d271}.has-success .form-control,.has-success .form-control:focus{border-color:#97d271;box-shadow:none}.has-warning .help-block,.has-warning .control-label,.has-warning .radio,.has-warning .checkbox,.has-warning .radio-inline,.has-warning .checkbox-inline{color:#FFC107}.has-warning .form-control,.has-warning .form-control:focus{border-color:#FFC107;box-shadow:none}.bootstrap-timepicker-widget .form-control{padding:0}.form-collapsible-fields{margin-bottom:12px;border-left:3px solid #435f6f;background-color:#F4F4F4}.form-collapsible-fields-label{margin-bottom:0;padding:12px}.form-collapsible-fields-label label{margin-bottom:0}.form-collapsible-fields fieldset{padding-top:15px;padding-left:12px;padding-right:12px}.form-collapsible-fields.opened fieldset{display:block}.form-collapsible-fields.opened .iconClose{display:inline}.form-collapsible-fields.opened .iconOpen{display:none}.form-collapsible-fields.closed fieldset,.form-collapsible-fields.closed .iconClose{display:none}.form-collapsible-fields.closed .iconOpen{display:inline}.content_create .content-create-input-group,.content_edit .content-create-input-group{display:flex;align-items:flex-end;flex-direction:column}.content_create .content-create-input-group>.form-group,.content_edit .content-create-input-group>.form-group{flex-grow:1;width:100%}.content_create .content-create-input-group>.form-group [data-ui-markdown],.content_edit .content-create-input-group>.form-group [data-ui-markdown]{word-break:break-word !important}.content_create .content-create-input-group>.form-group [data-ui-markdown] pre code,.content_edit .content-create-input-group>.form-group [data-ui-markdown] pre code{display:block;width:0}.content_create .content-create-input-group .form-group,.content_edit .content-create-input-group .form-group,.content_create .content-create-input-group .help-block,.content_edit .content-create-input-group .help-block{margin:0}.content_create .upload-buttons,.content_edit .upload-buttons{white-space:nowrap;padding-top:6px}.content_create .upload-buttons .btn:not(.dropdown-toggle),.content_edit .upload-buttons .btn:not(.dropdown-toggle){margin-left:6px}.content_create .upload-buttons .btn.fileinput-button,.content_edit .upload-buttons .btn.fileinput-button,.content_create .upload-buttons .fileinput-button+.dropdown-toggle,.content_edit .upload-buttons .fileinput-button+.dropdown-toggle{background-color:rgba(33,161,179,0.6)}.content_create .upload-buttons .btn.dropdown-toggle,.content_edit .upload-buttons .btn.dropdown-toggle{margin-left:0}.content_create .has-error+.upload-buttons,.content_edit .has-error+.upload-buttons{padding-bottom:22px}.content_create .fileinput-button:active,.content_edit .fileinput-button:active{box-shadow:none !important}#notification_overview_filter label{display:block}#notification_overview_list .img-space{position:absolute;top:25px;left:25px}@media (max-width:767px){.notifications{position:inherit !important;float:left !important}.notifications .dropdown-menu{width:300px !important;margin-left:0 !important}.notifications .dropdown-menu .arrow{margin-left:-142px !important}}.badge-space{margin-top:6px}.badge-space-chooser{padding:3px 5px;margin-left:1px}.badge{padding:3px 5px;border-radius:2px;font-weight:normal;font-family:Arial,sans-serif;font-size:10px !important;text-transform:uppercase;color:#fff;vertical-align:baseline;white-space:nowrap;text-shadow:none;background-color:#d7d7d7;line-height:1}.popover{border:1px solid rgba(0,0,0,0.15);border-radius:4px;box-shadow:0 6px 12px rgba(0,0,0,0.175)}.popover .popover-title{background:none;border-bottom:none;color:#000;font-weight:300;font-size:16px;padding:15px}.popover .popover-content{font-size:13px;padding:5px 15px;color:#000}.popover .popover-content a{color:#21A1B3}.popover .popover-content img{max-width:100%}.popover .popover-navigation{padding:15px}.panel-profile .panel-profile-header .image-upload-container{width:100%;height:100%;overflow:hidden}.panel-profile .panel-profile-header .image-upload-container #bannerfileupload{position:absolute;top:0;left:0;opacity:0;width:100%;height:100%}.panel-profile .panel-profile-header .img-profile-header-background{width:100%;max-height:192px}@media print{.panel-profile{display:none}}.list-group-item{padding:6px 15px;border:none;border-width:0 !important;border-left:3px solid #fff !important;font-size:12px;font-weight:600}.list-group-item i{font-size:14px}a.list-group-item:hover,a.list-group-item.active,a.list-group-item.active:hover,a.list-group-item.active:focus{z-index:2;color:#000;background-color:#f8f8f8;border-left:3px solid #21A1B3 !important}@media (max-width:991px){.list-group{margin-left:4px}.list-group-item{display:inline-block !important;border-radius:3px !important;margin:4px 0;margin-bottom:4px !important}.list-group-item{border:none !important}a.list-group-item:hover,a.list-group-item.active,a.list-group-item.active:hover,a.list-group-item.active:focus{border:none !important;background:#435f6f !important;color:#fff !important}}.modal-backdrop{background-color:rgba(0,0,0,0.5)}.modal-dialog.fadeIn,.modal-dialog.pulse{animation-duration:200ms}body.modal-open{height:100vh;overflow-y:hidden}@media screen and (max-width:768px){.modal-dialog{width:calc(100vw - 4px) !important}}.modal-top{z-index:999999 !important}.modal{overflow-y:visible}.modal.in{padding-right:0 !important}.modal-dialog-extra-small{width:400px}.modal-dialog-small{width:500px}.modal-dialog-normal{width:600px}.modal-dialog-medium{width:768px}.modal-dialog-large{width:900px}@media screen and (max-width:991px){.modal-dialog-large{width:auto !important;padding-top:30px;padding-bottom:30px}}.modal{border:none}.modal h1,.modal h2,.modal h3,.modal h4,.modal h5{margin-top:20px;color:#000;font-weight:300}.modal h4.media-heading{margin-top:0}.modal-title{font-size:20px;font-weight:200;color:#000}.modal-dialog,.modal-content{min-width:150px}.modal-content{box-shadow:0 2px 26px rgba(0,0,0,0.3),0 0 0 1px rgba(0,0,0,0.1);border:none}.modal-content .modal-header{padding:20px 20px 0;border-bottom:none;text-align:center}.modal-content .modal-header .close{margin-top:2px;margin-right:5px;opacity:1;color:#435f6f;font-size:28px}.modal-content .modal-header .close:hover{opacity:.9}.modal-content .modal-body{padding:20px;font-size:13px}.modal-content .modal-footer{margin-top:0;text-align:left;padding:10px 20px 30px;border-top:none;text-align:center}.modal-content .modal-footer hr{margin-top:0}.tooltip-inner{background-color:#435f6f;max-width:400px;text-align:left;padding:2px 8px 4px;font-size:12px;font-weight:bold;white-space:pre-wrap}.tooltip.top .tooltip-arrow{border-top-color:#435f6f}.tooltip.top-left .tooltip-arrow{border-top-color:#435f6f}.tooltip.top-right .tooltip-arrow{border-top-color:#435f6f}.tooltip.right .tooltip-arrow{border-right-color:#435f6f}.tooltip.left .tooltip-arrow{border-left-color:#435f6f}.tooltip.bottom .tooltip-arrow{border-bottom-color:#435f6f}.tooltip.bottom-left .tooltip-arrow{border-bottom-color:#435f6f}.tooltip.bottom-right .tooltip-arrow{border-bottom-color:#435f6f}.tooltip.in{opacity:1}.progress{height:10px;margin-bottom:15px;box-shadow:none;background:#ededed;border-radius:10px}.progress-bar-info{background-color:#21A1B3;box-shadow:none}#nprogress .bar{height:2px;background:#27c0d5}table{margin-bottom:0 !important}table th{font-size:11px;color:#555555;font-weight:normal}table thead tr th{border:none !important}table .time{font-size:12px}table td a:hover{color:#21A1B3}.table>thead>tr>th,.table>tbody>tr>th,.table>tfoot>tr>th,.table>thead>tr>td,.table>tbody>tr>td,.table>tfoot>tr>td{padding:10px 10px 10px 0}.table>thead>tr>th select,.table>tbody>tr>th select,.table>tfoot>tr>th select,.table>thead>tr>td select,.table>tbody>tr>td select,.table>tfoot>tr>td select{font-size:12px;padding:4px 8px;height:30px;margin:0}.table-middle>thead>tr>th,.table-middle>tbody>tr>th,.table-middle>tfoot>tr>th,.table-middle>thead>tr>td,.table-middle>tbody>tr>td,.table-middle>tfoot>tr>td{vertical-align:middle !important}@media (max-width:767px){.table-responsive>.table>tbody>tr>td.notification-type{white-space:normal}}.comment-container{margin-top:10px}.comment-container .wall-entry-controls{margin-left:35px}@media (max-width:767px){.comment .post-files img{height:100px}}.comment .media{position:relative !important;margin-top:0}.comment .media .nav-pills.preferences{display:none;right:-3px}.comment .media.comment-current{background:#daf0f3;padding:0 5px 5px 5px;margin:0 -5px -5px -5px;border-radius:3px}.comment .media.comment-current hr{position:relative;top:-6px}.comment .media.comment-current:first-of-type{padding-top:5px;margin-top:-5px}.comment .media.comment-current:first-of-type>.nav.preferences{margin-top:10px}.comment .media.comment-current>.nav.preferences{margin-right:10px}.comment .media.comment-current .nested-comments-root .comment-container{margin-top:5px;padding-bottom:10px}.comment .media.comment-current .nested-comments-root .comment-container .showMore{margin-top:0;padding-top:5px}.comment .comment-blocked-user img[data-contentcontainer-id]{filter:grayscale(100%)}.comment .media-body{overflow:visible}.comment .jp-progress{background-color:#dbdcdd !important}.comment .jp-play-bar{background:#cacaca}.comment .post-file-list{background-color:#ededed}.comment.guest-mode .media:last-child .wall-entry-controls{margin-bottom:0;margin-left:35px}.comment.guest-mode .media:last-child hr{display:none}.comment-container .content_edit{margin-left:35px}.comment-container .media{overflow:visible}.comment-container [data-ui-richtext] pre,.comment-container [data-ui-richtext] pre code.hljs{background-color:#ebebeb}.comment_edit_content{margin-left:35px;margin-top:0}.comment-message{overflow:hidden;word-wrap:break-word;overflow-wrap:break-word;word-break:break-word;hyphens:auto}.content-create-input-group.scrollActive .upload-buttons{right:22px}.comment .media .media-body h4.media-heading a{font-size:13px;color:#000;margin-bottom:3px;font-weight:500}div.comment>div.media:first-of-type hr.comment-separator{display:none}div.comment>div.media:first-of-type .nav-pills.preferences{display:none;top:-3px}div.nested-comments-root{margin-left:28px}div.nested-comments-root .ProseMirror-menubar-wrapper{z-index:210}div.nested-comments-root hr.comment-separator{display:inherit !important}div.nested-comments-root .showMore{margin-top:10px}div.nested-comments-root div.comment .media{position:relative !important;margin-top:0}div.nested-comments-root div.comment .media .nav-pills.preferences{display:none;top:8px;right:0}div.nested-comments-root div.comment-container{margin-top:0;padding-bottom:0;padding-top:0}.grid-view img{width:24px;height:24px}.grid-view .filters input,.grid-view .filters select{border:2px solid #ededed;box-shadow:none;min-height:35px;border-radius:4px;font-size:12px;padding:4px}.grid-view .filters input:focus,.grid-view .filters select:focus{border:2px solid #21A1B3;outline:0;box-shadow:none}.grid-view{padding:15px 0 0}.grid-view img{border-radius:3px}.grid-view table th{font-size:13px !important;font-weight:bold !important}.grid-view table td{vertical-align:middle !important}.grid-view table tr{font-size:13px !important}.grid-view table thead tr th:first-of-type{padding-left:5px}.grid-view table tbody tr{height:50px}.grid-view table tbody tr td:first-of-type{padding-left:5px}.grid-view .summary{font-size:12px;color:#bac2c7}.permission-grid-editor>.table>tbody>tr:first-child>td{border:none}.permission-grid-editor{padding-top:0px}.detail-view td,.detail-view th{padding:8px !important}.detail-view th{font-size:13px}.oembed_snippet[data-oembed-provider="youtube.com"],.oembed_snippet{margin-top:10px;position:relative;padding-bottom:55%;padding-top:15px;overflow:hidden}.oembed_snippet[data-oembed-provider="twitter.com"]{padding-bottom:0 !important;padding-top:0;margin-top:0}.oembed_snippet iframe{position:absolute;top:0;left:0;width:100%;height:100%}.oembed_confirmation{background:#f2f9fb;border-radius:4px;padding:15px;line-height:30px}.oembed_confirmation i.fa{float:left;color:#02a0b0;background:#FFF;border-radius:50%;font-size:30px;line-height:25px;margin-right:15px}.oembed_confirmation>div:not(.clearfix){float:left}#oembed-providers{width:100%;display:flex;flex-direction:row;justify-content:left;align-items:center;flex-wrap:wrap;margin:0 -0.5rem}#oembed-providers .oembed-provider-container{padding:0}#oembed-providers .oembed-provider-container .oembed-provider{display:flex;flex-direction:row;justify-content:space-between;align-items:center;border:1px solid #ddd;border-radius:2px;padding:.75rem;margin:0 .5rem .5rem .5rem}#oembed-providers .oembed-provider-container .oembed-provider .oembed-provider-name{display:flex;justify-content:center;align-items:center}#oembed-providers .oembed-provider-container .oembed-provider .oembed-provider-name .label.label-error{margin-left:2px}#endpoint-parameters{display:flex;flex-direction:row;justify-content:left;align-items:center;flex-wrap:wrap;margin:0 -15px}.activities{max-height:400px;overflow:auto}.activities li.activity-entry{padding:0}.activities li .media{position:relative;padding:10px}.activities li .media .img-space{position:absolute;top:24px;left:24px}.activities li .media .media-body{max-width:295px}.contentForm_options{margin-top:10px;min-height:29px}.contentForm_options .btn_container{position:relative}.contentForm_options .btn_container .label-container{position:absolute;right:40px;top:11px}#content-topic-bar{margin-top:5px;text-align:right}#content-topic-bar .label{margin-left:4px}#contentFormBody .form-group,#contentFormBody .help-block-error{margin:0}#contentFormBody .contentForm_options .form-group{margin-bottom:15px}#contentFormBody .contentForm_options .form-group .checkbox label{padding-left:22px}#contentFormBody .contentForm_options .form-group .checkbox label input[type=checkbox]{position:absolute;top:4px;left:0}#contentFormBody .contentForm_options .form-group .checkbox label input[type=checkbox]:focus{border-color:#ccc !important}#contentFormBody .contentForm_options .form-group .checkbox label input[type=checkbox]:focus:checked{border-color:#21A1B3 !important}.placeholder-empty-stream{background-image:url("../img/placeholder-postform-arrow.png");background-repeat:no-repeat;padding:37px 0 0 70px;margin-left:90px}#streamUpdateBadge{text-align:center;z-index:9999;margin-bottom:15px;margin-top:15px}#streamUpdateBadge .label{border-radius:10px;font-size:.8em !important;padding:5px 10px}#wallStream .back_button_holder{padding-bottom:15px}.wall-entry{position:relative}.wall-entry .panel .panel-body{padding:10px}.wall-entry .wall-entry-header{color:#000;position:relative;padding-bottom:10px;margin-bottom:10px;border-bottom:1px solid #eeeeee}.wall-entry .wall-entry-header .img-space{top:25px;left:25px}.wall-entry .wall-entry-header .wall-entry-container-link{color:#21A1B3}.wall-entry .wall-entry-header .stream-entry-icon-list{position:absolute;top:0;right:25px;display:inline-block;padding-top:2px}.wall-entry .wall-entry-header .stream-entry-icon-list i{padding-right:5px}.wall-entry .wall-entry-header .stream-entry-icon-list .icon-pin{color:#FC4A64}.wall-entry .wall-entry-header .stream-entry-icon-list .fa-archive{color:#FFC107}.wall-entry .wall-entry-header .wall-entry-header-image{display:table-cell;width:40px;padding-right:10px}.wall-entry .wall-entry-header .wall-entry-header-image .fa{font-size:2.39em;color:#21A1B3;margin-top:5px}.wall-entry .wall-entry-header .wall-entry-header-info{display:table-cell;padding-right:30px;width:100%}.wall-entry .wall-entry-header .wall-entry-header-info .media-heading{font-size:15px;padding-top:1px;margin-bottom:3px}.wall-entry .wall-entry-header .wall-entry-header-info i.archived{color:#FFC107}.wall-entry .wall-entry-header .preferences{position:absolute;right:0;top:0}.wall-entry .wall-entry-header .media-subheading i.fa-caret-right{margin:0 2px}.wall-entry .wall-entry-header .media-subheading .wall-entry-icons{display:inline-block}.wall-entry .wall-entry-header .media-subheading .wall-entry-icons i{margin-right:2px}.wall-entry .wall-entry-header .media-subheading .time,.wall-entry .wall-entry-header .media-subheading i,.wall-entry .wall-entry-header .media-subheading span{font-size:11px;white-space:nowrap}.wall-entry .wall-entry-body{padding-left:50px;padding-right:50px}.wall-entry .wall-entry-body .wall-entry-content{margin-bottom:5px}.wall-entry .wall-entry-body .wall-entry-content .post-short-text{font-size:1.6em}.wall-entry .wall-entry-body .wall-entry-content .post-short-text .emoji{width:20px}.wall-entry .wall-entry-body audio,.wall-entry .wall-entry-body video{width:100%}.wall-entry .wall-stream-footer .wall-stream-addons .files{margin-bottom:5px}.wall-entry .content a{color:#21A1B3}.wall-entry .content img{max-width:100%}.wall-entry .media{overflow:visible}.wall-entry .well{margin-bottom:0}.wall-entry .well .comment .showMore a{font-size:12px}.wall-entry .media-heading{font-size:14px;padding-top:1px;margin-bottom:3px}.wall-entry .media-heading .labels{padding-right:32px}.wall-entry .media-heading .viaLink{font-size:13px}.wall-entry .media-heading .viaLink i{color:#555555;padding-left:4px;padding-right:4px}.wall-entry .media-subheading{color:#555555;font-size:12px}.wall-entry .media-subheading .time{font-size:12px;white-space:nowrap}.wall-entry [data-ui-richtext] h1{font-size:1.45em;font-weight:normal}.wall-entry [data-ui-richtext] h2{font-size:1.3em;font-weight:normal}.wall-entry [data-ui-richtext] h3{font-size:1.2em;font-weight:normal}.wall-entry [data-ui-richtext] h4{font-size:1.1em;font-weight:normal}.wall-entry [data-ui-richtext] h5{font-size:1em;font-weight:normal}.wall-entry [data-ui-richtext] h6{font-size:.85em;font-weight:normal}@media (max-width:767px){.wall-entry .wall-entry-body{padding-left:0;padding-right:0}#wallStream .back_button_holder{padding-bottom:5px;text-align:center}}.wall-entry-controls a{font-size:11px;color:#21A1B3 !important;margin-top:10px;margin-bottom:0}#wall-stream-filter-nav{font-size:12px;margin-bottom:10px;padding-top:2px;border-radius:0 0 4px 4px}#wall-stream-filter-nav .wall-stream-filter-root{margin:0;border:0 !important}#wall-stream-filter-nav .filter-panel{padding:0 10px}#wall-stream-filter-nav .wall-stream-filter-head{padding:5px 5px 10px 5px;border-bottom:1px solid #ddd}#wall-stream-filter-nav .wall-stream-filter-body{overflow:hidden;background-color:#f8f8f8;border:1px solid #ddd;border-top:0;border-radius:0 0 4px 4px}#wall-stream-filter-nav hr{margin:5px 0 0 0}#wall-stream-filter-nav .topic-remove-label{float:left}#wall-stream-filter-nav .topic-remove-label,#wall-stream-filter-nav .content-type-remove-label{margin-right:6px}#wall-stream-filter-nav .select2{width:260px !important;margin-bottom:5px;margin-top:2px}#wall-stream-filter-nav .select2 .select2-search__field{height:25px !important}#wall-stream-filter-nav .select2 .select2-selection__choice{height:23px !important}#wall-stream-filter-nav .select2 .select2-selection__choice span,#wall-stream-filter-nav .select2 .select2-selection__choice i{line-height:19px !important}#wall-stream-filter-nav .select2 .select2-selection__choice .img-rounded{width:18px !important;height:18px !important}#wall-stream-filter-nav .wall-stream-filter-bar{display:inline;float:right;white-space:normal}#wall-stream-filter-nav .wall-stream-filter-bar .label{height:18px;padding-top:4px;background-color:#fff}#wall-stream-filter-nav .wall-stream-filter-bar .btn,#wall-stream-filter-nav .wall-stream-filter-bar .label{box-shadow:0 0 2px #7a7a7a}@media (max-width:767px){#wall-stream-filter-nav{margin-bottom:5px}#wall-stream-filter-nav .wall-stream-filter-root{white-space:nowrap}#wall-stream-filter-nav .wall-stream-filter-body{overflow:auto}}.filter-root{margin:15px}.filter-root .row{display:table !important}.filter-root .filter-panel{padding:0 5px;display:table-cell !important;float:none}.filter-root .filter-panel .filter-block strong{margin-bottom:5px}.filter-root .filter-panel .filter-block ul.filter-list{list-style:none;padding:0;margin:0 0 5px}.filter-root .filter-panel .filter-block ul.filter-list li{font-size:12px;padding:2px}.filter-root .filter-panel .filter-block ul.filter-list li a{color:#000}.filter-root .filter-panel div.filter-block:last-of-type ul.filter-list{margin:0}.filter-root .filter-panel+.filter-panel{border-left:2px solid #ededed}.stream-entry-loader{float:right;margin-top:5px}.load-suppressed{margin-top:-17px;margin-bottom:15px;text-align:center}.load-suppressed a{display:inline-block;background-color:white;padding:5px;border-radius:0 0 4px 4px;border:1px solid #ddd;font-size:11px}@media print{.wall-entry{page-break-inside:avoid}#wall-stream-filter-nav,#contentFormBody{display:none}}.space-owner{text-align:center;margin:14px 0;font-size:13px;color:#999}.space-member-sign{color:#97d271;position:absolute;top:42px;left:42px;font-size:16px;background:#fff;width:24px;height:24px;padding:2px 3px 1px 4px;border-radius:50px;border:2px solid #97d271}#space-menu-dropdown i.type{font-size:16px;color:#BFBFBF}#space-menu-spaces [data-space-chooser-item]{cursor:pointer}#space-menu-dropdown .input-group-addon{border-radius:0 4px 4px 0}#space-menu-dropdown .input-group-addon.focus{border-radius:0 4px 4px 0;border:2px solid #21A1B3;border-left:0}.input-group #space-menu-search{border-right:0}#space-menu-dropdown div:not(.input-group)>.search-reset{top:10px !important;right:15px !important}#space-directory-link i{margin-right:0}.space-acronym{color:#fff;text-align:center;display:inline-block}.current-space-image{margin-right:3px;margin-top:3px}@media (max-width:767px){#space-menu>.title{display:none}#space-menu-dropdown{width:300px !important}}.files,#postFormFiles_list{padding-left:0}ul.files{list-style:none;margin:0 0 5px;padding:0}ul.files li.file-preview-item{padding-left:24px;display:none}ul.files li.file-preview-item .file-fileInfo{padding-right:20px}.contentForm-upload-list{padding-left:0}.contentForm-upload-list li:first-child{margin-top:10px}.file_upload_remove_link,.file_upload_remove_link:hover{color:#FC4A64;cursor:pointer}.file-preview-item{text-overflow:ellipsis;overflow:hidden}.post-files{margin-top:10px;margin-bottom:10px}.post-files video{border-radius:4px}.post-files .jp-audio{margin-bottom:10px}.post-files .col-media{padding-left:0 !important;padding-right:0 !important}.post-files img{vertical-align:top;padding:2px;height:150px;width:100%;object-fit:cover;border-radius:4px}@media (max-width:650px){.post-files img{height:100px}}.post-file-list{padding:10px;padding-bottom:1px;margin-bottom:10px !important}.post-file-list a,.post-file-list a:active,.post-file-list a:focus,.post-file-list a:hover{color:#21A1B3}#wallStream.mobile .post-files{margin-top:10px;display:flex;overflow-x:auto}#wallStream.mobile .post-files img{max-width:190px;height:100px;width:auto}.file-preview-content{cursor:pointer}.image-upload-container{position:relative}.image-upload-container .image-upload-buttons{display:none;position:absolute;right:5px;bottom:5px}.image-upload-container input[type="file"]{position:absolute;opacity:0}.image-upload-container .image-upload-loader{display:none;position:absolute;top:0;left:0;width:100%;height:100%;padding:20px;background:#f8f8f8}.mime{background-repeat:no-repeat;background-position:0 0;padding:1px 0 4px 26px}.mime-word{background-image:url("../img/mime/word.png")}.mime-excel{background-image:url("../img/mime/excel.png")}.mime-powerpoint{background-image:url("../img/mime/powerpoint.png")}.mime-pdf{background-image:url("../img/mime/pdf.png")}.mime-zip{background-image:url("../img/mime/zip.png")}.mime-image{background-image:url("../img/mime/image.png")}.mime-file{background-image:url("../img/mime/file.png")}.mime-photoshop{background-image:url("../img/mime/photoshop.png")}.mime-illustrator{background-image:url("../img/mime/illustrator.png")}.mime-video{background-image:url("../img/mime/video.png")}.mime-audio{background-image:url("../img/mime/audio.png")}@media (max-width:480px){.jp-current-time{margin-left:0 !important}.jp-audio{width:auto !important;margin-left:0 !important}.jp-audio .jp-controls{padding:2px 12px 0 !important}.jp-audio .jp-progress{left:3px !important;top:45px !important;width:200px !important}.jp-audio .jp-volume-controls{position:absolute !important;top:15px !important;left:170px !important}.jp-audio .jp-time-holder{left:3px !important;top:60px !important;width:200px !important}.jp-audio .jp-toggles{left:210px !important;top:45px !important;width:auto !important}.jp-playlist ul{padding:0 0 0 0 !important}}div.jp-type-playlist div.jp-playlist a.jp-playlist-current,div.jp-type-playlist div.jp-playlist a:hover{color:#21A1B3 !important}.jp-details,.jp-playlist{border-top:1px solid #21A1B3}.jp-audio,.jp-audio-stream,.jp-video{border:1px solid #21A1B3}ul.tour-list{list-style:none;margin-bottom:0;padding-left:10px}ul.tour-list li{padding-top:5px}ul.tour-list li a{color:#21A1B3}ul.tour-list li a .fa{width:16px}ul.tour-list li.completed a{text-decoration:line-through;color:#555555}.atwho-view{background:#fff;color:#555555;border:1px solid #d7d7d7;border-radius:4px;box-shadow:0 6px 12px rgba(0,0,0,0.175);display:none;font-size:14px;font-weight:400;margin-top:18px;min-width:120px;max-width:265px;padding:5px 0;position:absolute;top:0;left:0;z-index:11110 !important}.atwho-view ul{list-style:none;margin:auto;padding:0}.atwho-view ul li{border-left:3px solid transparent;cursor:pointer;display:block;padding:4px 15px 4px 8px}.atwho-view ul li.hint{background:#fff !important;border-left:3px solid transparent !important;color:#aeaeae;font-size:12px}.atwho-input.form-control{height:auto;min-height:36px;padding-right:95px;word-wrap:break-word}.atwho-input p{padding:0;margin:0}.atwho-placeholder{color:#bac2c7 !important}.atwho-emoji-entry{float:left;padding:4px !important;margin:0 !important;border:none !important}.atwho-emoji-entry:hover,.atwho-emoji-entry:active,.atwho-emoji-entry:focus{padding:4px !important;margin:0 !important;border:none !important;background-color:#f8f8f8 !important;border-radius:3px}.atwho-view .cur{border-left:3px solid #21A1B3;background-color:#f8f8f8 !important}.atwho-user,.atwho-space,.atwho-input a{color:#21A1B3}.atwho-input a:hover{color:#21A1B3}.atwho-view strong{background-color:#fff4d3}.atwho-view .cur strong{background-color:#fff4d3}.atwho-view small{font-size:smaller;color:#7a7a7a;font-weight:normal}.atwho-view .cur small{color:var(--danger)}.atwho-view strong,.atwho-view b{font-weight:normal}.atwho-view span{padding:5px}.sk-spinner-three-bounce.sk-spinner{margin:0 auto;width:70px;text-align:center}.loader{padding:30px 0}.loader .sk-spinner-three-bounce div,.loader .sk-spinner-three-bounce span{width:12px;height:12px;background-color:#21A1B3;border-radius:100%;display:inline-block;animation:sk-threeBounceDelay 1.4s infinite ease-in-out;animation-fill-mode:both}.loader .sk-spinner-three-bounce .sk-bounce1{animation-delay:-0.32s}.loader .sk-spinner-three-bounce .sk-bounce2{animation-delay:-0.16s}@keyframes sk-threeBounceDelay{0%,80%,100%{transform:scale(0)}40%{transform:scale(1)}}.loader-modal{padding:8px 0}.loader-postform{padding:9px 0}.loader-postform .sk-spinner-three-bounce.sk-spinner{text-align:left;margin:0}.md-editor.active{border:2px solid #21A1B3 !important}.md-editor textarea{padding:10px !important}.markdown-render,[data-ui-markdown],[data-ui-richtext]{line-height:1.57;overflow:hidden;overflow-wrap:break-word}.markdown-render h1,[data-ui-markdown] h1,[data-ui-richtext] h1,.markdown-render h2,[data-ui-markdown] h2,[data-ui-richtext] h2,.markdown-render h3,[data-ui-markdown] h3,[data-ui-richtext] h3,.markdown-render h4,[data-ui-markdown] h4,[data-ui-richtext] h4,.markdown-render h5,[data-ui-markdown] h5,[data-ui-richtext] h5,.markdown-render h6,[data-ui-markdown] h6,[data-ui-richtext] h6{margin:1.2em 0 .8em;color:#555;font-weight:normal;text-align:start}.markdown-render h1:first-child,[data-ui-markdown] h1:first-child,[data-ui-richtext] h1:first-child,.markdown-render h2:first-child,[data-ui-markdown] h2:first-child,[data-ui-richtext] h2:first-child,.markdown-render h3:first-child,[data-ui-markdown] h3:first-child,[data-ui-richtext] h3:first-child,.markdown-render h4:first-child,[data-ui-markdown] h4:first-child,[data-ui-richtext] h4:first-child,.markdown-render h5:first-child,[data-ui-markdown] h5:first-child,[data-ui-richtext] h5:first-child,.markdown-render h6:first-child,[data-ui-markdown] h6:first-child,[data-ui-richtext] h6:first-child{margin:0 0 .8em}.markdown-render h1,[data-ui-markdown] h1,[data-ui-richtext] h1{font-size:1.7em}.markdown-render h2,[data-ui-markdown] h2,[data-ui-richtext] h2{font-size:1.5em}.markdown-render h3,[data-ui-markdown] h3,[data-ui-richtext] h3{font-size:1.2em}.markdown-render h4,[data-ui-markdown] h4,[data-ui-richtext] h4{font-size:1.1em}.markdown-render h5,[data-ui-markdown] h5,[data-ui-richtext] h5{font-size:1em}.markdown-render h6,[data-ui-markdown] h6,[data-ui-richtext] h6{font-size:.85em}.markdown-render p,[data-ui-markdown] p,[data-ui-richtext] p,.markdown-render pre,[data-ui-markdown] pre,[data-ui-richtext] pre,.markdown-render blockquote,[data-ui-markdown] blockquote,[data-ui-richtext] blockquote,.markdown-render ul,[data-ui-markdown] ul,[data-ui-richtext] ul,.markdown-render ol,[data-ui-markdown] ol,[data-ui-richtext] ol{margin:0 0 1.2em}.markdown-render li ul,[data-ui-markdown] li ul,[data-ui-richtext] li ul,.markdown-render li ol,[data-ui-markdown] li ol,[data-ui-richtext] li ol{margin:0}.markdown-render p:last-child,[data-ui-markdown] p:last-child,[data-ui-richtext] p:last-child{margin:0}.markdown-render pre,[data-ui-markdown] pre,[data-ui-richtext] pre{padding:0;border:none;background-color:#f8f8f8}.markdown-render pre code,[data-ui-markdown] pre code,[data-ui-richtext] pre code{background-color:#f8f8f8;color:#555}.markdown-render code,[data-ui-markdown] code,[data-ui-richtext] code{background-color:#dbf5f8;color:#197a88}.markdown-render blockquote,[data-ui-markdown] blockquote,[data-ui-richtext] blockquote{background-color:rgba(128,128,128,0.05);border-top-right-radius:5px;border-bottom-right-radius:5px;padding:15px 20px;font-size:1em;border-left:5px solid #435f6f}.markdown-render dt,[data-ui-markdown] dt,[data-ui-richtext] dt,.markdown-render dd,[data-ui-markdown] dd,[data-ui-richtext] dd{margin-top:5px;margin-bottom:5px;line-height:1.45}.markdown-render dt,[data-ui-markdown] dt,[data-ui-richtext] dt{font-weight:bold}.markdown-render dd,[data-ui-markdown] dd,[data-ui-richtext] dd{margin-left:40px}.markdown-render pre,[data-ui-markdown] pre,[data-ui-richtext] pre{text-align:start;border:0;padding:10px 20px;border-radius:0;border-left:2px solid #435f6f}.markdown-render pre code,[data-ui-markdown] pre code,[data-ui-richtext] pre code{white-space:pre !important}.markdown-render blockquote ul:last-child,[data-ui-markdown] blockquote ul:last-child,[data-ui-richtext] blockquote ul:last-child,.markdown-render blockquote ol:last-child,[data-ui-markdown] blockquote ol:last-child,[data-ui-richtext] blockquote ol:last-child{margin-bottom:0}.markdown-render ul,[data-ui-markdown] ul,[data-ui-richtext] ul,.markdown-render ol,[data-ui-markdown] ol,[data-ui-richtext] ol{margin-top:0;padding-left:30px}.markdown-render ul li p,[data-ui-markdown] ul li p,[data-ui-richtext] ul li p,.markdown-render ol li p,[data-ui-markdown] ol li p,[data-ui-richtext] ol li p{overflow:visible !important}.markdown-render .footnote,[data-ui-markdown] .footnote,[data-ui-richtext] .footnote{vertical-align:top;position:relative;top:-0.5em;font-size:.8em}.markdown-render .emoji,[data-ui-markdown] .emoji,[data-ui-richtext] .emoji{width:16px}.markdown-render a,[data-ui-markdown] a,[data-ui-richtext] a,.markdown-render a:visited,[data-ui-markdown] a:visited,[data-ui-richtext] a:visited{background-color:inherit;text-decoration:none;color:#21A1B3 !important}.markdown-render a.header-anchor,[data-ui-markdown] a.header-anchor,[data-ui-richtext] a.header-anchor{color:#555 !important}.markdown-render a.not-found,[data-ui-markdown] a.not-found,[data-ui-richtext] a.not-found{color:#FFC107}.markdown-render li,[data-ui-markdown] li,[data-ui-richtext] li{border:0 !important;background-color:transparent !important;padding:0;margin:5px 0}.markdown-render img:not(.center-block),[data-ui-markdown] img:not(.center-block),[data-ui-richtext] img:not(.center-block){max-width:100%}.markdown-render img.pull-right,[data-ui-markdown] img.pull-right,[data-ui-richtext] img.pull-right{margin:5px 0 0 10px}.markdown-render img.pull-left,[data-ui-markdown] img.pull-left,[data-ui-richtext] img.pull-left{margin:5px 10px 0 0}.markdown-render img.center-block,[data-ui-markdown] img.center-block,[data-ui-richtext] img.center-block{margin-top:5px;margin-bottom:5px}.markdown-render img[width='100%'],[data-ui-markdown] img[width='100%'],[data-ui-richtext] img[width='100%']{border-radius:4px}.markdown-render table,[data-ui-markdown] table,[data-ui-richtext] table{border:1px solid #d7d7d7;margin-bottom:1.2em !important;font-size:1em;width:100%}.markdown-render table th,[data-ui-markdown] table th,[data-ui-richtext] table th,.markdown-render table td,[data-ui-markdown] table td,[data-ui-richtext] table td{border:1px solid #d7d7d7 !important;box-sizing:border-box;position:relative}.markdown-render table th,[data-ui-markdown] table th,[data-ui-richtext] table th{background-color:#435f6f;color:#fff !important;font-size:1em}.markdown-render table th p,[data-ui-markdown] table th p,[data-ui-richtext] table th p{color:#fff !important}.markdown-render table td,[data-ui-markdown] table td,[data-ui-richtext] table td{padding:15px}.markdown-render table th,[data-ui-markdown] table th,[data-ui-richtext] table th{padding:10px 15px}@media (max-width:991px){.layout-sidebar-container{display:none}}.ui-widget-header{border:none !important;background:#fff !important;color:#7a7a7a !important;font-weight:300 !important}.ui-widget-content{border:1px solid #dddcda !important;border-radius:0 !important;background:#fff;color:#000 !important;box-shadow:0 6px 6px rgba(0,0,0,0.1)}.ui-datepicker .ui-datepicker-prev span,.ui-datepicker .ui-datepicker-next span{opacity:.2}.ui-datepicker .ui-datepicker-prev:hover,.ui-datepicker .ui-datepicker-next:hover{background:#fff !important;border:none;margin:1px}.ui-state-default,.ui-widget-content .ui-state-default,.ui-widget-header .ui-state-default{border:none !important;background:#f8f8f8 !important;color:#7a7a7a !important}.ui-state-highlight,.ui-widget-content .ui-state-highlight,.ui-widget-header .ui-state-highlight{border:none !important;border:1px solid #b2b2b2 !important}.ui-state-active,.ui-widget-content .ui-state-active,.ui-widget-header .ui-state-active{border:1px solid #21A1B3 !important;background:#6fd6e4 !important}.status-bar-body{color:white;position:fixed;width:100%;background-color:rgba(0,0,0,0.7);text-align:center;padding:20px;z-index:9999999;bottom:0px;display:block;line-height:20px}.status-bar-close{color:white;font-weight:bold;font-size:21px;cursor:pointer}.status-bar-close:hover{color:white}.status-bar-close i{vertical-align:top !important;padding-top:3px}.status-bar-content i{margin-right:10px;font-size:21px;vertical-align:middle}.status-bar-content .showMore{color:#21A1B3;float:right;margin-left:10px;font-size:.7em;cursor:pointer;vertical-align:middle;white-space:nowrap}.status-bar-content .status-bar-details{text-align:left;font-size:.7em;margin-top:20px;max-height:200px;overflow:auto}.status-bar-content span{vertical-align:middle}.status-bar-content i.error,.status-bar-content i.fatal{color:#FC4A64}.status-bar-content i.warning{color:#FFC107}.status-bar-content i.info,.status-bar-content i.debug{color:#21A1B3}.status-bar-content i.success{color:#85CA2B}.highlight{background-color:#daf0f3}.alert-default{color:#000;background-color:#f8f8f8;border-color:#ededed;font-size:13px}.alert-default .info{margin:10px 0}.alert-success{color:#84be5e;background-color:#f7fbf4;border-color:#97d271}.alert-warning{color:#e9b168;background-color:#fffbf7;border-color:#fdd198}.alert-danger{color:#ff8989;background-color:#fff6f6;border-color:#ff8989}.data-saved{padding-left:10px;color:#21A1B3}img.bounceIn{animation-duration:800ms}.tags .tag{margin-top:5px;border-radius:2px;padding:4px 8px;text-transform:uppercase;max-width:150px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}#user-tags-panel .tags .tag{max-width:250px}.label{text-transform:uppercase}.label{text-transform:uppercase;display:inline-block;padding:3px 5px 4px;font-weight:600;font-size:10px;color:white;vertical-align:baseline;white-space:nowrap;text-shadow:none}.label-default{background:#ededed;color:#7a7a7a !important}a.label-default:hover{background:#e0e0e0 !important}.label-info{background-color:#21A1B3}a.label-info:hover{background:#1d8e9d !important}.label-danger{background-color:#FC4A64}a.label-danger:hover{background:#fc314f !important}.label-success{background-color:#97d271}a.label-success:hover{background:#89cc5e !important}.label-warning{background-color:#FFC107}a.label-warning:hover{background:#ecb100 !important}.label-light{background-color:transparent;color:#7a7a7a;border:1px solid #bababa}.topic-label-list,.wall-entry-topics{margin-bottom:10px}.topic-label-list a,.wall-entry-topics a{margin-right:4px}.topic-label-list .label,.wall-entry-topics .label{padding:5px;border-radius:4px}.ProsemirrorEditor.fullscreen{height:calc(100vh - 3px);position:fixed;top:0;left:0;width:100vw;z-index:9998}.ProsemirrorEditor.fullscreen .ProseMirror-menubar-wrapper{height:100%}.ProsemirrorEditor.fullscreen .humhub-ui-richtext{max-height:none !important}.ProsemirrorEditor.fullscreen .ProseMirror{height:calc(100% - 26px);position:static;overflow:auto}.ProsemirrorEditor.fullscreen .ProseMirror-menubar{position:static !important;top:0 !important;left:0 !important;margin:0 !important;width:100% !important}.login-container .ProsemirrorEditor.fullscreen,.modal-dialog .ProsemirrorEditor.fullscreen{width:100%;height:100%}.ProsemirrorEditor .ProseMirror{padding-right:12px}.ProsemirrorEditor .ProseMirror.form-control{font-size:inherit}.ProsemirrorEditor .ProseMirror-menu{margin:0 -4px;line-height:1}.ProsemirrorEditor .ProseMirror-tooltip .ProseMirror-menu{width:fit-content;white-space:pre}.ProsemirrorEditor .ProseMirror-menuitem{display:flex;margin-right:0}.ProsemirrorEditor .ProseMirror-menuseparator{border-right:1px solid #d7d7d7;margin-right:1px}.ProsemirrorEditor .ProseMirror-menubar-wrapper{z-index:200}.ProsemirrorEditor .ProseMirror-menu-group{display:flex;flex-wrap:wrap;min-height:22px}.ProsemirrorEditor .ProseMirror-menuitem .ProseMirror-menu-group{border-right:1px solid #d7d7d7}.ProsemirrorEditor .ProseMirror-menuitem .ProseMirror-menu-group.last{border-right:none}.ProsemirrorEditor .ProseMirror-menuitem .ProseMirror-icon{background:transparent}.ProsemirrorEditor .ProseMirror-menuitem .seperator{border-right:1px solid #d7d7d7;border-radius:0}.ProsemirrorEditor .ProseMirror-menu-dropdown,.ProsemirrorEditor .ProseMirror-menu-dropdown-menu{white-space:nowrap}.ProsemirrorEditor .ProseMirror-menu-dropdown{cursor:pointer;position:relative;padding-right:14px !important}.ProsemirrorEditor .ProseMirror-menu-dropdown-wrap{padding:0;display:inline-block;position:relative}.ProsemirrorEditor .ProseMirror-menu-dropdown:after{content:"";border-left:4px solid transparent;border-right:4px solid transparent;border-top:4px solid currentColor;opacity:.6;position:absolute;right:4px;top:calc(50% - 2px)}.ProsemirrorEditor .ProseMirror-menu-dropdown-menu,.ProsemirrorEditor .ProseMirror-menu-submenu{background:#fff;border:1px solid #aeaeae;border-bottom-left-radius:4px;border-bottom-right-radius:4px;color:#000;position:absolute}.ProsemirrorEditor .ProseMirror-menu-dropdown-menu .ProseMirror-menu-active,.ProsemirrorEditor .ProseMirror-menu-submenu .ProseMirror-menu-active{background:#f8f8f8;border-left:2px solid #21A1B3;opacity:1 !important;padding:4px 7px 4px 5px}.ProsemirrorEditor .ProseMirror-menu-dropdown-menu{margin-top:2px;min-width:6em;z-index:15}.ProsemirrorEditor .ProseMirror-menu-dropdown-item{cursor:pointer}.ProsemirrorEditor .ProseMirror-menu-dropdown-item div[title],.ProsemirrorEditor .ProseMirror-menu-dropdown-item a.ProseMirror-menu-trigger,.ProsemirrorEditor .ProseMirror-menu-submenu-wrap{display:block;padding:4px 7px}.ProsemirrorEditor .ProseMirror-menu-dropdown-item:hover{background:#f8f8f8}.ProsemirrorEditor .ProseMirror-menu-submenu-wrap{position:relative}.ProsemirrorEditor .ProseMirror-menu-submenu-label:after{border-top:4px solid transparent;border-bottom:4px solid transparent;border-left:4px solid currentColor;content:"";opacity:.6;position:absolute;right:4px;top:calc(50% - 4px)}.ProsemirrorEditor .ProseMirror-menu-submenu{background:#fff;border-top-right-radius:4px;display:none;min-width:4em;left:100%;top:0}.ProsemirrorEditor .ProseMirror-menu-disabled{opacity:.5}.ProsemirrorEditor .ProseMirror-menu-submenu-wrap:hover .ProseMirror-menu-submenu,.ProsemirrorEditor .ProseMirror-menu-submenu-wrap-active .ProseMirror-menu-submenu{display:block}.ProsemirrorEditor .ProseMirror-icon{border:1px solid transparent;border-radius:4px;cursor:pointer;display:flex;align-items:center;justify-content:center;min-width:28px;padding:0 5px}.ProsemirrorEditor .ProseMirror-icon.ProseMirror-menu-active{border-color:#bac2c7}.ProsemirrorEditor .ProseMirror-icon.ProseMirror-menu-tableOption svg,.ProsemirrorEditor .ProseMirror-icon.ProseMirror-menu-insertEmoji svg{padding-top:1px;padding-left:1px}.ProsemirrorEditor .ProseMirror-menu-disabled.ProseMirror-icon{cursor:default}.ProsemirrorEditor .ProseMirror-icon svg{fill:currentColor;height:20px}.ProsemirrorEditor .ProseMirror-icon span{vertical-align:text-top}.ProsemirrorEditor .ProseMirror-editor-source{border:2px solid #ededed;border-radius:0 4px 4px 4px;box-sizing:border-box;display:block;min-height:36px;resize:none;overflow:auto;outline:none;padding:7px 12px;width:100%}.ProsemirrorEditor .ProseMirror-editor-source:focus{border:2px solid #21A1B3}.ProsemirrorEditor.plainMenu .ProseMirror{border-top-left-radius:0 !important;border-top-right-radius:0 !important;border-top-width:1px !important;min-height:100px}.ProsemirrorEditor.plainMenu .ProseMirror-menu-group,.ProsemirrorEditor.plainMenu .ProseMirror-menuitem .ProseMirror-menu-group{padding:2px}.ProsemirrorEditor.plainMenu .ProseMirror-menubar~.ProseMirror-focused{border-color:#21A1B3 !important}.ProsemirrorEditor.plainMenu .ProseMirror-textblock-dropdown{min-width:3em}.ProsemirrorEditor.plainMenu .ProseMirror-menubar-wrapper{z-index:8}.ProsemirrorEditor.plainMenu .ProseMirror-menubar{background:white;border:1px solid #d7d7d7;border-top-left-radius:4px;border-top-right-radius:4px;box-sizing:border-box;color:#555555;position:relative;min-height:1em;overflow:visible;padding:2px 0;top:0;left:0;right:0;z-index:10}.ProsemirrorEditor.focusMenu .form-control:focus{border-top-left-radius:0 !important}.ProsemirrorEditor.focusMenu .ProseMirror-menubar{background:white;border:1px solid #aeaeae;border-bottom:0;border-top-left-radius:4px;border-top-right-radius:4px;box-sizing:border-box;color:#555555;float:left;margin-top:-27px;min-height:1em;overflow:visible;padding:2px 0;position:relative;top:0;left:0;right:0;z-index:10}.ProsemirrorEditor .ProseMirror{position:relative;word-wrap:break-word;white-space:pre-wrap;font-variant-ligatures:none}.ProsemirrorEditor .ProseMirror ul,.ProsemirrorEditor .ProseMirror ol{cursor:default}.ProsemirrorEditor .ProseMirror pre{white-space:pre-wrap}.ProsemirrorEditor .ProseMirror li{position:relative}.ProsemirrorEditor .ProseMirror img{max-width:100%}.ProsemirrorEditor .ProseMirror-hideselection *::selection{background:transparent}.ProsemirrorEditor .ProseMirror-selectednode{outline:2px dashed #85dce8}.ProsemirrorEditor li.ProseMirror-selectednode{outline:none}.ProsemirrorEditor li.ProseMirror-selectednode:after{content:"";position:absolute;left:-32px;right:-2px;top:-2px;bottom:-2px;border:2px solid #85dce8;pointer-events:none}.ProsemirrorEditor .ProseMirror-textblock-dropdown{min-width:3em}.ProsemirrorEditor .ProseMirror-menu{margin:0 -4px;line-height:1}.ProsemirrorEditor .ProseMirror-tooltip .ProseMirror-menu{width:fit-content;white-space:pre}.ProsemirrorEditor .ProseMirror-gapcursor{display:none;pointer-events:none;position:absolute}.ProsemirrorEditor .ProseMirror-gapcursor:after{content:"";display:block;position:absolute;top:-2px;width:20px;border-top:1px solid black;animation:ProseMirror-cursor-blink 1.1s steps(2, start) infinite}@keyframes ProseMirror-cursor-blink{to{visibility:hidden}}.ProsemirrorEditor .ProseMirror-focused .ProseMirror-gapcursor{display:block}.ProsemirrorEditor .ProseMirror-example-setup-style hr{padding:2px 10px;border:none;margin:1em 0}.ProsemirrorEditor .ProseMirror-example-setup-style hr:after{content:"";display:block;height:1px;background-color:silver;line-height:2px}.ProsemirrorEditor .ProseMirror-example-setup-style img{cursor:default}.ProsemirrorEditor .ProseMirror p{margin-top:1.2em}.ProsemirrorEditor .ProseMirror p:first-child{margin:0}.ProsemirrorEditor .ProseMirror>p:first-child+*{margin-top:1.2em}.ProsemirrorEditor .ProsemirrorEditor{position:relative}.ProsemirrorEditor .ProsemirrorEditor .ProseMirror{padding-right:12px !important}.ProsemirrorEditor .ProsemirrorEditor img{max-width:100%}.ProsemirrorEditor .ProseMirror h1:first-child,.ProsemirrorEditor .ProseMirror h2:first-child,.ProsemirrorEditor .ProseMirror h3:first-child,.ProsemirrorEditor .ProseMirror h4:first-child,.ProsemirrorEditor .ProseMirror h5:first-child,.ProsemirrorEditor .ProseMirror h6:first-child{margin-top:10px}.ProsemirrorEditor .ProseMirror [data-mention]{color:#21A1B3}.ProsemirrorEditor .ProseMirror{outline:none}.ProsemirrorEditor .ProseMirror [data-oembed]{font-size:0}.ProsemirrorEditor .ProseMirror iframe{pointer-events:none;display:block}.ProsemirrorEditor .ProseMirror p{margin-bottom:1em}.ProsemirrorEditor .ProseMirror-textblock-dropdown{min-width:3em}.ProsemirrorEditor .ProseMirror .placeholder{padding:0 !important;pointer-events:none;height:0}.ProsemirrorEditor .ProseMirror:focus .placeholder{display:none}.ProsemirrorEditor .ProseMirror .tableWrapper{overflow-x:auto}.ProsemirrorEditor .ProseMirror .column-resize-handle{background-color:#b0e8f0;pointer-events:none;position:absolute;right:-2px;top:0;bottom:0;width:4px;z-index:20}.ProsemirrorEditor .ProseMirror.resize-cursor{cursor:ew-resize;cursor:col-resize}.ProsemirrorEditor .ProseMirror .selectedCell:after{background:rgba(200,255,255,0.4);content:"";pointer-events:none;position:absolute;left:0;right:0;top:0;bottom:0;z-index:2}.ProsemirrorEditor .ProseMirror-menubar-wrapper{position:relative;outline:none}.ProsemirrorEditor .ProseMirror table{margin:0}.ProsemirrorEditor .ProseMirror .tableWrapper{margin:1em 0}.ProseMirror-prompt{background:white;border:1px solid silver;border-radius:3px;box-shadow:-0.5px 2px 5px rgba(0,0,0,0.2);padding:5px 10px 5px 15px;position:fixed;min-width:300px;z-index:999999}.ProseMirror-prompt h5{font-weight:bold;font-size:100%;margin:15px 0}.ProseMirror-prompt input{margin-bottom:5px}.ProseMirror-prompt-close{background:transparent;color:#555555;padding:0;position:absolute;left:2px;top:1px;border:none}.ProseMirror-prompt-close:after{content:"✕";font-size:12px}.ProseMirror-invalid{background:#fff4d3;border:1px solid #ffce3a;border-radius:4px;padding:5px 10px;position:absolute;min-width:10em}.ProseMirror-prompt-buttons{margin:15px 0;text-align:center}.atwho-view .cur{border-left:3px solid #85dce8;background-color:#f8f8f8 !important}.atwho-user,.atwho-space,.atwho-input a{color:#21A1B3}.atwho-input a:hover{color:#21A1B3}.atwho-view strong{background-color:#fff4d3}.atwho-view .cur strong{background-color:#fff4d3}[data-emoji-category]{max-height:200px;display:block;position:relative;overflow:auto}[data-emoji-category] .atwho-emoji-entry{width:24px;height:28px;overflow:hidden}[data-emoji-category] .atwho-emoji-entry.cur{background-color:#ededed !important}.emoji-nav{padding-top:10px}.emoji-nav .emoji-nav-item{border-top:2px solid #daf0f3}.emoji-nav .emoji-nav-item.cur{border-left:0;border-top:2px solid #21A1B3}[data-ui-markdown],[data-ui-richtext]{overflow-x:auto;overflow-wrap:break-word}[data-ui-markdown] a,[data-ui-richtext] a{color:#21A1B3}#wallStream [data-ui-markdown],#wallStream [data-ui-richtext]{overflow-wrap:initial;word-break:initial;hyphens:initial}@media screen and (max-width:460px){.ProsemirrorEditor .ProseMirror-menu-dropdown-right{right:0}}@media screen and (max-width:768px){.ProsemirrorEditor.focusMenu .form-control:focus{border-top-right-radius:0 !important}.ProsemirrorEditor.focusMenu .ProseMirror-menubar{min-height:1em;margin-top:0}.ProsemirrorEditor.focusMenu .humhub-ui-richtext{margin-top:0}}@media only screen and (max-width : 768px){body{padding-top:105px}.modal-open #layout-content>.container{overflow-x:unset}#layout-content .left-navigation .list-group{-webkit-overflow-scrolling:auto;white-space:nowrap;overflow-x:auto}#layout-content .left-navigation .list-group::-webkit-scrollbar{-webkit-appearance:none}#layout-content .left-navigation .list-group::-webkit-scrollbar:vertical{width:8px}#layout-content .left-navigation .list-group::-webkit-scrollbar:horizontal{height:8px}#layout-content .left-navigation .list-group::-webkit-scrollbar-thumb{background-color:rgba(0,0,0,0.5);border-radius:10px;border:2px solid #ffffff}#layout-content .left-navigation .list-group::-webkit-scrollbar-track{border-radius:10px;background-color:#ffffff}#layout-content .table-responsive::-webkit-scrollbar{-webkit-appearance:none}#layout-content .table-responsive::-webkit-scrollbar:vertical{width:8px}#layout-content .table-responsive::-webkit-scrollbar:horizontal{height:8px}#layout-content .table-responsive::-webkit-scrollbar-thumb{background-color:rgba(0,0,0,0.5);border-radius:10px;border:2px solid #ffffff}#layout-content .table-responsive::-webkit-scrollbar-track{border-radius:10px;background-color:#ffffff}#layout-content .panel{margin-bottom:5px}#layout-content .panel .statistics .entry{margin-left:10px}#layout-content>.container{padding-right:2px !important;padding-left:2px !important;overflow-x:hidden}#layout-content .layout-nav-container .panel-heading{display:none}#layout-content .panel-profile-header #profilefileupload,#layout-content .panel-profile-header .profile-user-photo-container,#layout-content .panel-profile-header .space-acronym{height:100px !important;width:100px !important}#layout-content .panel-profile-header .profile-user-photo{height:95px !important;width:95px !important}#layout-content .image-upload-container .image-upload-buttons{right:2px !important}#layout-content .space-acronym{padding:6px 0 !important}#layout-content .panel-profile .panel-profile-header .img-profile-header-background{min-height:80px !important}#layout-content .panel-profile .panel-profile-header .img-profile-data{padding-top:50px !important;padding-left:130px}.modal-dialog{width:calc(100vw - 4px) !important;padding:0 !important;margin:2px !important}.dropdown-menu>li a,.nav-pills .dropdown-menu li a,.nav-tabs .dropdown-menu li a,.account .dropdown-menu li a,.modal .dropdown-menu li a,.panel .dropdown-menu li a,.nav-tabs .dropdown-menu li a{padding-top:10px;padding-bottom:10px;text-overflow:ellipsis;overflow:hidden;white-space:nowrap}.dropdown-menu{max-width:320px}select.form-control:not([multiple]){padding-right:23px;width:auto}.modal.in{padding-right:0 !important}.load-suppressed{margin-top:-8px;margin-bottom:5px}.ProsemirrorEditor .ProseMirror-menuitem{font-size:1.2em !important}}.icon-sm,.fa-sm{font-size:.875em}.icon-lg,.fa-lg{font-size:1.33333em;line-height:.75em;vertical-align:-0.0667em}.icon-2x,.fa-2x{font-size:2em}.icon-3x,.fa-3x{font-size:3em}.icon-4x,.fa-4x{font-size:4em}.icon-5x,.fa-5x{font-size:5em}.icon-6x,.fa-6x{font-size:6em}.icon-7x,.fa-7x{font-size:7em}.icon-9x,.fa-9x{font-size:9em}.icon-10x,.fa-10x{font-size:10em}@media print{a[href]:after{content:none}body{padding-top:0}pre,blockquote{page-break-inside:avoid}.preferences,.layout-sidebar-container,.layout-nav-container,button{display:none !important}}@media (min-width:500px){.container-cards.container-fluid .card{width:50%}}@media (min-width:1000px){.container-cards.container-fluid .card{width:33.33333333%}}@media (min-width:1300px){.container-cards.container-fluid .card{width:25%}}@media (min-width:1600px){.container-cards.container-fluid .card{width:20%}}@media (min-width:1900px){.container-cards.container-fluid .card{width:16.66666667%}}.container-cards .form-search .row>div{padding-bottom:3px}.container-cards .form-search .form-search-filter-keyword{position:relative}.container-cards .form-search .form-search-filter-keyword .form-button-search{position:absolute;right:18px}.container-cards .form-search .form-control.form-search-filter{width:100%;height:40px;margin:3px 0 0;padding:8px 30px 10px 8px;border-radius:4px;border:solid 1px #c5c5c5}.container-cards .form-search .form-button-search{background:none;border:0;font-size:16px;color:#000;top:initial;bottom:9px}.container-cards .form-search .form-search-field-info{font-size:80%}.container-cards .form-search-reset{text-decoration:underline;display:block;margin-top:26px}.container-cards .form-search-reset:hover{text-decoration:none}.container-cards .form-search-filter-tags{padding-top:21px}.container-cards .form-search-filter-tags button{margin:10px 10px 0 0}.container-cards .form-search-filter-tags .btn{padding-left:16px;padding-right:16px}.container-cards .form-search-filter-tags .btn:not(.active){padding:3px 14px}.container-cards .form-search-filter-tags .btn.btn-primary{border:1px solid #435f6f}.container-cards .form-search-filter-tags .btn.btn-primary.active,.container-cards .form-search-filter-tags .btn.btn-primary:not(.active):hover{background:#435f6f !important;color:#FFF !important}.container-cards .form-search-filter-tags .btn.btn-primary:not(.active){background:#FFF;color:#435f6f !important}.container-cards .directory-filters-footer{display:flex;align-items:center;flex-wrap:wrap;margin:30px -10px -10px;padding:20px 5px;color:#000;border-radius:0 0 4px 4px;font-size:14px}.container-cards .directory-filters-footer.directory-filters-footer-warning{background:#FFC107}.container-cards .directory-filters-footer.directory-filters-footer-info{background:#d9edf7;border:1px solid #bce8f1}.container-cards .directory-filters-footer .filter-footer-icon{font-size:35px;line-height:25px;text-align:center;color:#435F6F;background:#FFF;height:25px;border-radius:50%;margin-right:32px;vertical-align:middle}.container-cards .cards{display:flex;flex-direction:row;flex-wrap:wrap}.container-cards .cards-no-results{color:#000;font-size:16px;line-height:34px}.container-cards .card{display:flex;flex-direction:row}.container-cards .card .card-panel{position:relative;width:100%;display:flex;flex-direction:column;margin:15px 0;border-radius:4px;background-color:#ffffff}.container-cards .card .card-panel.card-archived{filter:opacity(60%)}.container-cards .card .card-icons .fa{color:#21A1B3}.container-cards .card .card-icons .fa span{font:12px 'Open Sans',sans-serif;font-weight:600}.container-cards .card .card-bg-image{width:100%;height:86px;background-color:#cfcfcf;background-size:cover;background-position:center;border-radius:4px 4px 0 0}.container-cards .card .card-status{font-size:13px;font-weight:bold;padding:5px 12px;color:#FFF;min-height:30px;max-height:30px}.container-cards .card .card-status.card-status-professional{background:#415F6E}.container-cards .card .card-status.card-status-official,.container-cards .card .card-status.card-status-partner{background:#90A1AA}.container-cards .card .card-status.card-status-deprecated{background:#EB0000}.container-cards .card .card-status.card-status-featured{background:#435f6f}.container-cards .card .card-status.card-status-new{background:#21A1B3}.container-cards .card .card-header{position:absolute;padding:16px;display:table;width:100%}.container-cards .card .card-header .card-image-wrapper{display:table-cell;width:98px}.container-cards .card .card-header .card-image-link{display:inline-block;border:2px solid #fff;border-radius:6px}.container-cards .card .card-header .card-status{position:absolute;right:16px;background:#435f6f}.container-cards .card .card-header .card-icons{display:table-cell;padding:0 0 2px 5px;text-align:right;vertical-align:bottom;font-size:16px}.container-cards .card .card-header .card-icons .fa{color:#21A1B3}.container-cards .card .card-header .card-icons .fa.fa-mobile-phone{font-size:22px;line-height:15px;position:relative;top:2px}.container-cards .card .card-status-none+.card-header{border-radius:4px 4px 0 0}.container-cards .card .card-body{flex-grow:1;padding:44px 16px 24px 16px;overflow:auto}.container-cards .card .card-body .card-title{font-size:16px;font-weight:bold;line-height:24px}.container-cards .card .card-body .card-details{margin-top:8px;color:#57646c}.container-cards .card .card-body .card-details a{color:#21A1B3;text-decoration:underline}.container-cards .card .card-body .card-details a:hover{text-decoration:none}.container-cards .card .card-body .card-tags{margin-top:20px}.container-cards .card .card-footer{padding:0 16px 20px}.container-cards .card .card-footer a.btn{float:left;margin:0 8px 4px 0;white-space:normal;hyphens:none}.container-cards .card .card-footer a.btn:last-child{margin-right:0}.container-cards .card .card-footer .btn-group a.btn{margin-right:0}.container-modules .modules-type{font-size:16px;font-weight:bold;color:#000;margin:70px 0 40px}.container-modules .row.cards{margin-top:40px}.container-modules .card-module .card-panel{background:none;overflow:hidden}.container-modules .card-module .card-panel>div:not(.card-status){background-color:#ffffff}.container-modules .card-module .card-header{position:relative}.container-modules .card-module .card-body{padding-top:8px;font-size:13px;color:#6C787E}.container-modules .card-module .card-body>div{padding-bottom:8px}.container-modules .card-module .card-body>div:last-child{padding-bottom:0}.container-modules .card-module .card-title{color:#000}.container-modules .card-module .card-footer{padding-bottom:14px}.container-modules .card-module .card-footer a.btn{float:none}.container-modules .card-module .card-footer.text-right a.btn{margin-left:8px;margin-right:0}.container-modules .card-module .card-footer.text-right a.btn:first-child{margin-left:0}.container-modules .marketplace-settings-dropdown{float:right;list-style:none}.container-modules .marketplace-settings-dropdown .dropdown-toggle{color:#02A1B1;font-size:22px;line-height:20px;margin:2px}.container-modules .marketplace-settings-dropdown .dropdown-toggle:hover{color:#1d8e9d}@media (max-width:460px){.container-modules .card{width:100%}}.container-content-modules{width:100%;padding:0 18px 5px 5px}.container-content-modules h4{font-size:16px;color:#000}.container-content-modules .card{width:100%;padding-right:3px}.container-content-modules .card .card-panel{margin-top:3px}@media (min-width:460px){.container-content-modules .card{width:50%}}@media (min-width:656px){.container-content-modules .card{width:33.33333333%}}@media (min-width:768px){.container-content-modules{padding:0 12px 5px 0}}@media (min-width:1200px){.container-content-modules .card{width:25%}}@media (min-width:460px){.container-content-modules.container-content-modules-col-3 .card{width:50%}}@media (min-width:656px){.container-content-modules.container-content-modules-col-3 .card{width:33.33333333%}}.container-create-space-modules.container-cards{width:100%;padding:0}.container-create-space-modules.container-cards .row.cards{margin-top:0}.container-create-space-modules.container-cards .card .card-panel>div{background:#F5F5F5}@media (min-width:500px){.container-modules.container-fluid .container-module-updates .card{width:33.33333333%}}@media (min-width:1000px){.container-modules.container-fluid .container-module-updates .card{width:25%}}@media (min-width:1300px){.container-modules.container-fluid .container-module-updates .card{width:20%}}@media (min-width:1600px){.container-modules.container-fluid .container-module-updates .card{width:16.66666667%}}@media (min-width:1900px){.container-modules.container-fluid .container-module-updates .card{width:12.5%}}.container-module-updates{background:#435f6f;margin-top:30px;padding:16px 10px 2px;border-radius:4px}.container-module-updates .row.cards{margin-right:-1px;margin-top:0}.container-module-updates .modules-type{color:#FFFFFF;margin:10px 0 30px}.container-module-updates .card{padding-right:1px}.container-module-updates .card .card-panel{color:#FFF;margin-top:0}.container-module-updates .card .card-panel>div:not(.card-status){background:#30444f}.container-module-updates .card .card-panel .card-header{padding:12px}.container-module-updates .card .card-panel .card-body{padding:4px 12px 20px;color:#FFF}.container-module-updates .card .card-panel .card-body .card-title{color:#FFF;font-size:14px}.container-module-updates .card .card-panel .card-footer{padding:0 12px 12px}.container-module-updates .card .card-panel .card-footer .btn-info{border-radius:4px;color:#435f6f !important}.container-module-updates .card .card-panel .card-footer .btn-info.active{border-color:#FFF}.container-module-updates .card .card-panel .card-footer .btn-info:not(.active){padding:0 4px;border:1px solid #FFF;background:#30444f;color:#FFF !important}.container-module-updates .card .card-panel .card-footer .btn-info:not(.active):hover,.container-module-updates .card .card-panel .card-footer .btn-info:not(.active):active{background:#435f6f !important}.container-module-updates .card .card-panel .card-footer .btn-info[data-update-status=failed]{border-color:#fc314f}.modules-group{margin-bottom:25px;padding:6px}.modules-group>strong{display:block;margin-bottom:13px}.modules-group .module-row{border-top:1px solid #ddd;margin:0 0 16px 0}.modules-group .module-row>div{padding-top:16px}.modules-group .module-row>div small{color:#aeaeae}.modules-group .module-row .module-icon{text-align:center;padding-left:6px}.modules-group .module-row .module-actions{white-space:nowrap;text-align:right;padding-right:0}.modules-group .module-row .module-actions .btn:not(:first-child){margin-left:14px}.modules-updates-info{border-radius:3px;border:1px solid var(--border-color-warning);background:var(--background-color-warning);color:var(--text-color-warning);padding:14px 20px 14px 25px;margin:20px 10px 10px;font-size:11px;line-height:20px}.modules-updates-info strong{font-size:13px}.modules-updates-info .btn{margin-top:8px}/*! Select2 humhub Theme v0.1.0-beta.4 | MIT License | github.com/select2/select2-humhub-theme */.select2-container--humhub{display:block}.select2-container--humhub .select2-selection{background-color:#fff;border:2px solid #ededed;border-radius:4px;color:#555;font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;font-size:14px;outline:0;min-height:35px}.select2-container--humhub .select2-search--dropdown .select2-search__field{background-color:#fff;border:2px solid #ededed;border-radius:4px;color:#555;font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;font-size:14px}.select2-container--humhub .select2-search__field{outline:0}.select2-container--humhub .select2-search__field::placeholder{color:#999;font-weight:normal}.select2-container--humhub .select2-results__option[role=group]{padding:0}.select2-container--humhub .select2-results__option[aria-disabled=true]{color:#777;cursor:not-allowed}.select2-container--humhub .select2-results__option[aria-selected=true]{background-color:#f5f5f5;color:#262626;border-left:3px solid transparent}.select2-container--humhub .select2-results__option[aria-selected=false]{border-left:3px solid transparent}.select2-container--humhub .select2-results__option--highlighted[aria-selected]{background-color:#f8f8f8;border-left:3px solid #21A1B3;color:#000}.select2-container--humhub .select2-results__option .select2-results__option{padding:6px 12px}.select2-container--humhub .select2-results__option .select2-results__option .select2-results__group{padding-left:0}.select2-container--humhub .select2-results__option .select2-results__option .select2-results__option{margin-left:-12px;padding-left:24px}.select2-container--humhub .select2-results__option .select2-results__option .select2-results__option .select2-results__option{margin-left:-24px;padding-left:36px}.select2-container--humhub .select2-results__option .select2-results__option .select2-results__option .select2-results__option .select2-results__option{margin-left:-36px;padding-left:48px}.select2-container--humhub .select2-results__option .select2-results__option .select2-results__option .select2-results__option .select2-results__option .select2-results__option{margin-left:-48px;padding-left:60px}.select2-container--humhub .select2-results__option .select2-results__option .select2-results__option .select2-results__option .select2-results__option .select2-results__option .select2-results__option{margin-left:-60px;padding-left:72px}.select2-container--humhub .select2-results__group{color:#777;display:block;padding:6px 12px;font-size:12px;line-height:1.42857143;white-space:nowrap}.select2-container--humhub.select2-container--focus .select2-selection,.select2-container--humhub.select2-container--open .select2-selection{border:2px solid #21A1B3;outline:0;box-shadow:none}.select2-container--humhub.select2-container--open .select2-selection .select2-selection__arrow b{border-color:transparent transparent #999 transparent;border-width:0 4px 4px 4px}.select2-container--humhub .select2-selection__clear{color:#999;cursor:pointer;float:right;font-weight:bold;margin-right:10px}.select2-container--humhub .select2-selection__clear:hover{color:#333}.select2-container--humhub.select2-container--disabled .select2-selection{border-color:#ccc;-webkit-box-shadow:none;box-shadow:none}.select2-container--humhub.select2-container--disabled .select2-selection,.select2-container--humhub.select2-container--disabled .select2-search__field{cursor:not-allowed}.select2-container--humhub.select2-container--disabled .select2-selection,.select2-container--humhub.select2-container--disabled .select2-selection--multiple .select2-selection__choice{background-color:#eee}.select2-container--humhub.select2-container--disabled .select2-selection__clear,.select2-container--humhub.select2-container--disabled .select2-selection--multiple .select2-selection__choice__remove{display:none}.select2-container--humhub .select2-dropdown{-webkit-box-shadow:0 6px 12px rgba(0,0,0,0.175);box-shadow:0 6px 12px rgba(0,0,0,0.175);border-color:#d7d7d7;overflow-x:hidden;margin-top:-1px}.select2-container--humhub .select2-dropdown--above{margin-top:1px}.select2-container--humhub .select2-results>.select2-results__options{max-height:400px;overflow-y:auto}.select2-container--humhub .select2-selection--single{height:34px;line-height:1.42857143;padding:6px 24px 6px 12px}.select2-container--humhub .select2-selection--single .select2-selection__arrow{position:absolute;bottom:0;right:12px;top:0;width:4px}.select2-container--humhub .select2-selection--single .select2-selection__arrow b{border-color:#999 transparent transparent transparent;border-style:solid;border-width:4px 4px 0 4px;height:0;left:0;margin-left:-4px;margin-top:-4px/2;position:absolute;top:50%;width:0}.select2-container--humhub .select2-selection--single .select2-selection__rendered{color:#555;padding:0}.select2-container--humhub .select2-selection--single .select2-selection__placeholder{color:#999}.select2-container--humhub .select2-selection--multiple{min-height:34px;padding:2px}.select2-container--humhub .select2-selection--multiple .select2-selection__rendered{box-sizing:border-box;display:block;line-height:1.42857143;list-style:none;margin:0;overflow:hidden;padding:0;width:100%;text-overflow:ellipsis;white-space:nowrap}.select2-container--humhub .select2-selection--multiple .select2-selection__placeholder{color:#999;float:left;margin-top:5px}.select2-container--humhub .select2-selection--multiple .select2-selection__choice{color:#555;border-radius:4px;cursor:default;padding:0 6px;background-color:#21A1B3;color:#fff;border-radius:3px;font-size:12px !important;padding:0 5px 2px 2px;float:left;margin:2px;height:28px}.select2-container--humhub .select2-selection--multiple .select2-selection__choice img,.select2-container--humhub .select2-selection--multiple .select2-selection__choice div{margin-right:5px}.select2-container--humhub .select2-selection--multiple .select2-selection__choice span.no-image{line-height:27px;padding-left:5px}.select2-container--humhub .select2-selection--multiple .select2-selection__choice i{margin:0px 2px;line-height:27px}.select2-container--humhub .select2-selection--multiple .select2-selection__choice .picker-close{cursor:pointer}.select2-container--humhub .select2-selection--multiple .select2-search--inline .select2-search__field{background:transparent;padding:0 5px;width:auto !important;height:32px;line-height:1.42857143;margin-top:0;min-width:5em}.select2-container--humhub .select2-selection--multiple .select2-selection__choice__remove{color:#999;cursor:pointer;display:none;font-weight:bold;margin-right:6px / 2}.select2-container--humhub .select2-selection--multiple .select2-selection__choice__remove:hover{color:#333}.select2-container--humhub .select2-selection--multiple .select2-selection__clear{margin-top:6px}.select2-container--humhub.input-sm,.select2-container--humhub.input-lg{border-radius:0;font-size:12px;height:auto;line-height:1;padding:0}.select2-container--humhub.input-sm .select2-selection--single,.input-group-sm .select2-container--humhub .select2-selection--single,.form-group-sm .select2-container--humhub .select2-selection--single{border-radius:3px;font-size:12px;height:30px;line-height:1.5;padding:5px 22px 5px 10px}.select2-container--humhub.input-sm .select2-selection--single .select2-selection__arrow b,.input-group-sm .select2-container--humhub .select2-selection--single .select2-selection__arrow b,.form-group-sm .select2-container--humhub .select2-selection--single .select2-selection__arrow b{margin-left:-5px}.select2-container--humhub.input-sm .select2-selection--multiple,.input-group-sm .select2-container--humhub .select2-selection--multiple,.form-group-sm .select2-container--humhub .select2-selection--multiple{min-height:30px}.select2-container--humhub.input-sm .select2-selection--multiple .select2-selection__choice,.input-group-sm .select2-container--humhub .select2-selection--multiple .select2-selection__choice,.form-group-sm .select2-container--humhub .select2-selection--multiple .select2-selection__choice{font-size:12px;line-height:1.5;margin:4px 0 0 10px/2;padding:0 5px}.select2-container--humhub.input-sm .select2-selection--multiple .select2-search--inline .select2-search__field,.input-group-sm .select2-container--humhub .select2-selection--multiple .select2-search--inline .select2-search__field,.form-group-sm .select2-container--humhub .select2-selection--multiple .select2-search--inline .select2-search__field{padding:0 10px;font-size:12px;height:28px;line-height:1.5}.select2-container--humhub.input-sm .select2-selection--multiple .select2-selection__clear,.input-group-sm .select2-container--humhub .select2-selection--multiple .select2-selection__clear,.form-group-sm .select2-container--humhub .select2-selection--multiple .select2-selection__clear{margin-top:5px}.select2-container--humhub.input-lg .select2-selection--single,.input-group-lg .select2-container--humhub .select2-selection--single,.form-group-lg .select2-container--humhub .select2-selection--single{border-radius:6px;font-size:18px;height:46px;line-height:1.3333333;padding:10px 31px 10px 16px}.select2-container--humhub.input-lg .select2-selection--single .select2-selection__arrow,.input-group-lg .select2-container--humhub .select2-selection--single .select2-selection__arrow,.form-group-lg .select2-container--humhub .select2-selection--single .select2-selection__arrow{width:5px}.select2-container--humhub.input-lg .select2-selection--single .select2-selection__arrow b,.input-group-lg .select2-container--humhub .select2-selection--single .select2-selection__arrow b,.form-group-lg .select2-container--humhub .select2-selection--single .select2-selection__arrow b{border-width:5px 5px 0 5px;margin-left:-5px;margin-left:-10px;margin-top:-5px/2}.select2-container--humhub.input-lg .select2-selection--multiple,.input-group-lg .select2-container--humhub .select2-selection--multiple,.form-group-lg .select2-container--humhub .select2-selection--multiple{min-height:46px}.select2-container--humhub.input-lg .select2-selection--multiple .select2-selection__choice,.input-group-lg .select2-container--humhub .select2-selection--multiple .select2-selection__choice,.form-group-lg .select2-container--humhub .select2-selection--multiple .select2-selection__choice{font-size:18px;line-height:1.3333333;border-radius:4px;margin:9px 0 0 16px/2;padding:0 10px}.select2-container--humhub.input-lg .select2-selection--multiple .select2-search--inline .select2-search__field,.input-group-lg .select2-container--humhub .select2-selection--multiple .select2-search--inline .select2-search__field,.form-group-lg .select2-container--humhub .select2-selection--multiple .select2-search--inline .select2-search__field{padding:0 16px;font-size:18px;height:44px;line-height:1.3333333}.select2-container--humhub.input-lg .select2-selection--multiple .select2-selection__clear,.input-group-lg .select2-container--humhub .select2-selection--multiple .select2-selection__clear,.form-group-lg .select2-container--humhub .select2-selection--multiple .select2-selection__clear{margin-top:10px}.select2-container--humhub.input-lg.select2-container--open .select2-selection--single .select2-selection__arrow b{border-color:transparent transparent #999 transparent;border-width:0 5px 5px 5px}.input-group-lg .select2-container--humhub.select2-container--open .select2-selection--single .select2-selection__arrow b{border-color:transparent transparent #999 transparent;border-width:0 5px 5px 5px}.select2-container--humhub[dir="rtl"] .select2-selection--single{padding-left:24px;padding-right:12px}.select2-container--humhub[dir="rtl"] .select2-selection--single .select2-selection__rendered{padding-right:0;padding-left:0;text-align:right}.select2-container--humhub[dir="rtl"] .select2-selection--single .select2-selection__clear{float:left}.select2-container--humhub[dir="rtl"] .select2-selection--single .select2-selection__arrow{left:12px;right:auto}.select2-container--humhub[dir="rtl"] .select2-selection--single .select2-selection__arrow b{margin-left:0}.select2-container--humhub[dir="rtl"] .select2-selection--multiple .select2-selection__choice,.select2-container--humhub[dir="rtl"] .select2-selection--multiple .select2-selection__placeholder{float:right}.select2-container--humhub[dir="rtl"] .select2-selection--multiple .select2-selection__choice{margin-left:0;margin-right:12px/2}.select2-container--humhub[dir="rtl"] .select2-selection--multiple .select2-selection__choice__remove{margin-left:2px;margin-right:auto}.has-warning .select2-dropdown,.has-warning .select2-selection{border-color:#FFC107}.has-warning .select2-container--focus .select2-selection,.has-warning .select2-container--open .select2-selection{-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,0.075),0 0 6px #ffdb6d;box-shadow:inset 0 1px 1px rgba(0,0,0,0.075),0 0 6px #ffdb6d;border-color:#d39e00}.has-warning.select2-drop-active{border-color:#d39e00}.has-warning.select2-drop-active.select2-drop.select2-drop-above{border-top-color:#d39e00}.has-error .select2-dropdown,.has-error .select2-selection{border-color:#FC4A64}.has-error .select2-container--focus .select2-selection,.has-error .select2-container--open .select2-selection{-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,0.075),0 0 6px #feaeba;box-shadow:inset 0 1px 1px rgba(0,0,0,0.075),0 0 6px #feaeba;border-color:#fb1839}.has-error.select2-drop-active{border-color:#fb1839}.has-error.select2-drop-active.select2-drop.select2-drop-above{border-top-color:#fb1839}.has-success .select2-dropdown,.has-success .select2-selection{border-color:#97d271}.has-success .select2-container--focus .select2-selection,.has-success .select2-container--open .select2-selection{-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,0.075),0 0 6px #d0ebbe;box-shadow:inset 0 1px 1px rgba(0,0,0,0.075),0 0 6px #d0ebbe;border-color:#7bc64a}.has-success.select2-drop-active{border-color:#7bc64a}.has-success.select2-drop-active.select2-drop.select2-drop-above{border-top-color:#7bc64a}.input-group .select2-container--humhub{display:table;table-layout:fixed;position:relative;z-index:2;float:left;width:100%;margin-bottom:0}.input-group.select2-humhub-prepend .select2-container--humhub .select2-selection{border-top-left-radius:0;border-bottom-left-radius:0}.input-group.select2-humhub-append .select2-container--humhub .select2-selection{border-top-right-radius:0;border-bottom-right-radius:0}.select2-humhub-append .select2-container--humhub,.select2-humhub-prepend .select2-container--humhub,.select2-humhub-append .input-group-btn,.select2-humhub-prepend .input-group-btn,.select2-humhub-append .input-group-btn .btn,.select2-humhub-prepend .input-group-btn .btn{vertical-align:top}.form-control.select2-hidden-accessible{position:absolute !important;width:1px !important}.form-inline .select2-container--humhub{display:inline-block}ul.tag_input{list-style:none;background-color:#fff;border:1px solid #ccc;border-radius:4px;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,0.075);box-shadow:inset 0 1px 1px rgba(0,0,0,0.075);-webkit-transition:border-color ease-in-out .15s,box-shadow ease-in-out .15s;transition:border-color ease-in-out .15s,box-shadow ease-in-out .15s;padding:0 0 9px 4px}ul.tag_input li img{margin:0 5px 0 0}.tag_input_field{outline:none;border:none !important;padding:5px 4px 0 !important;width:170px;margin:2px 0 0 !important}.userInput,.spaceInput{background-color:#21A1B3;font-weight:600;color:#fff;border-radius:3px;font-size:12px !important;padding:2px;float:left;margin:3px 4px 0 0}.userInput i,.spaceInput i{padding:0 6px;font-size:14px;cursor:pointer;line-height:8px}
+:root {
+  --default: #f3f3f3;
+  --primary: #435f6f;
+  --info: #21A1B3;
+  --success: #97d271;
+  --warning: #FFC107;
+  --danger: #FC4A64;
+  --link: #21A1B3;
+  --text-color-main: #555;
+  --text-color-secondary: #7a7a7a;
+  --text-color-highlight: #000;
+  --text-color-soft: #555555;
+  --text-color-soft2: #aeaeae;
+  --text-color-soft3: #bac2c7;
+  --text-color-contrast: #fff;
+  --background-color-main: #fff;
+  --background-color-secondary: #f8f8f8;
+  --background-color-page: #ededed;
+  --background-color-highlight: #daf0f3;
+  --background-color-highlight-soft: #f2f9fb;
+  --background3: #d7d7d7;
+  --background4: #b2b2b2;
+  --background-color-success: #f7fbf4;
+  --text-color-success: #84be5e;
+  --border-color-success: #97d271;
+  --background-color-warning: #fffbf7;
+  --text-color-warning: #e9b168;
+  --border-color-warning: #fdd198;
+  --background-color-danger: #fff6f6;
+  --text-color-danger: #ff8989;
+  --border-color-danger: #ff8989;
+  --mail-font-family: 'Open Sans', Arial, Tahoma, Helvetica, sans-serif;
+}
+/* Default */
+.colorDefault {
+  color: #f3f3f3;
+}
+.backgroundDefault {
+  background: #f3f3f3;
+}
+.borderDefault {
+  border-color: #f3f3f3;
+}
+/* Primary */
+.colorPrimary {
+  color: #435f6f !important;
+}
+.backgroundPrimary {
+  background: #435f6f !important;
+}
+.borderPrimary {
+  border-color: #435f6f !important;
+}
+/* Info */
+.colorInfo {
+  color: #21A1B3 !important;
+}
+.backgroundInfo {
+  background: #21A1B3 !important;
+}
+.borderInfo {
+  border-color: #21A1B3 !important;
+}
+/* Info */
+.colorLink {
+  color: #21A1B3 !important;
+}
+/* Success */
+.colorSuccess {
+  color: #97d271 !important;
+}
+.backgroundSuccess {
+  background: #97d271 !important;
+}
+.borderSuccess {
+  border-color: #97d271 !important;
+}
+/* Warning */
+.colorWarning {
+  color: #FFC107 !important;
+}
+.backgroundWarning {
+  background: #FFC107 !important;
+}
+.borderWarning {
+  border-color: #FFC107 !important;
+}
+/* Danger */
+.colorDanger {
+  color: #FC4A64 !important;
+}
+.backgroundDanger {
+  background: #FC4A64 !important;
+}
+.borderDanger {
+  border-color: #FC4A64 !important;
+}
+/* Fonts */
+.colorFont1 {
+  color: #bac2c7 !important;
+}
+.colorFont2 {
+  color: #7a7a7a !important;
+}
+.colorFont3 {
+  color: #000 !important;
+}
+.colorFont4 {
+  color: #555555 !important;
+}
+.colorFont5 {
+  color: #aeaeae !important;
+}
+.heading {
+  font-size: 16px;
+  font-weight: 300;
+  color: #000;
+  background-color: white;
+  border: none;
+  padding: 10px;
+}
+.text-center {
+  text-align: center !important;
+}
+.text-break {
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  word-break: break-word;
+  hyphens: auto;
+}
+.img-rounded {
+  border-radius: 3px;
+}
+body {
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  word-break: break-word;
+  hyphens: auto;
+  padding-top: 130px;
+  background-color: #ededed;
+  color: #555;
+  font-family: 'Open Sans', sans-serif;
+}
+body a,
+body a:hover,
+body a:focus,
+body a:active,
+body a.active {
+  color: #000;
+  text-decoration: none;
+}
+a:hover {
+  text-decoration: none;
+}
+hr {
+  margin-top: 10px;
+  margin-bottom: 10px;
+}
+.col-md-1,
+.col-md-2,
+.col-md-3,
+.col-md-4,
+.col-md-5,
+.col-md-6,
+.col-md-7,
+.col-md-8,
+.col-md-9,
+.col-md-10,
+.col-md-11,
+.col-md-12 {
+  position: inherit;
+}
+.layout-nav-container {
+  padding: 0 0 0 15px;
+}
+.layout-sidebar-container {
+  padding: 0 15px 0 0;
+}
+@media (max-width: 768px) {
+  .layout-nav-container {
+    padding: 0 15px;
+  }
+  .layout-nav-container .left-navigation {
+    margin-bottom: 0;
+  }
+}
+h4 {
+  font-weight: 300;
+  font-size: 150%;
+}
+input[type=text],
+input[type=password],
+input[type=select] {
+  /* Remove First */
+  appearance: none;
+}
+.powered,
+.powered a {
+  color: #b8c7d3 !important;
+}
+.langSwitcher {
+  display: inline-block;
+}
+[data-ui-show-more] {
+  overflow: hidden;
+}
+@media (min-width: 768px) and (max-width: 991px) {
+  .layout-nav-container {
+    padding: 0 15px;
+  }
+  body {
+    padding-top: 120px;
+  }
+}
+@media print {
+  #topbar-first,
+  #topbar-second {
+    display: none;
+  }
+}
+span.likeLinkContainer .like.disabled,
+span.likeLinkContainer .unlike.disabled {
+  pointer-events: none;
+  cursor: default;
+  text-decoration: none;
+  color: lightgrey;
+}
+.panel-body a[data-toggle],
+.modal-body a[data-toggle] {
+  color: #21A1B3;
+}
+.showMore {
+  font-size: 13px;
+}
+.table-responsive {
+  word-wrap: normal;
+  overflow-wrap: normal;
+  word-break: normal;
+  hyphens: none;
+}
+.topbar {
+  position: fixed;
+  display: block;
+  height: 50px;
+  width: 100%;
+  padding-left: 15px;
+  padding-right: 15px;
+}
+.topbar ul.nav {
+  float: left;
+}
+.topbar ul.nav > li {
+  float: left;
+}
+.topbar ul.nav > li > a {
+  padding-top: 15px;
+  padding-bottom: 15px;
+  line-height: 20px;
+}
+.topbar .dropdown-footer {
+  margin: 10px;
+}
+.topbar .dropdown-header {
+  font-size: 16px;
+  padding: 3px 10px;
+  margin-bottom: 10px;
+  font-weight: 300;
+  color: #555555;
+}
+.topbar .dropdown-header .dropdown-header-link {
+  position: absolute;
+  top: 2px;
+  right: 10px;
+}
+.topbar .dropdown-header .dropdown-header-link a {
+  color: #21A1B3 !important;
+  font-size: 12px;
+  font-weight: normal;
+}
+.topbar .dropdown-header:hover {
+  color: #555555;
+}
+#topbar-first {
+  background-color: #435f6f;
+  top: 0;
+  z-index: 1030;
+  color: white;
+}
+#topbar-first a.navbar-brand {
+  height: 50px;
+  padding: 5px;
+}
+#topbar-first a.navbar-brand img#img-logo {
+  max-height: 40px;
+}
+#topbar-first a.navbar-brand-text {
+  padding-top: 15px;
+}
+#topbar-first .nav > li > a:hover,
+#topbar-first .nav > .open > a {
+  background-color: #567a8f;
+}
+#topbar-first .nav > .account {
+  height: 50px;
+  margin-left: 20px;
+}
+#topbar-first .nav > .account img {
+  margin-left: 10px;
+}
+#topbar-first .nav > .account .dropdown-toggle {
+  padding: 10px 5px 8px;
+  line-height: 1.1em;
+  text-align: left;
+}
+#topbar-first .nav > .account .dropdown-toggle span {
+  font-size: 12px;
+}
+#topbar-first .nav > .account .dropdown-toggle #user-account-image {
+  margin-bottom: 0;
+}
+#topbar-first .topbar-brand {
+  position: relative;
+  z-index: 2;
+}
+#topbar-first .topbar-actions {
+  position: relative;
+  z-index: 3;
+}
+#topbar-first .notifications {
+  position: absolute;
+  left: 0;
+  right: 0;
+  text-align: center;
+  z-index: 1;
+}
+#topbar-first .notifications .btn-group {
+  position: relative;
+  text-align: left;
+}
+#topbar-first .notifications .btn-group > a {
+  padding: 5px 10px;
+  margin: 10px 2px;
+  display: inline-block;
+  border-radius: 2px;
+  text-decoration: none;
+  text-align: left;
+}
+#topbar-first .notifications .btn-group > .label {
+  position: absolute;
+  top: 4px;
+  right: -2px;
+}
+#topbar-first .notifications .arrow:after {
+  position: absolute;
+  display: block;
+  width: 0;
+  height: 0;
+  border-color: transparent;
+  border-style: solid;
+  border-width: 10px;
+  content: " ";
+  top: 1px;
+  margin-left: -10px;
+  border-top-width: 0;
+  border-bottom-color: #fff;
+  z-index: 1035;
+}
+#topbar-first .notifications .arrow {
+  position: absolute;
+  display: block;
+  width: 0;
+  height: 0;
+  border-color: transparent;
+  border-style: solid;
+  z-index: 1001;
+  border-width: 11px;
+  left: 50%;
+  margin-left: -18px;
+  border-top-width: 0;
+  border-bottom-color: rgba(0, 0, 0, 0.15);
+  top: -19px;
+  z-index: 1035;
+}
+#topbar-first .notifications .dropdown-menu {
+  width: 350px;
+  margin-left: -148px;
+}
+#topbar-first .notifications .dropdown-menu ul.media-list {
+  max-height: 400px;
+  overflow: auto;
+}
+#topbar-first .notifications .dropdown-menu li {
+  position: relative;
+}
+#topbar-first .notifications .dropdown-menu li i.approval {
+  position: absolute;
+  left: 2px;
+  top: 36px;
+  font-size: 14px;
+}
+#topbar-first .notifications .dropdown-menu li i.accepted {
+  color: #5cb85c;
+}
+#topbar-first .notifications .dropdown-menu li i.declined {
+  color: #d9534f;
+}
+#topbar-first .notifications .dropdown-menu li .media {
+  position: relative;
+}
+#topbar-first .notifications .dropdown-menu li .media .img-space {
+  position: absolute;
+  top: 14px;
+  left: 14px;
+}
+#topbar-first .dropdown-footer {
+  margin: 10px 10px 5px;
+}
+#topbar-first .dropdown-footer .btn.btn-default {
+  border: 1px solid #f3f3f3;
+  box-shadow: none;
+}
+#topbar-first .dropdown-footer .btn.btn-default:hover {
+  border-color: #d7d7d7;
+  background: #d7d7d7;
+}
+#topbar-first .dropdown-footer .btn.btn-default:active {
+  border-color: #7a7a7a;
+  background: white;
+}
+#topbar-first a {
+  color: white;
+}
+#topbar-first .caret {
+  border-top-color: #fff;
+}
+#topbar-first .btn-group > a {
+  background-color: #4d6d7f;
+}
+#topbar-first .btn-enter {
+  background-color: #4d6d7f;
+  margin: 6px 0;
+}
+#topbar-first .btn-enter:hover {
+  background-color: #527588;
+}
+#topbar-first .media-list a {
+  color: #000;
+  padding: 0;
+}
+#topbar-first .media-list li {
+  color: #000;
+}
+#topbar-first .media-list li i.accepted {
+  color: #21A1B3 !important;
+}
+#topbar-first .media-list li i.declined {
+  color: #FC4A64 !important;
+}
+#topbar-first .media-list li.placeholder {
+  border-bottom: none;
+}
+#topbar-first .media-list .media .media-body .label {
+  padding: 0.1em 0.5em;
+}
+#topbar-first .account .user-title {
+  text-align: right;
+}
+#topbar-first .account .user-title span {
+  color: #d7d7d7;
+}
+#topbar-first .dropdown.account > a,
+#topbar-first .dropdown.account.open > a,
+#topbar-first .dropdown.account > a:hover,
+#topbar-first .dropdown.account.open > a:hover {
+  background-color: #435f6f;
+}
+#topbar-second {
+  top: 50px;
+  background-color: #fff;
+  z-index: 1029;
+  background-image: none;
+  box-shadow: 0 1px 10px rgba(0, 0, 0, 0.1);
+  border-bottom: 1px solid #d4d4d4;
+}
+#topbar-second .dropdown-menu {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+#topbar-second .dropdown-menu .divider {
+  margin: 0;
+}
+#topbar-second #space-menu-dropdown,
+#topbar-second #search-menu-dropdown {
+  width: 400px;
+}
+#topbar-second #space-menu-dropdown .media-list,
+#topbar-second #search-menu-dropdown .media-list {
+  max-height: 400px;
+  overflow: auto;
+}
+@media screen and (max-width: 768px) {
+  #topbar-second #space-menu-dropdown .media-list,
+  #topbar-second #search-menu-dropdown .media-list {
+    max-height: 200px;
+  }
+}
+#topbar-second #space-menu-dropdown form,
+#topbar-second #search-menu-dropdown form {
+  margin: 10px;
+}
+#topbar-second #space-menu-dropdown .search-reset,
+#topbar-second #search-menu-dropdown .search-reset {
+  position: absolute;
+  color: #BFBFBF;
+  margin: 7px;
+  top: 0px;
+  right: 40px;
+  z-index: 10;
+  display: none;
+  cursor: pointer;
+}
+#topbar-second .nav > li > a {
+  padding: 7px 13px 0;
+  text-decoration: none;
+  text-shadow: none;
+  font-weight: 600;
+  font-size: 10px;
+  min-height: 50px;
+  text-transform: uppercase;
+  text-align: center;
+}
+#topbar-second .nav > li > a:hover,
+#topbar-second .nav > li > a:active,
+#topbar-second .nav > li > a:focus {
+  border-bottom: 3px solid #21A1B3;
+  background-color: #f8f8f8;
+  color: #000;
+  text-decoration: none;
+}
+#topbar-second .nav > li > a i {
+  font-size: 14px;
+}
+#topbar-second .nav > li > a .caret {
+  border-top-color: #7a7a7a;
+}
+#topbar-second .nav > li.active > a {
+  min-height: 47px;
+}
+#topbar-second .nav > li > ul > li > a {
+  border-left: 3px solid #fff;
+  background-color: #fff;
+  color: #000;
+}
+#topbar-second .nav > li > ul > li > a:hover,
+#topbar-second .nav > li > ul > li > a.active {
+  border-left: 3px solid #21A1B3;
+  background-color: #f8f8f8;
+  color: #000;
+}
+#topbar-second .nav > li > a#space-menu {
+  padding-right: 13px;
+  border-right: 1px solid #ededed;
+}
+#topbar-second .nav > li > a#search-menu {
+  padding-top: 15px;
+}
+#topbar-second .nav > li > a:hover,
+#topbar-second .nav > li.active {
+  border-bottom: 3px solid #21A1B3;
+  background-color: #f8f8f8;
+  color: #000;
+}
+#topbar-second .nav > li.active > a:hover,
+#topbar-second .nav > li.active > a:focus {
+  border-bottom: none;
+}
+#topbar-second #space-menu-dropdown li > ul > li > a > .media .media-body p {
+  color: #555555;
+  font-size: 11px;
+  margin: 0;
+  font-weight: 400;
+}
+@media (max-width: 767px) {
+  .topbar {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+.login-container {
+  background-color: #435f6f;
+  background-image: linear-gradient(to right, #435f6f 0%, #567a8f 50%, #567a8f 100%), linear-gradient(to right, #4d6d7f 0%, #7fa0b2 51%, #7094a8 100%);
+  background-size: 100% 100%;
+  position: relative;
+  padding-top: 40px;
+}
+.login-container #img-logo {
+  max-width: 100%;
+}
+.login-container .text {
+  color: #fff;
+  font-size: 12px;
+  margin-bottom: 15px;
+}
+.login-container .text a {
+  color: #fff;
+  text-decoration: underline;
+}
+.login-container .panel a {
+  color: #21A1B3;
+}
+.login-container h1,
+.login-container h2 {
+  color: #fff !important;
+}
+.login-container .panel {
+  box-shadow: 0 0 15px #627d92;
+}
+.login-container .panel .panel-heading,
+.login-container .panel .panel-body {
+  padding: 15px;
+}
+.login-container .panel h1,
+.login-container .panel h2 {
+  color: #555 !important;
+}
+.login-container select {
+  color: #000;
+}
+#account-login-form .form-group {
+  margin-bottom: 10px;
+}
+.dropdown-menu li a i {
+  margin-right: 5px;
+  font-size: 14px;
+  display: inline-block;
+  width: 14px;
+}
+.dropdown-menu li a:hover,
+.dropdown-menu li a:visited,
+.dropdown-menu li a:hover,
+.dropdown-menu li a:focus {
+  background: none;
+  cursor: pointer;
+}
+.dropdown-menu li:hover,
+.dropdown-menu li.selected {
+  color: #000;
+}
+.dropdown-menu li:first-child {
+  margin-top: 3px;
+}
+.dropdown-menu li:last-child {
+  margin-bottom: 3px;
+}
+.modal .dropdown-menu,
+.panel .dropdown-menu,
+.nav-tabs .dropdown-menu {
+  border: 1px solid #d7d7d7;
+}
+.modal .dropdown-menu li.divider,
+.panel .dropdown-menu li.divider,
+.nav-tabs .dropdown-menu li.divider {
+  background-color: #f8f8f8;
+  border-bottom: none;
+  margin: 9px 1px !important;
+}
+.modal .dropdown-menu li,
+.panel .dropdown-menu li,
+.nav-tabs .dropdown-menu li {
+  border-left: 3px solid white;
+}
+.modal .dropdown-menu li a,
+.panel .dropdown-menu li a,
+.nav-tabs .dropdown-menu li a {
+  color: #000;
+  font-size: 13px;
+  font-weight: 600;
+  padding: 4px 15px;
+}
+.modal .dropdown-menu li a i,
+.panel .dropdown-menu li a i,
+.nav-tabs .dropdown-menu li a i {
+  margin-right: 5px;
+}
+.modal .dropdown-menu li a:hover,
+.panel .dropdown-menu li a:hover,
+.nav-tabs .dropdown-menu li a:hover {
+  background: none;
+}
+.modal .dropdown-menu li:hover:not(.divider),
+.panel .dropdown-menu li:hover:not(.divider),
+.nav-tabs .dropdown-menu li:hover:not(.divider),
+.modal .dropdown-menu li.selected,
+.panel .dropdown-menu li.selected,
+.nav-tabs .dropdown-menu li.selected {
+  border-left: 3px solid #21A1B3;
+  background-color: #f8f8f8 !important;
+}
+ul.contextMenu {
+  border: 1px solid #d7d7d7;
+}
+ul.contextMenu li.divider {
+  background-color: #f8f8f8;
+  border-bottom: none;
+  margin: 9px 1px !important;
+}
+ul.contextMenu li {
+  border-left: 3px solid white;
+}
+ul.contextMenu li a {
+  color: #000;
+  font-size: 14px;
+  font-weight: 400;
+  padding: 4px 15px;
+}
+ul.contextMenu li a i {
+  margin-right: 5px;
+}
+ul.contextMenu li a:hover {
+  background: none;
+}
+ul.contextMenu li:hover,
+ul.contextMenu li.selected {
+  border-left: 3px solid #21A1B3;
+  background-color: #f8f8f8 !important;
+}
+.media-list li {
+  padding: 10px;
+  border-bottom: 1px solid #eee;
+  position: relative;
+  border-left: 3px solid white;
+  font-size: 12px;
+}
+.media-list li a {
+  color: #555;
+}
+.media-list .badge-space-type {
+  background-color: #f8f8f8;
+  border: 1px solid #d7d7d7;
+  color: #b2b2b2;
+  padding: 3px 3px 2px 3px;
+}
+.media-list li.new {
+  border-left: 3px solid #21A1B3;
+  background-color: #c5eff4;
+}
+.media-list li:hover,
+.media-list li.selected {
+  background-color: #f8f8f8;
+  border-left: 3px solid #21A1B3;
+}
+.media-list li.placeholder {
+  font-size: 14px !important;
+  border-bottom: none;
+}
+.media-list li.placeholder:hover {
+  background: none !important;
+  border-left: 3px solid white;
+}
+.media-left,
+.media > .pull-left {
+  padding-right: 0;
+  margin-right: 10px;
+}
+.media:after {
+  content: '';
+  clear: both;
+  display: block;
+}
+.media .time {
+  font-size: 11px;
+  color: #555555;
+}
+.media .img-space {
+  position: absolute;
+  top: 35px;
+  left: 35px;
+}
+.media .media-body {
+  overflow: hidden !important;
+  font-size: 13px;
+  white-space: normal;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  word-break: break-word;
+  hyphens: auto;
+}
+.media .media-body h4.media-heading {
+  font-size: 14px;
+  font-weight: 500;
+  color: #000;
+}
+.media .media-body h4.media-heading a {
+  color: #000;
+}
+.media .media-body h4.media-heading small,
+.media .media-body h4.media-heading small a {
+  font-size: 11px;
+  color: #555555;
+}
+.media .media-body h4.media-heading .content {
+  margin-right: 35px;
+}
+.media .media-body .content a {
+  word-break: break-all;
+}
+.media .media-body strong {
+  color: #000;
+}
+.media .media-body h5 {
+  color: #aeaeae;
+  font-weight: 300;
+  margin-top: 5px;
+  margin-bottom: 5px;
+  min-height: 15px;
+}
+.media .media-body .module-controls {
+  font-size: 85%;
+}
+.media .media-body .module-controls a {
+  color: #21A1B3;
+}
+.media .content a {
+  color: #21A1B3;
+}
+.media .content .files a {
+  color: #000;
+}
+.content span {
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  word-break: break-word;
+  hyphens: auto;
+}
+#blueimp-gallery .slide img {
+  max-height: 80%;
+}
+audio,
+canvas,
+progress,
+video {
+  display: inline-block;
+  vertical-align: baseline;
+  max-width: 100%;
+  height: auto;
+}
+img {
+  image-orientation: from-image;
+}
+.has-online-status {
+  position: relative;
+  display: inline-block;
+  margin-bottom: 10px;
+}
+.has-online-status .user-online-status {
+  aspect-ratio: 1 / 1;
+  width: 30%;
+  border-radius: 100%;
+  position: absolute;
+  right: -10%;
+  bottom: -10%;
+  border: 1px solid transparent;
+}
+.has-online-status .user-online-status.user-is-online {
+  border-color: #fff;
+  background-color: #97d271;
+}
+.has-online-status.img-size-small {
+  margin-bottom: 5px;
+}
+.has-online-status.img-size-small .user-online-status {
+  width: 10px;
+  right: -3px;
+  bottom: -3px;
+}
+.has-online-status.img-size-large .user-online-status {
+  width: 20px;
+  right: -5px;
+  bottom: -5px;
+  border-width: 2px;
+}
+.panel {
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  word-break: break-word;
+  hyphens: auto;
+  border: none;
+  background-color: #fff;
+  box-shadow: 0 0 3px #dadada;
+  border-radius: 4px;
+  position: relative;
+  margin-bottom: 15px;
+}
+.panel h1 {
+  font-size: 16px;
+  font-weight: 300;
+  margin-top: 0;
+  color: #000;
+}
+.panel .panel-heading {
+  font-size: 16px;
+  font-weight: 300;
+  color: #000;
+  background-color: white;
+  border: none;
+  padding: 10px;
+  border-radius: 4px;
+}
+.panel .panel-heading .heading-link {
+  color: #6fdbe8 !important;
+  font-size: 0.8em;
+}
+.panel .panel-body {
+  padding: 10px;
+  font-size: 13px;
+}
+.panel .panel-body p {
+  color: #555;
+}
+.panel .panel-body p a {
+  color: #21A1B3;
+}
+.panel .panel-body .usersearch-statuses,
+.panel .panel-body .spacesearch-visibilities {
+  padding-top: 5px;
+  padding-bottom: 5px;
+}
+@media (min-width: 992px) {
+  .panel .panel-body .usersearch-statuses,
+  .panel .panel-body .spacesearch-visibilities {
+    padding-top: 0;
+    padding-bottom: 0;
+    padding-left: 0;
+  }
+}
+.panel .statistics .entry {
+  margin-left: 20px;
+  font-size: 12px;
+  color: #000;
+}
+.panel .statistics .entry .count {
+  color: #21A1B3;
+  font-weight: 600;
+  font-size: 20px;
+  line-height: 0.8em;
+}
+.panel h3.media-heading small {
+  font-size: 75%;
+}
+.panel h3.media-heading small a {
+  color: #21A1B3;
+}
+.panel-danger {
+  border: 2px solid #FC4A64;
+}
+.panel-danger .panel-heading {
+  color: #FC4A64;
+}
+.panel-success {
+  border: 2px solid #97d271;
+}
+.panel-success .panel-heading {
+  color: #97d271;
+}
+.panel-warning {
+  border: 2px solid #FFC107;
+}
+.panel-warning .panel-heading {
+  color: #FFC107;
+}
+.panel-info {
+  border: 2px solid #21A1B3;
+}
+.panel-info .panel-heading {
+  color: #21A1B3;
+}
+.panel-primary {
+  border: 2px solid #435f6f;
+}
+.panel-primary .panel-heading {
+  color: #435f6f;
+}
+.panel.profile {
+  position: relative;
+}
+.panel.profile .controls {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+}
+.panel.groups .panel-body a img,
+.panel.spaces .panel-body a img {
+  margin-bottom: 5px;
+}
+.panel-profile .panel-profile-header {
+  position: relative;
+  border: 3px solid #fff;
+  border-top-right-radius: 3px;
+  border-top-left-radius: 3px;
+}
+.panel-profile .panel-profile-header .img-profile-header-background {
+  border-radius: 3px;
+  min-height: 110px;
+}
+.panel-profile .panel-profile-header .img-profile-data {
+  position: absolute;
+  height: 100px;
+  width: 100%;
+  bottom: 0;
+  left: 0;
+  padding-left: 180px;
+  padding-top: 30px;
+  border-bottom-right-radius: 3px;
+  border-bottom-left-radius: 3px;
+  color: #fff;
+  pointer-events: none;
+  background: linear-gradient(to bottom, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0) 1%, rgba(0, 0, 0, 0.38) 100%);
+}
+.panel-profile .panel-profile-header .img-profile-data h1 {
+  font-size: 30px;
+  font-weight: 100;
+  margin-bottom: 7px;
+  color: #fff;
+  max-width: 600px;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+.panel-profile .panel-profile-header .img-profile-data h2 {
+  font-size: 16px;
+  font-weight: 400;
+  margin-top: 0;
+}
+.panel-profile .panel-profile-header .img-profile-data h1.space {
+  font-size: 30px;
+  font-weight: 700;
+}
+.panel-profile .panel-profile-header .img-profile-data h2.space {
+  font-size: 13px;
+  font-weight: 300;
+  max-width: 600px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.panel-profile .panel-profile-header .profile-user-photo-container {
+  position: absolute;
+  bottom: -60px;
+  left: 15px;
+}
+.panel-profile .panel-profile-header .profile-user-photo-container .profile-user-photo {
+  border: 3px solid #fff;
+  border-radius: 5px;
+}
+.panel-profile .panel-profile-controls {
+  padding-left: 160px;
+}
+.panel.pulse,
+.panel.fadeIn {
+  animation-duration: 200ms;
+}
+@media (max-width: 767px) {
+  .panel-profile-controls {
+    padding-left: 0 !important;
+    padding-top: 50px;
+  }
+  .panel-profile .panel-profile-header .img-profile-data h1 {
+    font-size: 20px !important;
+    margin-bottom: 2px;
+  }
+}
+.panel-body > .tab-menu {
+  margin-left: -10px;
+  margin-right: -10px;
+}
+.installer .logo {
+  text-align: center;
+}
+.installer h2 {
+  font-weight: 100;
+}
+.installer .panel {
+  margin-top: 50px;
+}
+.installer .panel h3 {
+  margin-top: 0;
+}
+.installer .powered,
+.installer .powered a {
+  color: #bac2c7 !important;
+  margin-top: 10px;
+  font-size: 12px;
+}
+.installer .fa {
+  width: 18px;
+}
+.installer .check-ok {
+  color: #97d271;
+}
+.installer .check-warning {
+  color: #FFC107;
+}
+.installer .check-error {
+  color: #FC4A64;
+}
+.installer .prerequisites-list ul {
+  list-style: none;
+  padding-left: 15px;
+}
+.installer .prerequisites-list ul li {
+  padding-bottom: 5px;
+}
+.pagination-container {
+  text-align: center;
+}
+.pagination > .active > a,
+.pagination > .active > span,
+.pagination > .active > a:hover,
+.pagination > .active > span:hover,
+.pagination > .active > a:focus,
+.pagination > .active > span:focus {
+  background-color: #435f6f;
+  border-color: #435f6f;
+}
+.pagination > li > a,
+.pagination > li > span,
+.pagination > li > a:hover,
+.pagination > li > a:active,
+.pagination > li > a:focus {
+  color: #000;
+  cursor: pointer;
+}
+.well-small {
+  padding: 10px;
+  border-radius: 3px;
+}
+.well {
+  border: none;
+  box-shadow: none;
+  background-color: #f5f5f5;
+  margin-bottom: 1px;
+}
+.well hr {
+  margin: 10px 0;
+  border-top: 1px solid #d9d9d9;
+}
+.well table > thead {
+  font-size: 11px;
+}
+.tab-sub-menu {
+  padding-left: 10px;
+}
+.tab-sub-menu li > a:hover,
+.tab-sub-menu li > a:focus {
+  background-color: #f8f8f8;
+  border-bottom-color: #ddd;
+}
+.tab-sub-menu li.active > a {
+  background-color: #fff;
+  border-bottom-color: transparent;
+}
+.nav-tabs > li > a,
+.nav-tabs > li > a[data-toggle] {
+  color: #555;
+}
+.nav-tabs > li.active > a,
+.nav-tabs > li.active > a:hover,
+.nav-tabs > li.active > a:focus,
+.nav-tabs > li > a:hover,
+.nav-tabs > li > a:focus {
+  color: #000;
+}
+.tab-menu {
+  padding-top: 10px;
+  background-color: #fff;
+}
+.tab-menu .nav-tabs {
+  padding-left: 10px;
+}
+.tab-menu .nav-tabs li > a {
+  padding-top: 12px;
+  border-color: #ddd;
+  border-bottom: 1px solid #ddd;
+  background-color: #f8f8f8;
+  max-height: 41px;
+  outline: none;
+}
+.tab-menu .nav-tabs li > a:hover,
+.tab-menu .nav-tabs li > a:focus {
+  padding-top: 10px;
+  border-top: 3px solid #ddd;
+}
+.tab-menu .nav-tabs li > a:hover {
+  background-color: #f8f8f8;
+}
+.tab-menu .nav-tabs li.active > a,
+.tab-menu .nav-tabs li.active > a:hover {
+  padding-top: 10px;
+  border-top: 3px solid #21A1B3;
+}
+.tab-menu .nav-tabs li.active > a {
+  background-color: #fff;
+  border-bottom-color: transparent;
+}
+ul.tab-menu {
+  padding-top: 10px;
+  background-color: #fff;
+  padding-left: 10px;
+}
+ul.tab-menu-settings li > a {
+  padding-top: 12px;
+  border-color: #ddd;
+  border-bottom: 1px solid #ddd;
+  background-color: #f8f8f8;
+  max-height: 41px;
+  outline: none;
+}
+ul.tab-menu-settings li > a:hover,
+ul.tab-menu-settings li > a:focus {
+  padding-top: 10px;
+  border-top: 3px solid #ddd !important;
+}
+ul.tab-menu-settings li > a:hover {
+  background-color: #f8f8f8;
+}
+ul.tab-menu-settings li.active > a,
+ul.tab-menu-settings li.active > a:hover,
+ul.tab-menu-settings li.active > a:focus {
+  padding-top: 10px;
+  border-top: 3px solid #21A1B3 !important;
+}
+ul.tab-menu-settings li.active > a {
+  background-color: #fff;
+  border-bottom-color: transparent !important;
+}
+.nav-pills .dropdown-menu,
+.nav-tabs .dropdown-menu,
+.account .dropdown-menu {
+  background-color: #435f6f;
+  border: none;
+}
+.nav-pills .dropdown-menu li.divider,
+.nav-tabs .dropdown-menu li.divider,
+.account .dropdown-menu li.divider {
+  background-color: #39515f;
+  border-bottom: none;
+  margin: 9px 1px !important;
+}
+.nav-pills .dropdown-menu li,
+.nav-tabs .dropdown-menu li,
+.account .dropdown-menu li {
+  border-left: 3px solid #435f6f;
+}
+.nav-pills .dropdown-menu li a,
+.nav-tabs .dropdown-menu li a,
+.account .dropdown-menu li a {
+  color: white;
+  font-weight: 400;
+  font-size: 13px;
+  padding: 4px 15px;
+}
+.nav-pills .dropdown-menu li a i,
+.nav-tabs .dropdown-menu li a i,
+.account .dropdown-menu li a i {
+  margin-right: 0;
+  font-size: 14px;
+  display: inline-block;
+  width: 19px;
+  text-align: center;
+}
+.nav-pills .dropdown-menu li a:hover,
+.nav-tabs .dropdown-menu li a:hover,
+.account .dropdown-menu li a:hover,
+.nav-pills .dropdown-menu li a:visited,
+.nav-tabs .dropdown-menu li a:visited,
+.account .dropdown-menu li a:visited,
+.nav-pills .dropdown-menu li a:hover,
+.nav-tabs .dropdown-menu li a:hover,
+.account .dropdown-menu li a:hover,
+.nav-pills .dropdown-menu li a:focus,
+.nav-tabs .dropdown-menu li a:focus,
+.account .dropdown-menu li a:focus {
+  background: none;
+}
+.nav-pills .dropdown-menu li:hover:not(.divider),
+.nav-tabs .dropdown-menu li:hover:not(.divider),
+.account .dropdown-menu li:hover:not(.divider),
+.nav-pills .dropdown-menu li.selected,
+.nav-tabs .dropdown-menu li.selected,
+.account .dropdown-menu li.selected {
+  border-left: 3px solid #21A1B3;
+  color: #fff !important;
+  background-color: #39515f !important;
+}
+.nav-pills.preferences .dropdown .dropdown-toggle i {
+  color: #21A1B3;
+  font-size: 15px;
+  font-weight: 600;
+}
+.nav-pills.preferences .dropdown.open .dropdown-toggle,
+.nav-pills.preferences .dropdown.open .dropdown-toggle:hover {
+  background-color: #435f6f;
+}
+.nav-pills.preferences .dropdown.open .dropdown-toggle i,
+.nav-pills.preferences .dropdown.open .dropdown-toggle:hover i {
+  color: #fff;
+}
+.nav-pills.preferences li.divider:last-of-type {
+  display: none;
+}
+.nav-pills > li.active > a,
+.nav-pills > li.active > a:hover,
+.nav-pills > li.active > a:focus {
+  background-color: #435f6f;
+}
+.nav-tabs {
+  margin-bottom: 10px;
+}
+.list-group a [class^="fa-"],
+.list-group a [class*=" fa-"] {
+  display: inline-block;
+  width: 18px;
+}
+.nav-pills.preferences {
+  position: absolute;
+  right: 10px;
+  top: 10px;
+}
+.nav-pills.preferences .dropdown .dropdown-toggle {
+  padding: 2px 5px;
+}
+.nav-pills.preferences .dropdown.open .dropdown-toggle,
+.nav-pills.preferences .dropdown.open .dropdown-toggle:hover {
+  color: white;
+}
+.nav-tabs li {
+  font-weight: 600;
+  font-size: 12px;
+}
+.tab-content .tab-pane a {
+  color: #21A1B3;
+}
+.tab-content .tab-pane .form-group {
+  margin-bottom: 5px;
+}
+.nav-tabs.tabs-center li {
+  float: none;
+  display: inline-block;
+}
+.nav-tabs.tabs-small li > a {
+  padding: 5px 7px;
+}
+.nav .caret,
+.nav .caret:hover,
+.nav .caret:active {
+  border-top-color: #000;
+  border-bottom-color: #000;
+  height: 6.928px;
+}
+.nav li.dropdown > a:hover .caret,
+.nav li.dropdown > a:active .caret {
+  border-top-color: #000;
+  border-bottom-color: #000;
+}
+.nav .open > a .caret,
+.nav .open > a:hover .caret,
+.nav .open > a:focus .caret {
+  border-top-color: #000;
+  border-bottom-color: #000;
+}
+.nav .open > a,
+.nav .open > a:hover,
+.nav .open > a:focus {
+  border-color: #ededed;
+  color: #000;
+}
+.nav .open > a .caret,
+.nav .open > a:hover .caret,
+.nav .open > a:focus .caret {
+  color: #000;
+}
+.footer-nav {
+  filter: opacity(0.6);
+  font-size: 12px;
+  text-align: center;
+}
+@media (max-width: 991px) {
+  .controls-header {
+    text-align: left !important;
+  }
+}
+#contentFormMenu {
+  display: none;
+}
+#contentFormMenu.menu-without-form a {
+  border-radius: 4px;
+}
+#contentFormMenu .nav-tabs {
+  margin-bottom: 0;
+  border: none;
+  float: right;
+}
+#contentFormMenu .nav-tabs > li > a,
+#contentFormMenu .nav-tabs > li.active > a {
+  color: #7A7A7A;
+  background: #fff;
+  border-color: #fff;
+}
+#contentFormMenu .nav-tabs > li > a:hover,
+#contentFormMenu .nav-tabs > li.active > a:hover,
+#contentFormMenu .nav-tabs > li > a.active,
+#contentFormMenu .nav-tabs > li.active > a.active {
+  z-index: 1;
+  color: #333;
+}
+#contentFormMenu:after {
+  content: " ";
+  clear: both;
+  display: block;
+}
+#contentFormMenu .content-create-menu-more > i {
+  border-radius: 4px 4px 0 0;
+  background: #fff;
+  margin-right: 3px;
+  padding: 10px 15px 11px;
+  font-size: 18px;
+}
+#contentFormMenu .content-create-menu-more > i:hover {
+  color: #333;
+}
+#contentFormMenu .content-create-menu-more .dropdown-menu {
+  background-color: #fff;
+  border: 1px solid #D7D7D7;
+  border-radius: 4px;
+}
+#contentFormMenu .content-create-menu-more .dropdown-menu li {
+  border-left-color: #fff;
+}
+#contentFormMenu .content-create-menu-more .dropdown-menu li a {
+  color: #000;
+}
+#contentFormMenu .content-create-menu-more .dropdown-menu li:hover,
+#contentFormMenu .content-create-menu-more .dropdown-menu li.selected {
+  color: #000;
+  border-left-color: #21A1B3;
+  background-color: #f8f8f8 !important;
+}
+@media (max-width: 480px) {
+  #contentFormMenu .nav-tabs {
+    display: flex;
+    width: 100%;
+  }
+  #contentFormMenu .nav-tabs > li {
+    flex-grow: 1;
+    text-align: center;
+  }
+  #contentFormMenu .nav-tabs > li.content-create-menu-more {
+    flex-grow: 0.3;
+  }
+  #contentFormMenu .nav-tabs > li.content-create-menu-more > i.fa {
+    width: 100%;
+  }
+}
+.btn {
+  float: none;
+  border: none;
+  box-shadow: none;
+  background-image: none;
+  text-shadow: none;
+  border-radius: 3px;
+  outline: none !important;
+  margin-bottom: 0;
+  font-size: 14px;
+  font-weight: 600;
+  padding: 8px 16px;
+}
+.btn:not(.btn-icon-only) i.fa {
+  margin-right: 4px;
+}
+.input.btn {
+  outline: none;
+}
+.btn-lg {
+  padding: 16px 28px;
+}
+.btn-sm {
+  padding: 4px 8px;
+  font-size: 12px;
+}
+.btn-sm i {
+  font-size: 14px;
+}
+.btn-xs {
+  padding: 1px 5px;
+  font-size: 12px;
+}
+.btn-default {
+  background: #f3f3f3;
+  color: #7a7a7a !important;
+}
+.btn-default:hover,
+.btn-default:focus {
+  background: #eeeeee;
+  text-decoration: none;
+  color: #7a7a7a;
+}
+.btn-default:active,
+.btn-default.active {
+  outline: 0;
+  background: #e6e6e6;
+}
+.btn-default[disabled],
+.btn-default.disabled {
+  background: #f8f8f8;
+}
+.btn-default[disabled]:hover,
+.btn-default.disabled:hover,
+.btn-default[disabled]:focus,
+.btn-default.disabled:focus {
+  background: #f8f8f8;
+}
+.btn-default[disabled]:active,
+.btn-default.disabled:active,
+.btn-default[disabled].active,
+.btn-default.disabled.active {
+  background: #f8f8f8;
+}
+.btn-primary {
+  background: #435f6f;
+  color: #fff !important;
+}
+.btn-primary:hover,
+.btn-primary:focus {
+  background: #39515f;
+  text-decoration: none;
+}
+.btn-primary:active,
+.btn-primary.active {
+  outline: 0;
+  border: 1px solid #435f6f;
+  padding: 7px 15px;
+  color: #435f6f !important;
+  background: #fff !important;
+  box-shadow: none;
+}
+.btn-primary:active.btn-sm,
+.btn-primary.active.btn-sm {
+  padding: 3px 7px;
+}
+.btn-primary:active.btn-xs,
+.btn-primary.active.btn-xs {
+  padding: 0 4px;
+}
+.btn-primary.active:hover,
+.btn-primary.active:focus {
+  border: 1px solid #39515f;
+  color: #39515f !important;
+}
+.btn-primary[disabled],
+.btn-primary.disabled {
+  background: #4d6d7f;
+}
+.btn-primary[disabled]:hover,
+.btn-primary.disabled:hover,
+.btn-primary[disabled]:focus,
+.btn-primary.disabled:focus {
+  background: #4d6d7f;
+}
+.btn-primary[disabled]:active,
+.btn-primary.disabled:active,
+.btn-primary[disabled].active,
+.btn-primary.disabled.active {
+  background: #4d6d7f !important;
+}
+.btn-info {
+  background: #21A1B3;
+  color: #fff !important;
+}
+.btn-info:hover,
+.btn-info:focus {
+  background: #1d8e9d !important;
+  text-decoration: none;
+}
+.btn-info:active,
+.btn-info.active {
+  outline: 0;
+  border: 1px solid #21A1B3;
+  padding: 7px 15px;
+  color: #21A1B3 !important;
+  background: #fff !important;
+  box-shadow: none;
+}
+.btn-info:active.btn-sm,
+.btn-info.active.btn-sm {
+  padding: 3px 7px;
+}
+.btn-info:active.btn-xs,
+.btn-info.active.btn-xs {
+  padding: 0 4px;
+}
+.btn-info.active:hover,
+.btn-info.active:focus {
+  border: 1px solid #1d8e9d;
+  color: #1d8e9d !important;
+}
+.btn-info[disabled],
+.btn-info.disabled {
+  background: #25b4c9;
+}
+.btn-info[disabled]:hover,
+.btn-info.disabled:hover,
+.btn-info[disabled]:focus,
+.btn-info.disabled:focus {
+  background: #25b4c9;
+}
+.btn-info[disabled]:active,
+.btn-info.disabled:active,
+.btn-info[disabled].active,
+.btn-info.disabled.active {
+  background: #25b4c9 !important;
+}
+.btn-danger {
+  background: #FC4A64;
+  color: #fff !important;
+}
+.btn-danger:hover,
+.btn-danger:focus {
+  background: #fc314f;
+  text-decoration: none;
+}
+.btn-danger:active,
+.btn-danger.active {
+  outline: 0;
+  background: #fc314f !important;
+}
+.btn-danger[disabled],
+.btn-danger.disabled {
+  background: #fc6379;
+}
+.btn-danger[disabled]:hover,
+.btn-danger.disabled:hover,
+.btn-danger[disabled]:focus,
+.btn-danger.disabled:focus {
+  background: #fc6379;
+}
+.btn-danger[disabled]:active,
+.btn-danger.disabled:active,
+.btn-danger[disabled].active,
+.btn-danger.disabled.active {
+  background: #fc6379 !important;
+}
+.btn-success {
+  background: #97d271;
+  color: #fff !important;
+}
+.btn-success:hover,
+.btn-success:focus {
+  background: #89cc5e;
+  text-decoration: none;
+}
+.btn-success:active,
+.btn-success.active {
+  outline: 0;
+  background: #89cc5e !important;
+}
+.btn-success[disabled],
+.btn-success.disabled {
+  background: #a5d884;
+}
+.btn-success[disabled]:hover,
+.btn-success.disabled:hover,
+.btn-success[disabled]:focus,
+.btn-success.disabled:focus {
+  background: #a5d884;
+}
+.btn-success[disabled]:active,
+.btn-success.disabled:active,
+.btn-success[disabled].active,
+.btn-success.disabled.active {
+  background: #a5d884 !important;
+}
+.btn-warning {
+  background: #FFC107;
+  color: #fff !important;
+}
+.btn-warning:hover,
+.btn-warning:focus {
+  background: #fcbd00;
+  text-decoration: none;
+}
+.btn-warning:active,
+.btn-warning.active {
+  outline: 0;
+  background: #fcbd00 !important;
+}
+.btn-warning[disabled],
+.btn-warning.disabled {
+  background: #ffc721;
+}
+.btn-warning[disabled]:hover,
+.btn-warning.disabled:hover,
+.btn-warning[disabled]:focus,
+.btn-warning.disabled:focus {
+  background: #ffc721;
+}
+.btn-warning[disabled]:active,
+.btn-warning.disabled:active,
+.btn-warning[disabled].active,
+.btn-warning.disabled.active {
+  background: #ffc721 !important;
+}
+.btn-link {
+  color: #21A1B3 !important;
+}
+.btn-link:hover,
+.btn-link:focus {
+  color: #1f99aa;
+  text-decoration: none;
+}
+.btn-link:active,
+.btn-link.active {
+  outline: 0;
+  color: #1f99aa !important;
+}
+.btn-link[disabled],
+.btn-link.disabled {
+  color: #25b4c9;
+}
+.btn-link[disabled]:hover,
+.btn-link.disabled:hover,
+.btn-link[disabled]:focus,
+.btn-link.disabled:focus {
+  color: #25b4c9;
+}
+.btn-link[disabled]:active,
+.btn-link.disabled:active,
+.btn-link[disabled].active,
+.btn-link.disabled.active {
+  color: #25b4c9 !important;
+}
+.radio,
+.checkbox {
+  margin-top: 5px !important;
+  margin-bottom: 0;
+}
+div.required > label:after {
+  content: " *";
+  color: #21A1B3;
+}
+div.required.has-error > label:after {
+  content: " *";
+  color: #FC4A64;
+}
+.radio label,
+.checkbox label {
+  padding-left: 10px;
+}
+.form-control {
+  border: 2px solid #ededed;
+  box-shadow: none;
+  min-height: 35px;
+}
+.form-control:focus {
+  border: 2px solid #21A1B3;
+  outline: 0;
+  box-shadow: none;
+}
+.form-control.form-search {
+  border-radius: 30px;
+  padding-left: 34px;
+}
+.form-group-search {
+  position: relative;
+}
+.form-group-search:before {
+  font: 14px FontAwesome;
+  content: "\f002";
+  color: #ededed;
+  position: absolute;
+  top: 10px;
+  left: 13px;
+}
+.form-group-search .form-button-search {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  border-radius: 30px;
+}
+textarea {
+  resize: none;
+  height: 1.5em;
+}
+select.form-control:not([multiple]) {
+  appearance: none;
+  background-image: url("../img/select_arrow.png") !important;
+  background-repeat: no-repeat;
+  background-position: right 16px;
+  overflow: hidden;
+}
+label {
+  font-weight: normal;
+}
+div.PendingRegistrations thead > tr > th > label,
+div.PendingRegistrations tbody > tr > td > label {
+  margin-bottom: 0;
+  height: 17px;
+}
+label.control-label {
+  font-weight: bold;
+}
+::placeholder {
+  color: #bac2c7 !important;
+}
+/* hide native password reveal icons */
+input::-ms-clear,
+input::-ms-reveal {
+  display: none;
+}
+.placeholder {
+  padding: 10px;
+}
+input.placeholder,
+textarea.placeholder {
+  padding: 0 0 0 10px;
+  color: #999;
+}
+.help-block-error {
+  font-size: 12px;
+}
+.help-block:not(.help-block-error) {
+  color: #555555;
+  font-size: 13px;
+}
+.panel-body > .help-block {
+  padding-right: 20px;
+  margin-bottom: 20px;
+}
+.hint-block {
+  color: #aeaeae !important;
+  font-size: 12px;
+}
+.hint-block:hover {
+  color: #7a7a7a !important;
+  font-size: 12px;
+}
+.input-group-addon {
+  border: none;
+}
+a.input-field-addon {
+  font-size: 12px;
+  float: right;
+  margin-top: -10px;
+}
+a.input-field-addon-sm {
+  font-size: 11px;
+  float: right;
+  margin-top: -10px;
+}
+.timeZoneInputContainer {
+  padding-top: 10px;
+}
+.timeZoneInputContainer ~ .help-block {
+  margin: 0;
+}
+.radio input[type=radio],
+.radio-inline input[type=radio],
+.checkbox input[type=checkbox],
+.checkbox-inline input[type=checkbox] {
+  position: relative;
+  margin-left: 0;
+}
+input[type=checkbox],
+input[type=radio] {
+  -webkit-appearance: none;
+  position: relative;
+  display: inline-block;
+  width: auto;
+  height: auto;
+  min-height: auto;
+  padding: 7px;
+  margin: -4px 2px 0 0;
+  vertical-align: middle;
+  background: white;
+  border: 2px solid #ccc;
+  border-radius: 3px;
+}
+input[type=checkbox]:disabled,
+input[type=radio]:disabled {
+  background: #d7d7d7 !important;
+  border: 2px solid #d7d7d7 !important;
+  cursor: not-allowed;
+}
+input[type=checkbox]:focus {
+  border: 2px solid #000 !important;
+  outline: none;
+}
+input[type=checkbox]:checked {
+  border: 2px solid #21A1B3;
+  background: #21A1B3;
+  color: white;
+}
+input[type=checkbox]:checked::after {
+  content: '\2714';
+  font-size: 14px;
+  position: absolute;
+  top: -3px;
+  left: 1px;
+  color: white;
+}
+input[type=radio] {
+  border-radius: 50%;
+}
+input[type=radio]:checked {
+  border: 2px solid #d7d7d7;
+  color: #99a1a7;
+}
+input[type=radio]:checked::after {
+  content: ' ';
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  position: absolute;
+  top: 3px;
+  background: #21A1B3;
+  text-shadow: none;
+  left: 3px;
+  font-size: 32px;
+}
+div.form-group div.checkbox .help-block {
+  margin-left: 33px;
+}
+div.form-group div.checkbox .help-block.help-block-error:empty {
+  display: none;
+}
+.errorMessage {
+  color: #FC4A64;
+  padding: 10px 0;
+}
+.error {
+  border-color: #FC4A64 !important;
+}
+.has-error .help-block,
+.has-error .control-label,
+.has-error .radio,
+.has-error .checkbox,
+.has-error .radio-inline,
+.has-error .checkbox-inline {
+  color: #FC4A64 !important;
+}
+.has-error .form-control,
+.has-error .form-control:focus {
+  border-color: #FC4A64;
+  box-shadow: none;
+}
+.has-success .help-block,
+.has-success .control-label,
+.has-success .radio,
+.has-success .checkbox,
+.has-success .radio-inline,
+.has-success .checkbox-inline {
+  color: #97d271;
+}
+.has-success .form-control,
+.has-success .form-control:focus {
+  border-color: #97d271;
+  box-shadow: none;
+}
+.has-warning .help-block,
+.has-warning .control-label,
+.has-warning .radio,
+.has-warning .checkbox,
+.has-warning .radio-inline,
+.has-warning .checkbox-inline {
+  color: #FFC107;
+}
+.has-warning .form-control,
+.has-warning .form-control:focus {
+  border-color: #FFC107;
+  box-shadow: none;
+}
+.bootstrap-timepicker-widget .form-control {
+  padding: 0;
+}
+.form-collapsible-fields {
+  margin-bottom: 12px;
+  border-left: 3px solid #435f6f;
+  background-color: #F4F4F4;
+}
+.form-collapsible-fields-label {
+  margin-bottom: 0;
+  padding: 12px;
+}
+.form-collapsible-fields-label label {
+  margin-bottom: 0;
+}
+.form-collapsible-fields fieldset {
+  padding-top: 15px;
+  padding-left: 12px;
+  padding-right: 12px;
+}
+.form-collapsible-fields.opened fieldset {
+  display: block;
+}
+.form-collapsible-fields.opened .iconClose {
+  display: inline;
+}
+.form-collapsible-fields.opened .iconOpen {
+  display: none;
+}
+.form-collapsible-fields.closed fieldset,
+.form-collapsible-fields.closed .iconClose {
+  display: none;
+}
+.form-collapsible-fields.closed .iconOpen {
+  display: inline;
+}
+.content_create .content-create-input-group,
+.content_edit .content-create-input-group {
+  display: flex;
+  align-items: flex-end;
+  flex-direction: column;
+}
+.content_create .content-create-input-group > .form-group,
+.content_edit .content-create-input-group > .form-group {
+  flex-grow: 1;
+  width: 100%;
+}
+.content_create .content-create-input-group > .form-group [data-ui-markdown],
+.content_edit .content-create-input-group > .form-group [data-ui-markdown] {
+  word-break: break-word !important;
+}
+.content_create .content-create-input-group > .form-group [data-ui-markdown] pre code,
+.content_edit .content-create-input-group > .form-group [data-ui-markdown] pre code {
+  display: block;
+  width: 0;
+}
+.content_create .content-create-input-group .form-group,
+.content_edit .content-create-input-group .form-group,
+.content_create .content-create-input-group .help-block,
+.content_edit .content-create-input-group .help-block {
+  margin: 0;
+}
+.content_create .upload-buttons,
+.content_edit .upload-buttons {
+  white-space: nowrap;
+  padding-top: 6px;
+}
+.content_create .upload-buttons .btn:not(.dropdown-toggle),
+.content_edit .upload-buttons .btn:not(.dropdown-toggle) {
+  margin-left: 6px;
+}
+.content_create .upload-buttons .btn.fileinput-button,
+.content_edit .upload-buttons .btn.fileinput-button,
+.content_create .upload-buttons .fileinput-button + .dropdown-toggle,
+.content_edit .upload-buttons .fileinput-button + .dropdown-toggle {
+  background-color: rgba(33, 161, 179, 0.6);
+}
+.content_create .upload-buttons .btn.dropdown-toggle,
+.content_edit .upload-buttons .btn.dropdown-toggle {
+  margin-left: 0;
+}
+.content_create .has-error + .upload-buttons,
+.content_edit .has-error + .upload-buttons {
+  padding-bottom: 22px;
+}
+.content_create .fileinput-button:active,
+.content_edit .fileinput-button:active {
+  box-shadow: none !important;
+}
+#notification_overview_filter label {
+  display: block;
+}
+#notification_overview_list .img-space {
+  position: absolute;
+  top: 25px;
+  left: 25px;
+}
+@media (max-width: 767px) {
+  .notifications {
+    position: inherit !important;
+    float: left !important;
+  }
+  .notifications .dropdown-menu {
+    width: 300px !important;
+    margin-left: 0 !important;
+  }
+  .notifications .dropdown-menu .arrow {
+    margin-left: -142px !important;
+  }
+}
+.badge-space {
+  margin-top: 6px;
+}
+.badge-space-chooser {
+  padding: 3px 5px;
+  margin-left: 1px;
+}
+.badge {
+  padding: 3px 5px;
+  border-radius: 2px;
+  font-weight: normal;
+  font-family: Arial, sans-serif;
+  font-size: 10px !important;
+  text-transform: uppercase;
+  color: #fff;
+  vertical-align: baseline;
+  white-space: nowrap;
+  text-shadow: none;
+  background-color: #d7d7d7;
+  line-height: 1;
+}
+.popover {
+  border: 1px solid rgba(0, 0, 0, 0.15);
+  border-radius: 4px;
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
+}
+.popover .popover-title {
+  background: none;
+  border-bottom: none;
+  color: #000;
+  font-weight: 300;
+  font-size: 16px;
+  padding: 15px;
+}
+.popover .popover-content {
+  font-size: 13px;
+  padding: 5px 15px;
+  color: #000;
+}
+.popover .popover-content a {
+  color: #21A1B3;
+}
+.popover .popover-content img {
+  max-width: 100%;
+}
+.popover .popover-navigation {
+  padding: 15px;
+}
+.panel-profile .panel-profile-header .image-upload-container {
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}
+.panel-profile .panel-profile-header .image-upload-container #bannerfileupload {
+  position: absolute;
+  top: 0;
+  left: 0;
+  opacity: 0;
+  width: 100%;
+  height: 100%;
+}
+.panel-profile .panel-profile-header .img-profile-header-background {
+  width: 100%;
+  max-height: 192px;
+}
+@media print {
+  .panel-profile {
+    display: none;
+  }
+}
+.list-group-item {
+  padding: 6px 15px;
+  border: none;
+  border-width: 0 !important;
+  border-left: 3px solid #fff !important;
+  font-size: 12px;
+  font-weight: 600;
+}
+.list-group-item i {
+  font-size: 14px;
+}
+a.list-group-item:hover,
+a.list-group-item.active,
+a.list-group-item.active:hover,
+a.list-group-item.active:focus {
+  z-index: 2;
+  color: #000;
+  background-color: #f8f8f8;
+  border-left: 3px solid #21A1B3 !important;
+}
+@media (max-width: 991px) {
+  .list-group {
+    margin-left: 4px;
+  }
+  .list-group-item {
+    display: inline-block !important;
+    border-radius: 3px !important;
+    margin: 4px 0;
+    margin-bottom: 4px !important;
+  }
+  .list-group-item {
+    border: none !important;
+  }
+  a.list-group-item:hover,
+  a.list-group-item.active,
+  a.list-group-item.active:hover,
+  a.list-group-item.active:focus {
+    border: none !important;
+    background: #435f6f !important;
+    color: #fff !important;
+  }
+}
+.modal-backdrop {
+  background-color: rgba(0, 0, 0, 0.5);
+}
+.modal-dialog.fadeIn,
+.modal-dialog.pulse {
+  animation-duration: 200ms;
+}
+body.modal-open {
+  height: 100vh;
+  overflow-y: hidden;
+}
+@media screen and (max-width: 768px) {
+  .modal-dialog {
+    width: calc(100vw - 4px) !important;
+  }
+}
+.modal-top {
+  z-index: 999999 !important;
+}
+.modal {
+  overflow-y: visible;
+}
+.modal.in {
+  padding-right: 0 !important;
+}
+.modal-dialog-extra-small {
+  width: 400px;
+}
+.modal-dialog-small {
+  width: 500px;
+}
+.modal-dialog-normal {
+  width: 600px;
+}
+.modal-dialog-medium {
+  width: 768px;
+}
+.modal-dialog-large {
+  width: 900px;
+}
+@media screen and (max-width: 991px) {
+  .modal-dialog-large {
+    width: auto !important;
+    padding-top: 30px;
+    padding-bottom: 30px;
+  }
+}
+.modal {
+  border: none;
+}
+.modal h1,
+.modal h2,
+.modal h3,
+.modal h4,
+.modal h5 {
+  margin-top: 20px;
+  color: #000;
+  font-weight: 300;
+}
+.modal h4.media-heading {
+  margin-top: 0;
+}
+.modal-title {
+  font-size: 20px;
+  font-weight: 200;
+  color: #000;
+}
+.modal-dialog,
+.modal-content {
+  min-width: 150px;
+}
+.modal-content {
+  box-shadow: 0 2px 26px rgba(0, 0, 0, 0.3), 0 0 0 1px rgba(0, 0, 0, 0.1);
+  border: none;
+}
+.modal-content .modal-header {
+  padding: 20px 20px 0;
+  border-bottom: none;
+  text-align: center;
+}
+.modal-content .modal-header .close {
+  margin-top: 2px;
+  margin-right: 5px;
+  opacity: 1;
+  color: #435f6f;
+  font-size: 28px;
+}
+.modal-content .modal-header .close:hover {
+  opacity: 0.9;
+}
+.modal-content .modal-body {
+  padding: 20px;
+  font-size: 13px;
+}
+.modal-content .modal-footer {
+  margin-top: 0;
+  text-align: left;
+  padding: 10px 20px 30px;
+  border-top: none;
+  text-align: center;
+}
+.modal-content .modal-footer hr {
+  margin-top: 0;
+}
+.tooltip-inner {
+  background-color: #435f6f;
+  max-width: 400px;
+  text-align: left;
+  padding: 2px 8px 4px;
+  font-size: 12px;
+  font-weight: bold;
+  white-space: pre-wrap;
+}
+.tooltip.top .tooltip-arrow {
+  border-top-color: #435f6f;
+}
+.tooltip.top-left .tooltip-arrow {
+  border-top-color: #435f6f;
+}
+.tooltip.top-right .tooltip-arrow {
+  border-top-color: #435f6f;
+}
+.tooltip.right .tooltip-arrow {
+  border-right-color: #435f6f;
+}
+.tooltip.left .tooltip-arrow {
+  border-left-color: #435f6f;
+}
+.tooltip.bottom .tooltip-arrow {
+  border-bottom-color: #435f6f;
+}
+.tooltip.bottom-left .tooltip-arrow {
+  border-bottom-color: #435f6f;
+}
+.tooltip.bottom-right .tooltip-arrow {
+  border-bottom-color: #435f6f;
+}
+.tooltip.in {
+  opacity: 1;
+}
+.progress {
+  height: 10px;
+  margin-bottom: 15px;
+  box-shadow: none;
+  background: #ededed;
+  border-radius: 10px;
+}
+.progress-bar-info {
+  background-color: #21A1B3;
+  box-shadow: none;
+}
+#nprogress .bar {
+  height: 2px;
+  background: #27c0d5;
+}
+table {
+  margin-bottom: 0 !important;
+}
+table th {
+  font-size: 11px;
+  color: #555555;
+  font-weight: normal;
+}
+table thead tr th {
+  border: none !important;
+}
+table .time {
+  font-size: 12px;
+}
+table td a:hover {
+  color: #21A1B3;
+}
+.table > thead > tr > th,
+.table > tbody > tr > th,
+.table > tfoot > tr > th,
+.table > thead > tr > td,
+.table > tbody > tr > td,
+.table > tfoot > tr > td {
+  padding: 10px 10px 10px 0;
+}
+.table > thead > tr > th select,
+.table > tbody > tr > th select,
+.table > tfoot > tr > th select,
+.table > thead > tr > td select,
+.table > tbody > tr > td select,
+.table > tfoot > tr > td select {
+  font-size: 12px;
+  padding: 4px 8px;
+  height: 30px;
+  margin: 0;
+}
+.table-middle > thead > tr > th,
+.table-middle > tbody > tr > th,
+.table-middle > tfoot > tr > th,
+.table-middle > thead > tr > td,
+.table-middle > tbody > tr > td,
+.table-middle > tfoot > tr > td {
+  vertical-align: middle !important;
+}
+@media (max-width: 767px) {
+  .table-responsive > .table > tbody > tr > td.notification-type {
+    white-space: normal;
+  }
+}
+.comment-container {
+  margin-top: 10px;
+}
+.comment-container .wall-entry-controls {
+  margin-left: 35px;
+}
+@media (max-width: 767px) {
+  .comment .post-files img {
+    height: 100px;
+  }
+}
+.comment {
+  /*-- Since v1.2 overflow: visible */
+}
+.comment .media {
+  position: relative !important;
+  margin-top: 0;
+}
+.comment .media .nav-pills.preferences {
+  display: none;
+  right: -3px;
+}
+.comment .media.comment-current {
+  background: #daf0f3;
+  padding: 0 5px 5px 5px;
+  margin: 0 -5px -5px -5px;
+  border-radius: 3px;
+}
+.comment .media.comment-current hr {
+  position: relative;
+  top: -6px;
+}
+.comment .media.comment-current:first-of-type {
+  padding-top: 5px;
+  margin-top: -5px;
+}
+.comment .media.comment-current:first-of-type > .nav.preferences {
+  margin-top: 10px;
+}
+.comment .media.comment-current > .nav.preferences {
+  margin-right: 10px;
+}
+.comment .media.comment-current .nested-comments-root .comment-container {
+  margin-top: 5px;
+  padding-bottom: 10px;
+}
+.comment .media.comment-current .nested-comments-root .comment-container .showMore {
+  margin-top: 0;
+  padding-top: 5px;
+}
+.comment .comment-blocked-user img[data-contentcontainer-id] {
+  filter: grayscale(100%);
+}
+.comment .media-body {
+  overflow: visible;
+}
+.comment .jp-progress {
+  background-color: #dbdcdd !important;
+}
+.comment .jp-play-bar {
+  background: #cacaca;
+}
+.comment .post-file-list {
+  background-color: #ededed;
+}
+.comment.guest-mode .media:last-child .wall-entry-controls {
+  margin-bottom: 0;
+  margin-left: 35px;
+}
+.comment.guest-mode .media:last-child hr {
+  display: none;
+}
+.comment-container .content_edit {
+  margin-left: 35px;
+}
+.comment-container .media {
+  overflow: visible;
+}
+.comment-container [data-ui-richtext] pre,
+.comment-container [data-ui-richtext] pre code.hljs {
+  background-color: #ebebeb;
+}
+.comment_edit_content {
+  margin-left: 35px;
+  margin-top: 0;
+}
+.comment-message {
+  overflow: hidden;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  word-break: break-word;
+  hyphens: auto;
+}
+.content-create-input-group.scrollActive .upload-buttons {
+  right: 22px;
+}
+.comment .media .media-body h4.media-heading a {
+  font-size: 13px;
+  color: #000;
+  margin-bottom: 3px;
+  font-weight: 500;
+}
+div.comment > div.media:first-of-type hr.comment-separator {
+  display: none;
+}
+div.comment > div.media:first-of-type .nav-pills.preferences {
+  display: none;
+  top: -3px;
+}
+div.nested-comments-root {
+  margin-left: 28px;
+}
+div.nested-comments-root .ProseMirror-menubar-wrapper {
+  z-index: 210;
+}
+div.nested-comments-root hr.comment-separator {
+  display: inherit !important;
+}
+div.nested-comments-root .showMore {
+  margin-top: 10px;
+}
+div.nested-comments-root div.comment .media {
+  position: relative !important;
+  margin-top: 0;
+}
+div.nested-comments-root div.comment .media .nav-pills.preferences {
+  display: none;
+  top: 8px;
+  right: 0;
+}
+div.nested-comments-root div.comment-container {
+  margin-top: 0;
+  padding-bottom: 0;
+  padding-top: 0;
+}
+.grid-view img {
+  width: 24px;
+  height: 24px;
+}
+.grid-view .filters input,
+.grid-view .filters select {
+  border: 2px solid #ededed;
+  box-shadow: none;
+  min-height: 35px;
+  border-radius: 4px;
+  font-size: 12px;
+  padding: 4px;
+}
+.grid-view .filters input:focus,
+.grid-view .filters select:focus {
+  border: 2px solid #21A1B3;
+  outline: 0;
+  box-shadow: none;
+}
+.grid-view {
+  padding: 15px 0 0;
+}
+.grid-view img {
+  border-radius: 3px;
+}
+.grid-view table th {
+  font-size: 13px !important;
+  font-weight: bold !important;
+}
+.grid-view table td {
+  vertical-align: middle !important;
+}
+.grid-view table tr {
+  font-size: 13px !important;
+}
+.grid-view table thead tr th:first-of-type {
+  padding-left: 5px;
+}
+.grid-view table tbody tr {
+  height: 50px;
+}
+.grid-view table tbody tr td:first-of-type {
+  padding-left: 5px;
+}
+.grid-view .summary {
+  font-size: 12px;
+  color: #bac2c7;
+}
+.permission-grid-editor > .table > tbody > tr:first-child > td {
+  border: none;
+}
+.permission-grid-editor {
+  padding-top: 0px;
+}
+.detail-view td,
+.detail-view th {
+  padding: 8px !important;
+}
+.detail-view th {
+  font-size: 13px;
+}
+.oembed_snippet[data-oembed-provider="youtube.com"],
+.oembed_snippet {
+  margin-top: 10px;
+  position: relative;
+  padding-bottom: 55%;
+  padding-top: 15px;
+  overflow: hidden;
+}
+.oembed_snippet[data-oembed-provider="twitter.com"] {
+  padding-bottom: 0 !important;
+  padding-top: 0;
+  margin-top: 0;
+}
+.oembed_snippet iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+.oembed_confirmation {
+  background: #f2f9fb;
+  border-radius: 4px;
+  padding: 15px;
+  line-height: 30px;
+}
+.oembed_confirmation i.fa {
+  float: left;
+  color: #02a0b0;
+  background: #FFF;
+  border-radius: 50%;
+  font-size: 30px;
+  line-height: 25px;
+  margin-right: 15px;
+}
+.oembed_confirmation > div:not(.clearfix) {
+  float: left;
+}
+#oembed-providers {
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  justify-content: left;
+  align-items: center;
+  flex-wrap: wrap;
+  margin: 0 -0.5rem;
+}
+#oembed-providers .oembed-provider-container {
+  padding: 0;
+}
+#oembed-providers .oembed-provider-container .oembed-provider {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  border: 1px solid #ddd;
+  border-radius: 2px;
+  padding: 0.75rem;
+  margin: 0 0.5rem 0.5rem 0.5rem;
+}
+#oembed-providers .oembed-provider-container .oembed-provider .oembed-provider-name {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+#oembed-providers .oembed-provider-container .oembed-provider .oembed-provider-name .label.label-error {
+  margin-left: 2px;
+}
+#endpoint-parameters {
+  display: flex;
+  flex-direction: row;
+  justify-content: left;
+  align-items: center;
+  flex-wrap: wrap;
+  margin: 0 -15px;
+}
+.activities {
+  max-height: 400px;
+  overflow: auto;
+}
+.activities li.activity-entry {
+  padding: 0;
+}
+.activities li .media {
+  position: relative;
+  padding: 10px;
+}
+.activities li .media .img-space {
+  position: absolute;
+  top: 24px;
+  left: 24px;
+}
+.activities li .media .media-body {
+  max-width: 295px;
+}
+.contentForm_options {
+  margin-top: 10px;
+  min-height: 29px;
+}
+.contentForm_options .btn_container {
+  position: relative;
+}
+.contentForm_options .btn_container .label-container {
+  position: absolute;
+  right: 40px;
+  top: 11px;
+}
+#content-topic-bar {
+  margin-top: 5px;
+  text-align: right;
+}
+#content-topic-bar .label {
+  margin-left: 4px;
+}
+#contentFormBody .form-group,
+#contentFormBody .help-block-error {
+  margin: 0;
+}
+#contentFormBody .contentForm_options .form-group {
+  margin-bottom: 15px;
+}
+#contentFormBody .contentForm_options .form-group .checkbox label {
+  padding-left: 22px;
+}
+#contentFormBody .contentForm_options .form-group .checkbox label input[type=checkbox] {
+  position: absolute;
+  top: 4px;
+  left: 0;
+}
+#contentFormBody .contentForm_options .form-group .checkbox label input[type=checkbox]:focus {
+  border-color: #ccc !important;
+}
+#contentFormBody .contentForm_options .form-group .checkbox label input[type=checkbox]:focus:checked {
+  border-color: #21A1B3 !important;
+}
+.placeholder-empty-stream {
+  background-image: url("../img/placeholder-postform-arrow.png");
+  background-repeat: no-repeat;
+  padding: 37px 0 0 70px;
+  margin-left: 90px;
+}
+#streamUpdateBadge {
+  text-align: center;
+  z-index: 9999;
+  margin-bottom: 15px;
+  margin-top: 15px;
+}
+#streamUpdateBadge .label {
+  border-radius: 10px;
+  font-size: 0.8em !important;
+  padding: 5px 10px;
+}
+#wallStream .back_button_holder {
+  padding-bottom: 15px;
+}
+.wall-entry {
+  position: relative;
+}
+.wall-entry .panel .panel-body {
+  padding: 10px;
+}
+.wall-entry .wall-entry-header {
+  color: #000;
+  position: relative;
+  padding-bottom: 10px;
+  margin-bottom: 10px;
+  border-bottom: 1px solid #eeeeee;
+}
+.wall-entry .wall-entry-header .img-space {
+  top: 25px;
+  left: 25px;
+}
+.wall-entry .wall-entry-header .wall-entry-container-link {
+  color: #21A1B3;
+}
+.wall-entry .wall-entry-header .stream-entry-icon-list {
+  position: absolute;
+  top: 0;
+  right: 25px;
+  display: inline-block;
+  padding-top: 2px;
+}
+.wall-entry .wall-entry-header .stream-entry-icon-list i {
+  padding-right: 5px;
+}
+.wall-entry .wall-entry-header .stream-entry-icon-list .icon-pin {
+  color: #FC4A64;
+}
+.wall-entry .wall-entry-header .stream-entry-icon-list .fa-archive {
+  color: #FFC107;
+}
+.wall-entry .wall-entry-header .wall-entry-header-image {
+  display: table-cell;
+  width: 40px;
+  padding-right: 10px;
+}
+.wall-entry .wall-entry-header .wall-entry-header-image .fa {
+  font-size: 2.39em;
+  color: #21A1B3;
+  margin-top: 5px;
+}
+.wall-entry .wall-entry-header .wall-entry-header-info {
+  display: table-cell;
+  padding-right: 30px;
+  width: 100%;
+}
+.wall-entry .wall-entry-header .wall-entry-header-info .media-heading {
+  font-size: 15px;
+  padding-top: 1px;
+  margin-bottom: 3px;
+}
+.wall-entry .wall-entry-header .wall-entry-header-info i.archived {
+  color: #FFC107;
+}
+.wall-entry .wall-entry-header .preferences {
+  position: absolute;
+  right: 0;
+  top: 0;
+}
+.wall-entry .wall-entry-header .media-subheading i.fa-caret-right {
+  margin: 0 2px;
+}
+.wall-entry .wall-entry-header .media-subheading .wall-entry-icons {
+  display: inline-block;
+}
+.wall-entry .wall-entry-header .media-subheading .wall-entry-icons i {
+  margin-right: 2px;
+}
+.wall-entry .wall-entry-header .media-subheading .time,
+.wall-entry .wall-entry-header .media-subheading i,
+.wall-entry .wall-entry-header .media-subheading span {
+  font-size: 11px;
+  white-space: nowrap;
+}
+.wall-entry .wall-entry-body {
+  padding-left: 50px;
+  padding-right: 50px;
+}
+.wall-entry .wall-entry-body .wall-entry-content {
+  margin-bottom: 5px;
+}
+.wall-entry .wall-entry-body .wall-entry-content .post-short-text {
+  font-size: 1.6em;
+}
+.wall-entry .wall-entry-body .wall-entry-content .post-short-text .emoji {
+  width: 20px;
+}
+.wall-entry .wall-entry-body audio,
+.wall-entry .wall-entry-body video {
+  width: 100%;
+}
+.wall-entry .wall-stream-footer .wall-stream-addons .files {
+  margin-bottom: 5px;
+}
+.wall-entry .content a {
+  color: #21A1B3;
+}
+.wall-entry .content img {
+  max-width: 100%;
+}
+.wall-entry .media {
+  overflow: visible;
+}
+.wall-entry .well {
+  margin-bottom: 0;
+}
+.wall-entry .well .comment .showMore a {
+  font-size: 12px;
+}
+.wall-entry .media-heading {
+  font-size: 14px;
+  padding-top: 1px;
+  margin-bottom: 3px;
+}
+.wall-entry .media-heading .labels {
+  padding-right: 32px;
+}
+.wall-entry .media-heading .viaLink {
+  font-size: 13px;
+}
+.wall-entry .media-heading .viaLink i {
+  color: #555555;
+  padding-left: 4px;
+  padding-right: 4px;
+}
+.wall-entry .media-subheading {
+  color: #555555;
+  font-size: 12px;
+}
+.wall-entry .media-subheading .time {
+  font-size: 12px;
+  white-space: nowrap;
+}
+.wall-entry [data-ui-richtext] h1 {
+  font-size: 1.45em;
+  font-weight: normal;
+}
+.wall-entry [data-ui-richtext] h2 {
+  font-size: 1.3em;
+  font-weight: normal;
+}
+.wall-entry [data-ui-richtext] h3 {
+  font-size: 1.2em;
+  font-weight: normal;
+}
+.wall-entry [data-ui-richtext] h4 {
+  font-size: 1.1em;
+  font-weight: normal;
+}
+.wall-entry [data-ui-richtext] h5 {
+  font-size: 1em;
+  font-weight: normal;
+}
+.wall-entry [data-ui-richtext] h6 {
+  font-size: 0.85em;
+  font-weight: normal;
+}
+@media (max-width: 767px) {
+  .wall-entry .wall-entry-body {
+    padding-left: 0;
+    padding-right: 0;
+  }
+  #wallStream .back_button_holder {
+    padding-bottom: 5px;
+    text-align: center;
+  }
+}
+.wall-entry-controls a {
+  font-size: 11px;
+  color: #21A1B3 !important;
+  margin-top: 10px;
+  margin-bottom: 0;
+}
+#wall-stream-filter-nav {
+  font-size: 12px;
+  margin-bottom: 10px;
+  padding-top: 2px;
+  border-radius: 0 0 4px 4px;
+}
+#wall-stream-filter-nav .wall-stream-filter-root {
+  margin: 0;
+  border: 0 !important;
+}
+#wall-stream-filter-nav .filter-panel {
+  padding: 0 10px;
+}
+#wall-stream-filter-nav .wall-stream-filter-head {
+  padding: 5px 5px 10px 5px;
+  border-bottom: 1px solid #ddd;
+}
+#wall-stream-filter-nav .wall-stream-filter-body {
+  overflow: hidden;
+  background-color: #f8f8f8;
+  border: 1px solid #ddd;
+  border-top: 0;
+  border-radius: 0 0 4px 4px;
+}
+#wall-stream-filter-nav hr {
+  margin: 5px 0 0 0;
+}
+#wall-stream-filter-nav .topic-remove-label {
+  float: left;
+}
+#wall-stream-filter-nav .topic-remove-label,
+#wall-stream-filter-nav .content-type-remove-label {
+  margin-right: 6px;
+}
+#wall-stream-filter-nav .select2 {
+  width: 260px !important;
+  margin-bottom: 5px;
+  margin-top: 2px;
+}
+#wall-stream-filter-nav .select2 .select2-search__field {
+  height: 25px !important;
+}
+#wall-stream-filter-nav .select2 .select2-selection__choice {
+  height: 23px !important;
+}
+#wall-stream-filter-nav .select2 .select2-selection__choice span,
+#wall-stream-filter-nav .select2 .select2-selection__choice i {
+  line-height: 19px !important;
+}
+#wall-stream-filter-nav .select2 .select2-selection__choice .img-rounded {
+  width: 18px !important;
+  height: 18px !important;
+}
+#wall-stream-filter-nav .wall-stream-filter-bar {
+  display: inline;
+  float: right;
+  white-space: normal;
+}
+#wall-stream-filter-nav .wall-stream-filter-bar .label {
+  height: 18px;
+  padding-top: 4px;
+  background-color: #fff;
+}
+#wall-stream-filter-nav .wall-stream-filter-bar .btn,
+#wall-stream-filter-nav .wall-stream-filter-bar .label {
+  box-shadow: 0 0 2px #7a7a7a;
+}
+@media (max-width: 767px) {
+  #wall-stream-filter-nav {
+    margin-bottom: 5px;
+  }
+  #wall-stream-filter-nav .wall-stream-filter-root {
+    white-space: nowrap;
+  }
+  #wall-stream-filter-nav .wall-stream-filter-body {
+    overflow: auto;
+  }
+}
+.filter-root {
+  margin: 15px;
+}
+.filter-root .row {
+  display: table !important;
+}
+.filter-root .filter-panel {
+  padding: 0 5px;
+  display: table-cell !important;
+  float: none;
+}
+.filter-root .filter-panel .filter-block strong {
+  margin-bottom: 5px;
+}
+.filter-root .filter-panel .filter-block ul.filter-list {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 5px;
+}
+.filter-root .filter-panel .filter-block ul.filter-list li {
+  font-size: 12px;
+  padding: 2px;
+}
+.filter-root .filter-panel .filter-block ul.filter-list li a {
+  color: #000;
+}
+.filter-root .filter-panel div.filter-block:last-of-type ul.filter-list {
+  margin: 0;
+}
+.filter-root .filter-panel + .filter-panel {
+  border-left: 2px solid #ededed;
+}
+.stream-entry-loader {
+  float: right;
+  margin-top: 5px;
+}
+.load-suppressed {
+  margin-top: -17px;
+  margin-bottom: 15px;
+  text-align: center;
+}
+.load-suppressed a {
+  display: inline-block;
+  background-color: white;
+  padding: 5px;
+  border-radius: 0 0 4px 4px;
+  border: 1px solid #ddd;
+  font-size: 11px;
+}
+@media print {
+  .wall-entry {
+    page-break-inside: avoid;
+  }
+  #wall-stream-filter-nav,
+  #contentFormBody {
+    display: none;
+  }
+}
+.space-owner {
+  text-align: center;
+  margin: 14px 0;
+  font-size: 13px;
+  color: #999;
+}
+.space-member-sign {
+  color: #97d271;
+  position: absolute;
+  top: 42px;
+  left: 42px;
+  font-size: 16px;
+  background: #fff;
+  width: 24px;
+  height: 24px;
+  padding: 2px 3px 1px 4px;
+  border-radius: 50px;
+  border: 2px solid #97d271;
+}
+#space-menu-dropdown i.type {
+  font-size: 16px;
+  color: #BFBFBF;
+}
+#space-menu-spaces [data-space-chooser-item] {
+  cursor: pointer;
+}
+#space-menu-dropdown .input-group-addon {
+  border-radius: 0 4px 4px 0;
+}
+#space-menu-dropdown .input-group-addon.focus {
+  border-radius: 0 4px 4px 0;
+  border: 2px solid #21A1B3;
+  border-left: 0;
+}
+.input-group #space-menu-search {
+  border-right: 0;
+}
+#space-menu-dropdown div:not(.input-group) > .search-reset {
+  top: 10px !important;
+  right: 15px !important;
+}
+#space-directory-link i {
+  margin-right: 0;
+}
+.space-acronym {
+  color: #fff;
+  text-align: center;
+  display: inline-block;
+}
+.current-space-image {
+  margin-right: 3px;
+  margin-top: 3px;
+}
+@media (max-width: 767px) {
+  #space-menu > .title {
+    display: none;
+  }
+  #space-menu-dropdown {
+    width: 300px !important;
+  }
+}
+.files,
+#postFormFiles_list {
+  padding-left: 0;
+}
+ul.files {
+  list-style: none;
+  margin: 0 0 5px;
+  padding: 0;
+}
+ul.files li.file-preview-item {
+  padding-left: 24px;
+  display: none;
+}
+ul.files li.file-preview-item .file-fileInfo {
+  padding-right: 20px;
+}
+.contentForm-upload-list {
+  padding-left: 0;
+}
+.contentForm-upload-list li:first-child {
+  margin-top: 10px;
+}
+.file_upload_remove_link,
+.file_upload_remove_link:hover {
+  color: #FC4A64;
+  cursor: pointer;
+}
+.file-preview-item {
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+.post-files {
+  margin-top: 10px;
+  margin-bottom: 10px;
+}
+.post-files video {
+  border-radius: 4px;
+}
+.post-files .jp-audio {
+  margin-bottom: 10px;
+}
+.post-files .col-media {
+  padding-left: 0 !important;
+  padding-right: 0 !important;
+}
+.post-files img {
+  vertical-align: top;
+  padding: 2px;
+  height: 150px;
+  width: 100%;
+  object-fit: cover;
+  border-radius: 4px;
+}
+@media (max-width: 650px) {
+  .post-files img {
+    height: 100px;
+  }
+}
+.post-file-list {
+  padding: 10px;
+  padding-bottom: 1px;
+  margin-bottom: 10px !important;
+}
+.post-file-list a,
+.post-file-list a:active,
+.post-file-list a:focus,
+.post-file-list a:hover {
+  color: #21A1B3;
+}
+#wallStream.mobile .post-files {
+  margin-top: 10px;
+  display: flex;
+  overflow-x: auto;
+}
+#wallStream.mobile .post-files img {
+  max-width: 190px;
+  height: 100px;
+  width: auto;
+}
+.file-preview-content {
+  cursor: pointer;
+}
+.image-upload-container {
+  position: relative;
+}
+.image-upload-container .image-upload-buttons {
+  display: none;
+  position: absolute;
+  right: 5px;
+  bottom: 5px;
+}
+.image-upload-container input[type="file"] {
+  position: absolute;
+  opacity: 0;
+}
+.image-upload-container .image-upload-loader {
+  display: none;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  padding: 20px;
+  background: #f8f8f8;
+}
+.mime {
+  background-repeat: no-repeat;
+  background-position: 0 0;
+  padding: 1px 0 4px 26px;
+}
+.mime-word {
+  background-image: url("../img/mime/word.png");
+}
+.mime-excel {
+  background-image: url("../img/mime/excel.png");
+}
+.mime-powerpoint {
+  background-image: url("../img/mime/powerpoint.png");
+}
+.mime-pdf {
+  background-image: url("../img/mime/pdf.png");
+}
+.mime-zip {
+  background-image: url("../img/mime/zip.png");
+}
+.mime-image {
+  background-image: url("../img/mime/image.png");
+}
+.mime-file {
+  background-image: url("../img/mime/file.png");
+}
+.mime-photoshop {
+  background-image: url("../img/mime/photoshop.png");
+}
+.mime-illustrator {
+  background-image: url("../img/mime/illustrator.png");
+}
+.mime-video {
+  background-image: url("../img/mime/video.png");
+}
+.mime-audio {
+  background-image: url("../img/mime/audio.png");
+}
+@media (max-width: 480px) {
+  .jp-current-time {
+    margin-left: 0 !important;
+  }
+  .jp-audio {
+    width: auto !important;
+    margin-left: 0 !important;
+  }
+  .jp-audio .jp-controls {
+    padding: 2px 12px 0 !important;
+  }
+  .jp-audio .jp-progress {
+    left: 3px !important;
+    top: 45px !important;
+    width: 200px !important;
+  }
+  .jp-audio .jp-volume-controls {
+    position: absolute !important;
+    top: 15px !important;
+    left: 170px !important;
+  }
+  .jp-audio .jp-time-holder {
+    left: 3px !important;
+    top: 60px !important;
+    width: 200px !important;
+  }
+  .jp-audio .jp-toggles {
+    left: 210px !important;
+    top: 45px !important;
+    width: auto !important;
+  }
+  .jp-playlist ul {
+    padding: 0 0 0 0 !important;
+  }
+}
+div.jp-type-playlist div.jp-playlist a.jp-playlist-current,
+div.jp-type-playlist div.jp-playlist a:hover {
+  color: #21A1B3 !important;
+}
+.jp-details,
+.jp-playlist {
+  border-top: 1px solid #21A1B3;
+}
+.jp-audio,
+.jp-audio-stream,
+.jp-video {
+  border: 1px solid #21A1B3;
+}
+ul.tour-list {
+  list-style: none;
+  margin-bottom: 0;
+  padding-left: 10px;
+}
+ul.tour-list li {
+  padding-top: 5px;
+}
+ul.tour-list li a {
+  color: #21A1B3;
+}
+ul.tour-list li a .fa {
+  width: 16px;
+}
+ul.tour-list li.completed a {
+  text-decoration: line-through;
+  color: #555555;
+}
+.atwho-view {
+  background: #fff;
+  color: #555555;
+  border: 1px solid #d7d7d7;
+  border-radius: 4px;
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
+  display: none;
+  font-size: 14px;
+  font-weight: 400;
+  margin-top: 18px;
+  min-width: 120px;
+  max-width: 265px;
+  padding: 5px 0;
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 11110 !important;
+}
+.atwho-view ul {
+  list-style: none;
+  margin: auto;
+  padding: 0;
+}
+.atwho-view ul li {
+  border-left: 3px solid transparent;
+  cursor: pointer;
+  display: block;
+  padding: 4px 15px 4px 8px;
+}
+.atwho-view ul li.hint {
+  background: #fff !important;
+  border-left: 3px solid transparent !important;
+  color: #aeaeae;
+  font-size: 12px;
+}
+.atwho-input.form-control {
+  height: auto;
+  min-height: 36px;
+  padding-right: 95px;
+  word-wrap: break-word;
+}
+.atwho-input p {
+  padding: 0;
+  margin: 0;
+}
+.atwho-placeholder {
+  color: #bac2c7 !important;
+}
+.atwho-emoji-entry {
+  float: left;
+  padding: 4px !important;
+  margin: 0 !important;
+  border: none !important;
+}
+.atwho-emoji-entry:hover,
+.atwho-emoji-entry:active,
+.atwho-emoji-entry:focus {
+  padding: 4px !important;
+  margin: 0 !important;
+  border: none !important;
+  background-color: #f8f8f8 !important;
+  border-radius: 3px;
+}
+.atwho-view .cur {
+  border-left: 3px solid #21A1B3;
+  background-color: #f8f8f8 !important;
+}
+.atwho-user,
+.atwho-space,
+.atwho-input a {
+  color: #21A1B3;
+}
+.atwho-input a:hover {
+  color: #21A1B3;
+}
+.atwho-view strong {
+  background-color: #fff4d3;
+}
+.atwho-view .cur strong {
+  background-color: #fff4d3;
+}
+.atwho-view small {
+  font-size: smaller;
+  color: #7a7a7a;
+  font-weight: normal;
+}
+.atwho-view .cur small {
+  color: var(--danger);
+}
+.atwho-view strong,
+.atwho-view b {
+  font-weight: normal;
+}
+.atwho-view span {
+  padding: 5px;
+}
+.sk-spinner-three-bounce.sk-spinner {
+  margin: 0 auto;
+  width: 70px;
+  text-align: center;
+}
+.loader {
+  padding: 30px 0;
+}
+.loader .sk-spinner-three-bounce div,
+.loader .sk-spinner-three-bounce span {
+  width: 12px;
+  height: 12px;
+  background-color: #21A1B3;
+  border-radius: 100%;
+  display: inline-block;
+  animation: sk-threeBounceDelay 1.4s infinite ease-in-out;
+  /* Prevent first frame from flickering when animation starts */
+  animation-fill-mode: both;
+}
+.loader .sk-spinner-three-bounce .sk-bounce1 {
+  animation-delay: -0.32s;
+}
+.loader .sk-spinner-three-bounce .sk-bounce2 {
+  animation-delay: -0.16s;
+}
+@keyframes sk-threeBounceDelay {
+  0%,
+  80%,
+  100% {
+    transform: scale(0);
+  }
+  40% {
+    transform: scale(1);
+  }
+}
+.loader-modal {
+  padding: 8px 0;
+}
+.loader-postform {
+  padding: 9px 0;
+}
+.loader-postform .sk-spinner-three-bounce.sk-spinner {
+  text-align: left;
+  margin: 0;
+}
+.md-editor.active {
+  border: 2px solid #21A1B3 !important;
+}
+.md-editor textarea {
+  padding: 10px !important;
+}
+.markdown-render,
+[data-ui-markdown],
+[data-ui-richtext] {
+  line-height: 1.57;
+  overflow: hidden;
+  overflow-wrap: break-word;
+}
+.markdown-render h1,
+[data-ui-markdown] h1,
+[data-ui-richtext] h1,
+.markdown-render h2,
+[data-ui-markdown] h2,
+[data-ui-richtext] h2,
+.markdown-render h3,
+[data-ui-markdown] h3,
+[data-ui-richtext] h3,
+.markdown-render h4,
+[data-ui-markdown] h4,
+[data-ui-richtext] h4,
+.markdown-render h5,
+[data-ui-markdown] h5,
+[data-ui-richtext] h5,
+.markdown-render h6,
+[data-ui-markdown] h6,
+[data-ui-richtext] h6 {
+  margin: 1.2em 0 0.8em;
+  color: #555;
+  font-weight: normal;
+  text-align: start;
+}
+.markdown-render h1:first-child,
+[data-ui-markdown] h1:first-child,
+[data-ui-richtext] h1:first-child,
+.markdown-render h2:first-child,
+[data-ui-markdown] h2:first-child,
+[data-ui-richtext] h2:first-child,
+.markdown-render h3:first-child,
+[data-ui-markdown] h3:first-child,
+[data-ui-richtext] h3:first-child,
+.markdown-render h4:first-child,
+[data-ui-markdown] h4:first-child,
+[data-ui-richtext] h4:first-child,
+.markdown-render h5:first-child,
+[data-ui-markdown] h5:first-child,
+[data-ui-richtext] h5:first-child,
+.markdown-render h6:first-child,
+[data-ui-markdown] h6:first-child,
+[data-ui-richtext] h6:first-child {
+  margin: 0 0 0.8em;
+}
+.markdown-render h1,
+[data-ui-markdown] h1,
+[data-ui-richtext] h1 {
+  font-size: 1.7em;
+}
+.markdown-render h2,
+[data-ui-markdown] h2,
+[data-ui-richtext] h2 {
+  font-size: 1.5em;
+}
+.markdown-render h3,
+[data-ui-markdown] h3,
+[data-ui-richtext] h3 {
+  font-size: 1.2em;
+}
+.markdown-render h4,
+[data-ui-markdown] h4,
+[data-ui-richtext] h4 {
+  font-size: 1.1em;
+}
+.markdown-render h5,
+[data-ui-markdown] h5,
+[data-ui-richtext] h5 {
+  font-size: 1em;
+}
+.markdown-render h6,
+[data-ui-markdown] h6,
+[data-ui-richtext] h6 {
+  font-size: 0.85em;
+}
+.markdown-render p,
+[data-ui-markdown] p,
+[data-ui-richtext] p,
+.markdown-render pre,
+[data-ui-markdown] pre,
+[data-ui-richtext] pre,
+.markdown-render blockquote,
+[data-ui-markdown] blockquote,
+[data-ui-richtext] blockquote,
+.markdown-render ul,
+[data-ui-markdown] ul,
+[data-ui-richtext] ul,
+.markdown-render ol,
+[data-ui-markdown] ol,
+[data-ui-richtext] ol {
+  margin: 0 0 1.2em;
+}
+.markdown-render li ul,
+[data-ui-markdown] li ul,
+[data-ui-richtext] li ul,
+.markdown-render li ol,
+[data-ui-markdown] li ol,
+[data-ui-richtext] li ol {
+  margin: 0;
+}
+.markdown-render p:last-child,
+[data-ui-markdown] p:last-child,
+[data-ui-richtext] p:last-child {
+  margin: 0;
+}
+.markdown-render pre,
+[data-ui-markdown] pre,
+[data-ui-richtext] pre {
+  padding: 0;
+  border: none;
+  background-color: #f8f8f8;
+}
+.markdown-render pre code,
+[data-ui-markdown] pre code,
+[data-ui-richtext] pre code {
+  background-color: #f8f8f8;
+  color: #555;
+}
+.markdown-render code,
+[data-ui-markdown] code,
+[data-ui-richtext] code {
+  background-color: #dbf5f8;
+  color: #197a88;
+}
+.markdown-render blockquote,
+[data-ui-markdown] blockquote,
+[data-ui-richtext] blockquote {
+  background-color: rgba(128, 128, 128, 0.05);
+  border-top-right-radius: 5px;
+  border-bottom-right-radius: 5px;
+  padding: 15px 20px;
+  font-size: 1em;
+  border-left: 5px solid #435f6f;
+}
+.markdown-render dt,
+[data-ui-markdown] dt,
+[data-ui-richtext] dt,
+.markdown-render dd,
+[data-ui-markdown] dd,
+[data-ui-richtext] dd {
+  margin-top: 5px;
+  margin-bottom: 5px;
+  line-height: 1.45;
+}
+.markdown-render dt,
+[data-ui-markdown] dt,
+[data-ui-richtext] dt {
+  font-weight: bold;
+}
+.markdown-render dd,
+[data-ui-markdown] dd,
+[data-ui-richtext] dd {
+  margin-left: 40px;
+}
+.markdown-render pre,
+[data-ui-markdown] pre,
+[data-ui-richtext] pre {
+  text-align: start;
+  border: 0;
+  padding: 10px 20px;
+  border-radius: 0;
+  border-left: 2px solid #435f6f;
+}
+.markdown-render pre code,
+[data-ui-markdown] pre code,
+[data-ui-richtext] pre code {
+  white-space: pre !important;
+}
+.markdown-render blockquote ul:last-child,
+[data-ui-markdown] blockquote ul:last-child,
+[data-ui-richtext] blockquote ul:last-child,
+.markdown-render blockquote ol:last-child,
+[data-ui-markdown] blockquote ol:last-child,
+[data-ui-richtext] blockquote ol:last-child {
+  margin-bottom: 0;
+}
+.markdown-render ul,
+[data-ui-markdown] ul,
+[data-ui-richtext] ul,
+.markdown-render ol,
+[data-ui-markdown] ol,
+[data-ui-richtext] ol {
+  margin-top: 0;
+  padding-left: 30px;
+}
+.markdown-render ul li p,
+[data-ui-markdown] ul li p,
+[data-ui-richtext] ul li p,
+.markdown-render ol li p,
+[data-ui-markdown] ol li p,
+[data-ui-richtext] ol li p {
+  overflow: visible !important;
+}
+.markdown-render .footnote,
+[data-ui-markdown] .footnote,
+[data-ui-richtext] .footnote {
+  vertical-align: top;
+  position: relative;
+  top: -0.5em;
+  font-size: 0.8em;
+}
+.markdown-render .emoji,
+[data-ui-markdown] .emoji,
+[data-ui-richtext] .emoji {
+  width: 16px;
+}
+.markdown-render a,
+[data-ui-markdown] a,
+[data-ui-richtext] a,
+.markdown-render a:visited,
+[data-ui-markdown] a:visited,
+[data-ui-richtext] a:visited {
+  background-color: inherit;
+  text-decoration: none;
+  color: #21A1B3 !important;
+}
+.markdown-render a.header-anchor,
+[data-ui-markdown] a.header-anchor,
+[data-ui-richtext] a.header-anchor {
+  color: #555 !important;
+}
+.markdown-render a.not-found,
+[data-ui-markdown] a.not-found,
+[data-ui-richtext] a.not-found {
+  color: #FFC107;
+}
+.markdown-render li,
+[data-ui-markdown] li,
+[data-ui-richtext] li {
+  border: 0 !important;
+  background-color: transparent !important;
+  padding: 0;
+  margin: 5px 0;
+}
+.markdown-render img:not(.center-block),
+[data-ui-markdown] img:not(.center-block),
+[data-ui-richtext] img:not(.center-block) {
+  max-width: 100%;
+}
+.markdown-render img.pull-right,
+[data-ui-markdown] img.pull-right,
+[data-ui-richtext] img.pull-right {
+  margin: 5px 0 0 10px;
+}
+.markdown-render img.pull-left,
+[data-ui-markdown] img.pull-left,
+[data-ui-richtext] img.pull-left {
+  margin: 5px 10px 0 0;
+}
+.markdown-render img.center-block,
+[data-ui-markdown] img.center-block,
+[data-ui-richtext] img.center-block {
+  margin-top: 5px;
+  margin-bottom: 5px;
+}
+.markdown-render img[width='100%'],
+[data-ui-markdown] img[width='100%'],
+[data-ui-richtext] img[width='100%'] {
+  border-radius: 4px;
+}
+.markdown-render table,
+[data-ui-markdown] table,
+[data-ui-richtext] table {
+  border: 1px solid #d7d7d7;
+  margin-bottom: 1.2em !important;
+  font-size: 1em;
+  width: 100%;
+}
+.markdown-render table th,
+[data-ui-markdown] table th,
+[data-ui-richtext] table th,
+.markdown-render table td,
+[data-ui-markdown] table td,
+[data-ui-richtext] table td {
+  border: 1px solid #d7d7d7 !important;
+  box-sizing: border-box;
+  position: relative;
+}
+.markdown-render table th,
+[data-ui-markdown] table th,
+[data-ui-richtext] table th {
+  background-color: #435f6f;
+  color: #fff !important;
+  font-size: 1em;
+}
+.markdown-render table th p,
+[data-ui-markdown] table th p,
+[data-ui-richtext] table th p {
+  color: #fff !important;
+}
+.markdown-render table td,
+[data-ui-markdown] table td,
+[data-ui-richtext] table td {
+  padding: 15px;
+}
+.markdown-render table th,
+[data-ui-markdown] table th,
+[data-ui-richtext] table th {
+  padding: 10px 15px;
+}
+@media (max-width: 991px) {
+  .layout-sidebar-container {
+    display: none;
+  }
+}
+.ui-widget-header {
+  border: none !important;
+  background: #fff !important;
+  color: #7a7a7a !important;
+  font-weight: 300 !important;
+}
+.ui-widget-content {
+  border: 1px solid #dddcda !important;
+  border-radius: 0 !important;
+  background: #fff;
+  color: #000 !important;
+  box-shadow: 0 6px 6px rgba(0, 0, 0, 0.1);
+}
+.ui-datepicker .ui-datepicker-prev span,
+.ui-datepicker .ui-datepicker-next span {
+  opacity: 0.2;
+}
+.ui-datepicker .ui-datepicker-prev:hover,
+.ui-datepicker .ui-datepicker-next:hover {
+  background: #fff !important;
+  border: none;
+  margin: 1px;
+}
+.ui-state-default,
+.ui-widget-content .ui-state-default,
+.ui-widget-header .ui-state-default {
+  border: none !important;
+  background: #f8f8f8 !important;
+  color: #7a7a7a !important;
+}
+.ui-state-highlight,
+.ui-widget-content .ui-state-highlight,
+.ui-widget-header .ui-state-highlight {
+  border: none !important;
+  border: 1px solid #b2b2b2 !important;
+}
+.ui-state-active,
+.ui-widget-content .ui-state-active,
+.ui-widget-header .ui-state-active {
+  border: 1px solid #21A1B3 !important;
+  background: #6fd6e4 !important;
+}
+.status-bar-body {
+  color: white;
+  position: fixed;
+  width: 100%;
+  background-color: rgba(0, 0, 0, 0.7);
+  text-align: center;
+  padding: 20px;
+  z-index: 9999999;
+  bottom: 0px;
+  display: block;
+  line-height: 20px;
+}
+.status-bar-close {
+  color: white;
+  font-weight: bold;
+  font-size: 21px;
+  cursor: pointer;
+}
+.status-bar-close:hover {
+  color: white;
+}
+.status-bar-close i {
+  vertical-align: top !important;
+  padding-top: 3px;
+}
+.status-bar-content i {
+  margin-right: 10px;
+  font-size: 21px;
+  vertical-align: middle;
+}
+.status-bar-content .showMore {
+  color: #21A1B3;
+  float: right;
+  margin-left: 10px;
+  font-size: 0.7em;
+  cursor: pointer;
+  vertical-align: middle;
+  white-space: nowrap;
+}
+.status-bar-content .status-bar-details {
+  text-align: left;
+  font-size: 0.7em;
+  margin-top: 20px;
+  max-height: 200px;
+  overflow: auto;
+}
+.status-bar-content span {
+  vertical-align: middle;
+}
+.status-bar-content i.error,
+.status-bar-content i.fatal {
+  color: #FC4A64;
+}
+.status-bar-content i.warning {
+  color: #FFC107;
+}
+.status-bar-content i.info,
+.status-bar-content i.debug {
+  color: #21A1B3;
+}
+.status-bar-content i.success {
+  color: #85CA2B;
+}
+.highlight {
+  background-color: #daf0f3;
+}
+.alert-default {
+  color: #000;
+  background-color: #f8f8f8;
+  border-color: #ededed;
+  font-size: 13px;
+}
+.alert-default .info {
+  margin: 10px 0;
+}
+.alert-success {
+  color: #84be5e;
+  background-color: #f7fbf4;
+  border-color: #97d271;
+}
+.alert-warning {
+  color: #e9b168;
+  background-color: #fffbf7;
+  border-color: #fdd198;
+}
+.alert-danger {
+  color: #ff8989;
+  background-color: #fff6f6;
+  border-color: #ff8989;
+}
+.data-saved {
+  padding-left: 10px;
+  color: #21A1B3;
+}
+img.bounceIn {
+  animation-duration: 800ms;
+}
+.tags .tag {
+  margin-top: 5px;
+  border-radius: 2px;
+  padding: 4px 8px;
+  text-transform: uppercase;
+  max-width: 150px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+#user-tags-panel .tags .tag {
+  max-width: 250px;
+}
+.label {
+  text-transform: uppercase;
+}
+.label {
+  text-transform: uppercase;
+  display: inline-block;
+  padding: 3px 5px 4px;
+  font-weight: 600;
+  font-size: 10px;
+  color: white;
+  vertical-align: baseline;
+  white-space: nowrap;
+  text-shadow: none;
+}
+.label-default {
+  background: #ededed;
+  color: #7a7a7a !important;
+}
+a.label-default:hover {
+  background: #e0e0e0 !important;
+}
+.label-info {
+  background-color: #21A1B3;
+}
+a.label-info:hover {
+  background: #1d8e9d !important;
+}
+.label-danger {
+  background-color: #FC4A64;
+}
+a.label-danger:hover {
+  background: #fc314f !important;
+}
+.label-success {
+  background-color: #97d271;
+}
+a.label-success:hover {
+  background: #89cc5e !important;
+}
+.label-warning {
+  background-color: #FFC107;
+}
+a.label-warning:hover {
+  background: #ecb100 !important;
+}
+.label-light {
+  background-color: transparent;
+  color: #7a7a7a;
+  border: 1px solid #bababa;
+}
+.topic-label-list,
+.wall-entry-topics {
+  margin-bottom: 10px;
+}
+.topic-label-list a,
+.wall-entry-topics a {
+  margin-right: 4px;
+}
+.topic-label-list .label,
+.wall-entry-topics .label {
+  padding: 5px;
+  border-radius: 4px;
+}
+.ProsemirrorEditor.fullscreen {
+  height: calc(100vh - 3px);
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  z-index: 9998;
+}
+.ProsemirrorEditor.fullscreen .ProseMirror-menubar-wrapper {
+  height: 100%;
+}
+.ProsemirrorEditor.fullscreen .humhub-ui-richtext {
+  max-height: none !important;
+}
+.ProsemirrorEditor.fullscreen .ProseMirror {
+  height: calc(100% - 26px);
+  position: static;
+  overflow: auto;
+}
+.ProsemirrorEditor.fullscreen .ProseMirror-menubar {
+  position: static !important;
+  top: 0 !important;
+  left: 0 !important;
+  margin: 0 !important;
+  width: 100% !important;
+}
+.login-container .ProsemirrorEditor.fullscreen,
+.modal-dialog .ProsemirrorEditor.fullscreen {
+  width: 100%;
+  height: 100%;
+}
+/**
+ * Menu defaults
+ */
+.ProsemirrorEditor .ProseMirror {
+  padding-right: 12px;
+}
+.ProsemirrorEditor .ProseMirror.form-control {
+  font-size: inherit;
+}
+.ProsemirrorEditor .ProseMirror-menu {
+  margin: 0 -4px;
+  line-height: 1;
+}
+.ProsemirrorEditor .ProseMirror-tooltip .ProseMirror-menu {
+  width: fit-content;
+  white-space: pre;
+}
+.ProsemirrorEditor .ProseMirror-menuitem {
+  display: flex;
+  margin-right: 0;
+}
+.ProsemirrorEditor .ProseMirror-menuseparator {
+  border-right: 1px solid #d7d7d7;
+  margin-right: 1px;
+}
+.ProsemirrorEditor .ProseMirror-menubar-wrapper {
+  z-index: 200;
+}
+.ProsemirrorEditor .ProseMirror-menu-group {
+  display: flex;
+  flex-wrap: wrap;
+  min-height: 22px;
+}
+.ProsemirrorEditor .ProseMirror-menuitem .ProseMirror-menu-group {
+  border-right: 1px solid #d7d7d7;
+}
+.ProsemirrorEditor .ProseMirror-menuitem .ProseMirror-menu-group.last {
+  border-right: none;
+}
+.ProsemirrorEditor .ProseMirror-menuitem .ProseMirror-icon {
+  background: transparent;
+}
+.ProsemirrorEditor .ProseMirror-menuitem .seperator {
+  border-right: 1px solid #d7d7d7;
+  border-radius: 0;
+}
+.ProsemirrorEditor .ProseMirror-menu-dropdown,
+.ProsemirrorEditor .ProseMirror-menu-dropdown-menu {
+  white-space: nowrap;
+}
+.ProsemirrorEditor .ProseMirror-menu-dropdown {
+  cursor: pointer;
+  position: relative;
+  padding-right: 14px !important;
+}
+.ProsemirrorEditor .ProseMirror-menu-dropdown-wrap {
+  padding: 0;
+  display: inline-block;
+  position: relative;
+}
+.ProsemirrorEditor .ProseMirror-menu-dropdown:after {
+  content: "";
+  border-left: 4px solid transparent;
+  border-right: 4px solid transparent;
+  border-top: 4px solid currentColor;
+  opacity: 0.6;
+  position: absolute;
+  right: 4px;
+  top: calc(50% - 2px);
+}
+.ProsemirrorEditor .ProseMirror-menu-dropdown-menu,
+.ProsemirrorEditor .ProseMirror-menu-submenu {
+  background: #fff;
+  border: 1px solid #aeaeae;
+  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: 4px;
+  color: #000;
+  position: absolute;
+}
+.ProsemirrorEditor .ProseMirror-menu-dropdown-menu .ProseMirror-menu-active,
+.ProsemirrorEditor .ProseMirror-menu-submenu .ProseMirror-menu-active {
+  background: #f8f8f8;
+  border-left: 2px solid #21A1B3;
+  opacity: 1 !important;
+  padding: 4px 7px 4px 5px;
+}
+.ProsemirrorEditor .ProseMirror-menu-dropdown-menu {
+  margin-top: 2px;
+  min-width: 6em;
+  z-index: 15;
+}
+.ProsemirrorEditor .ProseMirror-menu-dropdown-item {
+  cursor: pointer;
+}
+.ProsemirrorEditor .ProseMirror-menu-dropdown-item div[title],
+.ProsemirrorEditor .ProseMirror-menu-dropdown-item a.ProseMirror-menu-trigger,
+.ProsemirrorEditor .ProseMirror-menu-submenu-wrap {
+  display: block;
+  padding: 4px 7px;
+}
+.ProsemirrorEditor .ProseMirror-menu-dropdown-item:hover {
+  background: #f8f8f8;
+}
+.ProsemirrorEditor .ProseMirror-menu-submenu-wrap {
+  position: relative;
+}
+.ProsemirrorEditor .ProseMirror-menu-submenu-label:after {
+  border-top: 4px solid transparent;
+  border-bottom: 4px solid transparent;
+  border-left: 4px solid currentColor;
+  content: "";
+  opacity: 0.6;
+  position: absolute;
+  right: 4px;
+  top: calc(50% - 4px);
+}
+.ProsemirrorEditor .ProseMirror-menu-submenu {
+  background: #fff;
+  border-top-right-radius: 4px;
+  display: none;
+  min-width: 4em;
+  left: 100%;
+  top: 0;
+}
+.ProsemirrorEditor .ProseMirror-menu-disabled {
+  opacity: 0.5;
+}
+.ProsemirrorEditor .ProseMirror-menu-submenu-wrap:hover .ProseMirror-menu-submenu,
+.ProsemirrorEditor .ProseMirror-menu-submenu-wrap-active .ProseMirror-menu-submenu {
+  display: block;
+}
+.ProsemirrorEditor .ProseMirror-icon {
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 28px;
+  padding: 0 5px;
+}
+.ProsemirrorEditor .ProseMirror-icon.ProseMirror-menu-active {
+  border-color: #bac2c7;
+}
+.ProsemirrorEditor .ProseMirror-icon.ProseMirror-menu-tableOption svg,
+.ProsemirrorEditor .ProseMirror-icon.ProseMirror-menu-insertEmoji svg {
+  padding-top: 1px;
+  padding-left: 1px;
+}
+.ProsemirrorEditor .ProseMirror-menu-disabled.ProseMirror-icon {
+  cursor: default;
+}
+.ProsemirrorEditor .ProseMirror-icon svg {
+  fill: currentColor;
+  height: 20px;
+}
+.ProsemirrorEditor .ProseMirror-icon span {
+  vertical-align: text-top;
+}
+.ProsemirrorEditor .ProseMirror-editor-source {
+  border: 2px solid #ededed;
+  border-radius: 0 4px 4px 4px;
+  box-sizing: border-box;
+  display: block;
+  min-height: 36px;
+  resize: none;
+  overflow: auto;
+  outline: none;
+  padding: 7px 12px;
+  width: 100%;
+}
+.ProsemirrorEditor .ProseMirror-editor-source:focus {
+  border: 2px solid #21A1B3;
+}
+/**
+ * Static plain editor style
+ */
+.ProsemirrorEditor.plainMenu .ProseMirror {
+  border-top-left-radius: 0 !important;
+  border-top-right-radius: 0 !important;
+  border-top-width: 1px !important;
+  min-height: 100px;
+}
+.ProsemirrorEditor.plainMenu .ProseMirror-menu-group,
+.ProsemirrorEditor.plainMenu .ProseMirror-menuitem .ProseMirror-menu-group {
+  padding: 2px;
+}
+.ProsemirrorEditor.plainMenu .ProseMirror-menubar ~ .ProseMirror-focused {
+  border-color: #21A1B3 !important;
+}
+.ProsemirrorEditor.plainMenu .ProseMirror-textblock-dropdown {
+  min-width: 3em;
+}
+.ProsemirrorEditor.plainMenu .ProseMirror-menubar-wrapper {
+  z-index: 8;
+}
+.ProsemirrorEditor.plainMenu .ProseMirror-menubar {
+  background: white;
+  border: 1px solid #d7d7d7;
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
+  box-sizing: border-box;
+  color: #555555;
+  position: relative;
+  min-height: 1em;
+  overflow: visible;
+  padding: 2px 0;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 10;
+}
+/**
+ * Editor style attached at the top of input only visible on focus
+ */
+.ProsemirrorEditor.focusMenu .form-control:focus {
+  border-top-left-radius: 0 !important;
+}
+.ProsemirrorEditor.focusMenu .ProseMirror-menubar {
+  background: white;
+  border: 1px solid #aeaeae;
+  border-bottom: 0;
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
+  box-sizing: border-box;
+  color: #555555;
+  float: left;
+  margin-top: -27px;
+  min-height: 1em;
+  overflow: visible;
+  padding: 2px 0;
+  position: relative;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 10;
+}
+.ProsemirrorEditor {
+  /* Make sure li selections wrap around markers */
+  /* Add space around the hr to make clicking it easier */
+  /* Give selected cells a blue overlay */
+}
+.ProsemirrorEditor .ProseMirror {
+  position: relative;
+  word-wrap: break-word;
+  white-space: pre-wrap;
+  font-variant-ligatures: none;
+}
+.ProsemirrorEditor .ProseMirror ul,
+.ProsemirrorEditor .ProseMirror ol {
+  cursor: default;
+}
+.ProsemirrorEditor .ProseMirror pre {
+  white-space: pre-wrap;
+}
+.ProsemirrorEditor .ProseMirror li {
+  position: relative;
+}
+.ProsemirrorEditor .ProseMirror img {
+  max-width: 100%;
+}
+.ProsemirrorEditor .ProseMirror-hideselection *::selection {
+  background: transparent;
+}
+.ProsemirrorEditor .ProseMirror-selectednode {
+  outline: 2px dashed #85dce8;
+}
+.ProsemirrorEditor li.ProseMirror-selectednode {
+  outline: none;
+}
+.ProsemirrorEditor li.ProseMirror-selectednode:after {
+  content: "";
+  position: absolute;
+  left: -32px;
+  right: -2px;
+  top: -2px;
+  bottom: -2px;
+  border: 2px solid #85dce8;
+  pointer-events: none;
+}
+.ProsemirrorEditor .ProseMirror-textblock-dropdown {
+  min-width: 3em;
+}
+.ProsemirrorEditor .ProseMirror-menu {
+  margin: 0 -4px;
+  line-height: 1;
+}
+.ProsemirrorEditor .ProseMirror-tooltip .ProseMirror-menu {
+  width: fit-content;
+  white-space: pre;
+}
+.ProsemirrorEditor .ProseMirror-gapcursor {
+  display: none;
+  pointer-events: none;
+  position: absolute;
+}
+.ProsemirrorEditor .ProseMirror-gapcursor:after {
+  content: "";
+  display: block;
+  position: absolute;
+  top: -2px;
+  width: 20px;
+  border-top: 1px solid black;
+  animation: ProseMirror-cursor-blink 1.1s steps(2, start) infinite;
+}
+@keyframes ProseMirror-cursor-blink {
+  to {
+    visibility: hidden;
+  }
+}
+.ProsemirrorEditor .ProseMirror-focused .ProseMirror-gapcursor {
+  display: block;
+}
+.ProsemirrorEditor .ProseMirror-example-setup-style hr {
+  padding: 2px 10px;
+  border: none;
+  margin: 1em 0;
+}
+.ProsemirrorEditor .ProseMirror-example-setup-style hr:after {
+  content: "";
+  display: block;
+  height: 1px;
+  background-color: silver;
+  line-height: 2px;
+}
+.ProsemirrorEditor .ProseMirror-example-setup-style img {
+  cursor: default;
+}
+.ProsemirrorEditor .ProseMirror p {
+  margin-top: 1.2em;
+}
+.ProsemirrorEditor .ProseMirror p:first-child {
+  margin: 0;
+}
+.ProsemirrorEditor .ProseMirror > p:first-child + * {
+  margin-top: 1.2em;
+}
+.ProsemirrorEditor .ProsemirrorEditor {
+  position: relative;
+}
+.ProsemirrorEditor .ProsemirrorEditor .ProseMirror {
+  padding-right: 12px !important;
+}
+.ProsemirrorEditor .ProsemirrorEditor img {
+  max-width: 100%;
+}
+.ProsemirrorEditor .ProseMirror h1:first-child,
+.ProsemirrorEditor .ProseMirror h2:first-child,
+.ProsemirrorEditor .ProseMirror h3:first-child,
+.ProsemirrorEditor .ProseMirror h4:first-child,
+.ProsemirrorEditor .ProseMirror h5:first-child,
+.ProsemirrorEditor .ProseMirror h6:first-child {
+  margin-top: 10px;
+}
+.ProsemirrorEditor .ProseMirror [data-mention] {
+  color: #21A1B3;
+}
+.ProsemirrorEditor .ProseMirror {
+  outline: none;
+}
+.ProsemirrorEditor .ProseMirror [data-oembed] {
+  font-size: 0;
+}
+.ProsemirrorEditor .ProseMirror iframe {
+  pointer-events: none;
+  display: block;
+}
+.ProsemirrorEditor .ProseMirror p {
+  margin-bottom: 1em;
+}
+.ProsemirrorEditor .ProseMirror-textblock-dropdown {
+  min-width: 3em;
+}
+.ProsemirrorEditor .ProseMirror .placeholder {
+  padding: 0 !important;
+  pointer-events: none;
+  height: 0;
+}
+.ProsemirrorEditor .ProseMirror:focus .placeholder {
+  display: none;
+}
+.ProsemirrorEditor .ProseMirror .tableWrapper {
+  overflow-x: auto;
+}
+.ProsemirrorEditor .ProseMirror .column-resize-handle {
+  background-color: #b0e8f0;
+  pointer-events: none;
+  position: absolute;
+  right: -2px;
+  top: 0;
+  bottom: 0;
+  width: 4px;
+  z-index: 20;
+}
+.ProsemirrorEditor .ProseMirror.resize-cursor {
+  cursor: ew-resize;
+  cursor: col-resize;
+}
+.ProsemirrorEditor .ProseMirror .selectedCell:after {
+  background: rgba(200, 255, 255, 0.4);
+  content: "";
+  pointer-events: none;
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  z-index: 2;
+}
+.ProsemirrorEditor .ProseMirror-menubar-wrapper {
+  position: relative;
+  outline: none;
+}
+.ProsemirrorEditor .ProseMirror table {
+  margin: 0;
+}
+.ProsemirrorEditor .ProseMirror .tableWrapper {
+  margin: 1em 0;
+}
+.ProseMirror-prompt {
+  background: white;
+  border: 1px solid silver;
+  border-radius: 3px;
+  box-shadow: -0.5px 2px 5px rgba(0, 0, 0, 0.2);
+  padding: 5px 10px 5px 15px;
+  position: fixed;
+  min-width: 300px;
+  z-index: 999999;
+}
+.ProseMirror-prompt h5 {
+  font-weight: bold;
+  font-size: 100%;
+  margin: 15px 0;
+}
+.ProseMirror-prompt input {
+  margin-bottom: 5px;
+}
+.ProseMirror-prompt-close {
+  background: transparent;
+  color: #555555;
+  padding: 0;
+  position: absolute;
+  left: 2px;
+  top: 1px;
+  border: none;
+}
+.ProseMirror-prompt-close:after {
+  content: "✕";
+  font-size: 12px;
+}
+.ProseMirror-invalid {
+  background: #fff4d3;
+  border: 1px solid #ffce3a;
+  border-radius: 4px;
+  padding: 5px 10px;
+  position: absolute;
+  min-width: 10em;
+}
+.ProseMirror-prompt-buttons {
+  margin: 15px 0;
+  text-align: center;
+}
+.atwho-view .cur {
+  border-left: 3px solid #85dce8;
+  background-color: #f8f8f8 !important;
+}
+.atwho-user,
+.atwho-space,
+.atwho-input a {
+  color: #21A1B3;
+}
+.atwho-input a:hover {
+  color: #21A1B3;
+}
+.atwho-view strong {
+  background-color: #fff4d3;
+}
+.atwho-view .cur strong {
+  background-color: #fff4d3;
+}
+[data-emoji-category] {
+  max-height: 200px;
+  display: block;
+  position: relative;
+  overflow: auto;
+}
+[data-emoji-category] .atwho-emoji-entry {
+  width: 24px;
+  height: 28px;
+  overflow: hidden;
+}
+[data-emoji-category] .atwho-emoji-entry.cur {
+  background-color: #ededed !important;
+}
+.emoji-nav {
+  padding-top: 10px;
+}
+.emoji-nav .emoji-nav-item {
+  border-top: 2px solid #daf0f3;
+}
+.emoji-nav .emoji-nav-item.cur {
+  border-left: 0;
+  border-top: 2px solid #21A1B3;
+}
+[data-ui-markdown],
+[data-ui-richtext] {
+  overflow-x: auto;
+  overflow-wrap: break-word;
+}
+[data-ui-markdown] a,
+[data-ui-richtext] a {
+  color: #21A1B3;
+}
+#wallStream [data-ui-markdown],
+#wallStream [data-ui-richtext] {
+  overflow-wrap: initial;
+  word-break: initial;
+  hyphens: initial;
+}
+@media screen and (max-width: 460px) {
+  .ProsemirrorEditor .ProseMirror-menu-dropdown-right {
+    right: 0;
+  }
+}
+@media screen and (max-width: 768px) {
+  .ProsemirrorEditor.focusMenu .form-control:focus {
+    border-top-right-radius: 0 !important;
+  }
+  .ProsemirrorEditor.focusMenu .ProseMirror-menubar {
+    min-height: 1em;
+    margin-top: 0;
+  }
+  .ProsemirrorEditor.focusMenu .humhub-ui-richtext {
+    margin-top: 0;
+  }
+}
+@media only screen and (max-width : 768px) {
+  body {
+    padding-top: 105px;
+  }
+  .modal-open #layout-content > .container {
+    overflow-x: unset;
+  }
+  #layout-content .left-navigation .list-group {
+    -webkit-overflow-scrolling: auto;
+    white-space: nowrap;
+    overflow-x: auto;
+  }
+  #layout-content .left-navigation .list-group::-webkit-scrollbar {
+    -webkit-appearance: none;
+  }
+  #layout-content .left-navigation .list-group::-webkit-scrollbar:vertical {
+    width: 8px;
+  }
+  #layout-content .left-navigation .list-group::-webkit-scrollbar:horizontal {
+    height: 8px;
+  }
+  #layout-content .left-navigation .list-group::-webkit-scrollbar-thumb {
+    background-color: rgba(0, 0, 0, 0.5);
+    border-radius: 10px;
+    border: 2px solid #ffffff;
+  }
+  #layout-content .left-navigation .list-group::-webkit-scrollbar-track {
+    border-radius: 10px;
+    background-color: #ffffff;
+  }
+  #layout-content .table-responsive::-webkit-scrollbar {
+    -webkit-appearance: none;
+  }
+  #layout-content .table-responsive::-webkit-scrollbar:vertical {
+    width: 8px;
+  }
+  #layout-content .table-responsive::-webkit-scrollbar:horizontal {
+    height: 8px;
+  }
+  #layout-content .table-responsive::-webkit-scrollbar-thumb {
+    background-color: rgba(0, 0, 0, 0.5);
+    border-radius: 10px;
+    border: 2px solid #ffffff;
+  }
+  #layout-content .table-responsive::-webkit-scrollbar-track {
+    border-radius: 10px;
+    background-color: #ffffff;
+  }
+  #layout-content .panel {
+    margin-bottom: 5px;
+  }
+  #layout-content .panel .statistics .entry {
+    margin-left: 10px;
+  }
+  #layout-content > .container {
+    padding-right: 2px !important;
+    padding-left: 2px !important;
+    overflow-x: hidden;
+  }
+  #layout-content .layout-nav-container .panel-heading {
+    display: none;
+  }
+  #layout-content .panel-profile-header #profilefileupload,
+  #layout-content .panel-profile-header .profile-user-photo-container,
+  #layout-content .panel-profile-header .space-acronym {
+    height: 100px !important;
+    width: 100px !important;
+  }
+  #layout-content .panel-profile-header .profile-user-photo {
+    height: 95px !important;
+    width: 95px !important;
+  }
+  #layout-content .image-upload-container .image-upload-buttons {
+    right: 2px !important;
+  }
+  #layout-content .space-acronym {
+    padding: 6px 0 !important;
+  }
+  #layout-content .panel-profile .panel-profile-header .img-profile-header-background {
+    min-height: 80px !important;
+  }
+  #layout-content .panel-profile .panel-profile-header .img-profile-data {
+    padding-top: 50px !important;
+    padding-left: 130px;
+  }
+  .modal-dialog {
+    width: calc(100vw - 4px) !important;
+    padding: 0 !important;
+    margin: 2px !important;
+  }
+  .dropdown-menu > li a,
+  .nav-pills .dropdown-menu li a,
+  .nav-tabs .dropdown-menu li a,
+  .account .dropdown-menu li a,
+  .modal .dropdown-menu li a,
+  .panel .dropdown-menu li a,
+  .nav-tabs .dropdown-menu li a {
+    padding-top: 10px;
+    padding-bottom: 10px;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+  }
+  .dropdown-menu {
+    max-width: 320px;
+  }
+  select.form-control:not([multiple]) {
+    padding-right: 23px;
+    width: auto;
+  }
+  .modal.in {
+    padding-right: 0 !important;
+  }
+  .load-suppressed {
+    margin-top: -8px;
+    margin-bottom: 5px;
+  }
+  .ProsemirrorEditor .ProseMirror-menuitem {
+    font-size: 1.2em !important;
+  }
+}
+.icon-sm,
+.fa-sm {
+  font-size: 0.875em;
+}
+.icon-lg,
+.fa-lg {
+  font-size: 1.33333em;
+  line-height: 0.75em;
+  vertical-align: -0.0667em;
+}
+.icon-2x,
+.fa-2x {
+  font-size: 2em;
+}
+.icon-3x,
+.fa-3x {
+  font-size: 3em;
+}
+.icon-4x,
+.fa-4x {
+  font-size: 4em;
+}
+.icon-5x,
+.fa-5x {
+  font-size: 5em;
+}
+.icon-6x,
+.fa-6x {
+  font-size: 6em;
+}
+.icon-7x,
+.fa-7x {
+  font-size: 7em;
+}
+.icon-9x,
+.fa-9x {
+  font-size: 9em;
+}
+.icon-10x,
+.fa-10x {
+  font-size: 10em;
+}
+@media print {
+  a[href]:after {
+    content: none;
+  }
+  body {
+    padding-top: 0;
+  }
+  pre,
+  blockquote {
+    page-break-inside: avoid;
+  }
+  .preferences,
+  .layout-sidebar-container,
+  .layout-nav-container,
+  button {
+    display: none !important;
+  }
+}
+@media (min-width: 500px) {
+  .container-cards.container-fluid .card {
+    width: 50%;
+  }
+}
+@media (min-width: 1000px) {
+  .container-cards.container-fluid .card {
+    width: 33.33333333%;
+  }
+}
+@media (min-width: 1300px) {
+  .container-cards.container-fluid .card {
+    width: 25%;
+  }
+}
+@media (min-width: 1600px) {
+  .container-cards.container-fluid .card {
+    width: 20%;
+  }
+}
+@media (min-width: 1900px) {
+  .container-cards.container-fluid .card {
+    width: 16.66666667%;
+  }
+}
+.container-cards .form-search .row > div {
+  padding-bottom: 3px;
+}
+.container-cards .form-search .form-search-filter-keyword {
+  position: relative;
+}
+.container-cards .form-search .form-search-filter-keyword .form-button-search {
+  position: absolute;
+  right: 18px;
+}
+.container-cards .form-search .form-control.form-search-filter {
+  width: 100%;
+  height: 40px;
+  margin: 3px 0 0;
+  padding: 8px 30px 10px 8px;
+  border-radius: 4px;
+  border: solid 1px #c5c5c5;
+}
+.container-cards .form-search .form-button-search {
+  background: none;
+  border: 0;
+  font-size: 16px;
+  color: #000;
+  top: initial;
+  bottom: 9px;
+}
+.container-cards .form-search .form-search-field-info {
+  font-size: 80%;
+}
+.container-cards .form-search-reset {
+  text-decoration: underline;
+  display: block;
+  margin-top: 26px;
+}
+.container-cards .form-search-reset:hover {
+  text-decoration: none;
+}
+.container-cards .form-search-filter-tags {
+  padding-top: 21px;
+}
+.container-cards .form-search-filter-tags button {
+  margin: 10px 10px 0 0;
+}
+.container-cards .form-search-filter-tags .btn {
+  padding-left: 16px;
+  padding-right: 16px;
+}
+.container-cards .form-search-filter-tags .btn:not(.active) {
+  padding: 3px 14px;
+}
+.container-cards .form-search-filter-tags .btn.btn-primary {
+  border: 1px solid #435f6f;
+}
+.container-cards .form-search-filter-tags .btn.btn-primary.active,
+.container-cards .form-search-filter-tags .btn.btn-primary:not(.active):hover {
+  background: #435f6f !important;
+  color: #FFF !important;
+}
+.container-cards .form-search-filter-tags .btn.btn-primary:not(.active) {
+  background: #FFF;
+  color: #435f6f !important;
+}
+.container-cards .directory-filters-footer {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  margin: 30px -10px -10px;
+  padding: 20px 5px;
+  color: #000;
+  border-radius: 0 0 4px 4px;
+  font-size: 14px;
+}
+.container-cards .directory-filters-footer.directory-filters-footer-warning {
+  background: #FFC107;
+}
+.container-cards .directory-filters-footer.directory-filters-footer-info {
+  background: #d9edf7;
+  border: 1px solid #bce8f1;
+}
+.container-cards .directory-filters-footer .filter-footer-icon {
+  font-size: 35px;
+  line-height: 25px;
+  text-align: center;
+  color: #435F6F;
+  background: #FFF;
+  height: 25px;
+  border-radius: 50%;
+  margin-right: 32px;
+  vertical-align: middle;
+}
+.container-cards .cards {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+}
+.container-cards .cards-no-results {
+  color: #000;
+  font-size: 16px;
+  line-height: 34px;
+}
+.container-cards .card {
+  display: flex;
+  flex-direction: row;
+}
+.container-cards .card .card-panel {
+  position: relative;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  margin: 15px 0;
+  border-radius: 4px;
+  background-color: #ffffff;
+}
+.container-cards .card .card-panel.card-archived {
+  filter: opacity(60%);
+}
+.container-cards .card .card-icons .fa {
+  color: #21A1B3;
+}
+.container-cards .card .card-icons .fa span {
+  font: 12px 'Open Sans', sans-serif;
+  font-weight: 600;
+}
+.container-cards .card .card-bg-image {
+  width: 100%;
+  height: 86px;
+  background-color: #cfcfcf;
+  background-size: cover;
+  background-position: center;
+  border-radius: 4px 4px 0 0;
+}
+.container-cards .card .card-status {
+  font-size: 13px;
+  font-weight: bold;
+  padding: 5px 12px;
+  color: #FFF;
+  min-height: 30px;
+  max-height: 30px;
+}
+.container-cards .card .card-status.card-status-professional {
+  background: #415F6E;
+}
+.container-cards .card .card-status.card-status-official,
+.container-cards .card .card-status.card-status-partner {
+  background: #90A1AA;
+}
+.container-cards .card .card-status.card-status-deprecated {
+  background: #EB0000;
+}
+.container-cards .card .card-status.card-status-featured {
+  background: #435f6f;
+}
+.container-cards .card .card-status.card-status-new {
+  background: #21A1B3;
+}
+.container-cards .card .card-header {
+  position: absolute;
+  padding: 16px;
+  display: table;
+  width: 100%;
+}
+.container-cards .card .card-header .card-image-wrapper {
+  display: table-cell;
+  width: 98px;
+}
+.container-cards .card .card-header .card-image-link {
+  display: inline-block;
+  border: 2px solid #fff;
+  border-radius: 6px;
+}
+.container-cards .card .card-header .card-status {
+  position: absolute;
+  right: 16px;
+  background: #435f6f;
+}
+.container-cards .card .card-header .card-icons {
+  display: table-cell;
+  padding: 0 0 2px 5px;
+  text-align: right;
+  vertical-align: bottom;
+  font-size: 16px;
+}
+.container-cards .card .card-header .card-icons .fa {
+  color: #21A1B3;
+}
+.container-cards .card .card-header .card-icons .fa.fa-mobile-phone {
+  font-size: 22px;
+  line-height: 15px;
+  position: relative;
+  top: 2px;
+}
+.container-cards .card .card-status-none + .card-header {
+  border-radius: 4px 4px 0 0;
+}
+.container-cards .card .card-body {
+  flex-grow: 1;
+  padding: 44px 16px 24px 16px;
+  overflow: auto;
+}
+.container-cards .card .card-body .card-title {
+  font-size: 16px;
+  font-weight: bold;
+  line-height: 24px;
+}
+.container-cards .card .card-body .card-details {
+  margin-top: 8px;
+  color: #57646c;
+}
+.container-cards .card .card-body .card-details a {
+  color: #21A1B3;
+  text-decoration: underline;
+}
+.container-cards .card .card-body .card-details a:hover {
+  text-decoration: none;
+}
+.container-cards .card .card-body .card-tags {
+  margin-top: 20px;
+}
+.container-cards .card .card-footer {
+  padding: 0 16px 20px;
+}
+.container-cards .card .card-footer a.btn {
+  float: left;
+  margin: 0 8px 4px 0;
+  white-space: normal;
+  hyphens: none;
+}
+.container-cards .card .card-footer a.btn:last-child {
+  margin-right: 0;
+}
+.container-cards .card .card-footer .btn-group a.btn {
+  margin-right: 0;
+}
+.container-modules .modules-type {
+  font-size: 16px;
+  font-weight: bold;
+  color: #000;
+  margin: 70px 0 40px;
+}
+.container-modules .row.cards {
+  margin-top: 40px;
+}
+.container-modules .card-module .card-panel {
+  background: none;
+  overflow: hidden;
+}
+.container-modules .card-module .card-panel > div:not(.card-status) {
+  background-color: #ffffff;
+}
+.container-modules .card-module .card-header {
+  position: relative;
+}
+.container-modules .card-module .card-body {
+  padding-top: 8px;
+  font-size: 13px;
+  color: #6C787E;
+}
+.container-modules .card-module .card-body > div {
+  padding-bottom: 8px;
+}
+.container-modules .card-module .card-body > div:last-child {
+  padding-bottom: 0;
+}
+.container-modules .card-module .card-title {
+  color: #000;
+}
+.container-modules .card-module .card-footer {
+  padding-bottom: 14px;
+}
+.container-modules .card-module .card-footer a.btn {
+  float: none;
+}
+.container-modules .card-module .card-footer.text-right a.btn {
+  margin-left: 8px;
+  margin-right: 0;
+}
+.container-modules .card-module .card-footer.text-right a.btn:first-child {
+  margin-left: 0;
+}
+.container-modules .marketplace-settings-dropdown {
+  float: right;
+  list-style: none;
+}
+.container-modules .marketplace-settings-dropdown .dropdown-toggle {
+  color: #02A1B1;
+  font-size: 22px;
+  line-height: 20px;
+  margin: 2px;
+}
+.container-modules .marketplace-settings-dropdown .dropdown-toggle:hover {
+  color: #1d8e9d;
+}
+@media (max-width: 460px) {
+  .container-modules .card {
+    width: 100%;
+  }
+}
+.container-content-modules {
+  width: 100%;
+  padding: 0 18px 5px 5px;
+}
+.container-content-modules h4 {
+  font-size: 16px;
+  color: #000;
+}
+.container-content-modules .card {
+  width: 100%;
+  padding-right: 3px;
+}
+.container-content-modules .card .card-panel {
+  margin-top: 3px;
+}
+@media (min-width: 460px) {
+  .container-content-modules .card {
+    width: 50%;
+  }
+}
+@media (min-width: 656px) {
+  .container-content-modules .card {
+    width: 33.33333333%;
+  }
+}
+@media (min-width: 768px) {
+  .container-content-modules {
+    padding: 0 12px 5px 0;
+  }
+}
+@media (min-width: 1200px) {
+  .container-content-modules .card {
+    width: 25%;
+  }
+}
+@media (min-width: 460px) {
+  .container-content-modules.container-content-modules-col-3 .card {
+    width: 50%;
+  }
+}
+@media (min-width: 656px) {
+  .container-content-modules.container-content-modules-col-3 .card {
+    width: 33.33333333%;
+  }
+}
+.container-create-space-modules.container-cards {
+  width: 100%;
+  padding: 0;
+}
+.container-create-space-modules.container-cards .row.cards {
+  margin-top: 0;
+}
+.container-create-space-modules.container-cards .card .card-panel > div {
+  background: #F5F5F5;
+}
+@media (min-width: 500px) {
+  .container-modules.container-fluid .container-module-updates .card {
+    width: 33.33333333%;
+  }
+}
+@media (min-width: 1000px) {
+  .container-modules.container-fluid .container-module-updates .card {
+    width: 25%;
+  }
+}
+@media (min-width: 1300px) {
+  .container-modules.container-fluid .container-module-updates .card {
+    width: 20%;
+  }
+}
+@media (min-width: 1600px) {
+  .container-modules.container-fluid .container-module-updates .card {
+    width: 16.66666667%;
+  }
+}
+@media (min-width: 1900px) {
+  .container-modules.container-fluid .container-module-updates .card {
+    width: 12.5%;
+  }
+}
+.container-module-updates {
+  background: #435f6f;
+  margin-top: 30px;
+  padding: 16px 10px 2px;
+  border-radius: 4px;
+}
+.container-module-updates .row.cards {
+  margin-right: -1px;
+  margin-top: 0;
+}
+.container-module-updates .modules-type {
+  color: #FFFFFF;
+  margin: 10px 0 30px;
+}
+.container-module-updates .card {
+  padding-right: 1px;
+}
+.container-module-updates .card .card-panel {
+  color: #FFF;
+  margin-top: 0;
+}
+.container-module-updates .card .card-panel > div:not(.card-status) {
+  background: #30444f;
+}
+.container-module-updates .card .card-panel .card-header {
+  padding: 12px;
+}
+.container-module-updates .card .card-panel .card-body {
+  padding: 4px 12px 20px;
+  color: #FFF;
+}
+.container-module-updates .card .card-panel .card-body .card-title {
+  color: #FFF;
+  font-size: 14px;
+}
+.container-module-updates .card .card-panel .card-footer {
+  padding: 0 12px 12px;
+}
+.container-module-updates .card .card-panel .card-footer .btn-info {
+  border-radius: 4px;
+  color: #435f6f !important;
+}
+.container-module-updates .card .card-panel .card-footer .btn-info.active {
+  border-color: #FFF;
+}
+.container-module-updates .card .card-panel .card-footer .btn-info:not(.active) {
+  padding: 0 4px;
+  border: 1px solid #FFF;
+  background: #30444f;
+  color: #FFF !important;
+}
+.container-module-updates .card .card-panel .card-footer .btn-info:not(.active):hover,
+.container-module-updates .card .card-panel .card-footer .btn-info:not(.active):active {
+  background: #435f6f !important;
+}
+.container-module-updates .card .card-panel .card-footer .btn-info[data-update-status=failed] {
+  border-color: #fc314f;
+}
+.modules-group {
+  margin-bottom: 25px;
+  padding: 6px;
+}
+.modules-group > strong {
+  display: block;
+  margin-bottom: 13px;
+}
+.modules-group .module-row {
+  border-top: 1px solid #ddd;
+  margin: 0 0 16px 0;
+}
+.modules-group .module-row > div {
+  padding-top: 16px;
+}
+.modules-group .module-row > div small {
+  color: #aeaeae;
+}
+.modules-group .module-row .module-icon {
+  text-align: center;
+  padding-left: 6px;
+}
+.modules-group .module-row .module-actions {
+  white-space: nowrap;
+  text-align: right;
+  padding-right: 0;
+}
+.modules-group .module-row .module-actions .btn:not(:first-child) {
+  margin-left: 14px;
+}
+.modules-updates-info {
+  border-radius: 3px;
+  border: 1px solid var(--border-color-warning);
+  background: var(--background-color-warning);
+  color: var(--text-color-warning);
+  padding: 14px 20px 14px 25px;
+  margin: 20px 10px 10px;
+  font-size: 11px;
+  line-height: 20px;
+}
+.modules-updates-info strong {
+  font-size: 13px;
+}
+.modules-updates-info .btn {
+  margin-top: 8px;
+}
+/*! Select2 humhub Theme v0.1.0-beta.4 | MIT License | github.com/select2/select2-humhub-theme */
+.select2-container--humhub {
+  display: block;
+  /*------------------------------------*\
+            #COMMON STYLES
+    \*------------------------------------*/
+  /**
+     * Search field in the Select2 dropdown.
+     */
+  /**
+     * No outline for all search fields - in the dropdown
+     * and inline in multi Select2s.
+     */
+  /**
+     * Adjust Select2's choices hover and selected styles to match
+     * humhub 3's default dropdown styles.
+     *
+     * @see http://gethumhub.com/components/#dropdowns
+     */
+  /**
+     * Clear the selection.
+     */
+  /**
+     * Address disabled Select2 styles.
+     *
+     * @see https://select2.github.io/examples.html#disabled
+     * @see http://gethumhub.com/css/#forms-control-disabled
+     */
+  /*------------------------------------*\
+            #DROPDOWN
+    \*------------------------------------*/
+  /**
+     * Dropdown border color and box-shadow.
+     */
+  /**
+     * Limit the dropdown height.
+     */
+  /*------------------------------------*\
+            #SINGLE SELECT2
+    \*------------------------------------*/
+  /*------------------------------------*\
+        #MULTIPLE SELECT2
+    \*------------------------------------*/
+  /**
+     * Address humhub control sizing classes
+     *
+     * 1. Reset humhub defaults.
+     * 2. Adjust the dropdown arrow button icon position.
+     *
+     * @see http://gethumhub.com/css/#forms-control-sizes
+     */
+  /* 1 */
+  /*------------------------------------*\
+        #RTL SUPPORT
+    \*------------------------------------*/
+}
+.select2-container--humhub .select2-selection {
+  background-color: #fff;
+  border: 2px solid #ededed;
+  border-radius: 4px;
+  color: #555555;
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-size: 14px;
+  outline: 0;
+  min-height: 35px;
+}
+.select2-container--humhub .select2-search--dropdown .select2-search__field {
+  background-color: #fff;
+  border: 2px solid #ededed;
+  border-radius: 4px;
+  color: #555555;
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-size: 14px;
+}
+.select2-container--humhub .select2-search__field {
+  outline: 0;
+}
+.select2-container--humhub .select2-search__field::placeholder {
+  color: #999;
+  font-weight: normal;
+}
+.select2-container--humhub .select2-results__option {
+  /**
+         * Disabled results.
+         *
+         * @see https://select2.github.io/examples.html#disabled-results
+         */
+  /**
+         * Hover state.
+         */
+  /**
+         * Selected state.
+         */
+}
+.select2-container--humhub .select2-results__option[role=group] {
+  padding: 0;
+}
+.select2-container--humhub .select2-results__option[aria-disabled=true] {
+  color: #777777;
+  cursor: not-allowed;
+}
+.select2-container--humhub .select2-results__option[aria-selected=true] {
+  background-color: #f5f5f5;
+  color: #262626;
+  border-left: 3px solid transparent;
+}
+.select2-container--humhub .select2-results__option[aria-selected=false] {
+  border-left: 3px solid transparent;
+}
+.select2-container--humhub .select2-results__option--highlighted[aria-selected] {
+  background-color: #f8f8f8;
+  border-left: 3px solid #21A1B3;
+  color: #000;
+}
+.select2-container--humhub .select2-results__option .select2-results__option {
+  padding: 6px 12px;
+}
+.select2-container--humhub .select2-results__option .select2-results__option .select2-results__group {
+  padding-left: 0;
+}
+.select2-container--humhub .select2-results__option .select2-results__option .select2-results__option {
+  margin-left: -12px;
+  padding-left: 24px;
+}
+.select2-container--humhub .select2-results__option .select2-results__option .select2-results__option .select2-results__option {
+  margin-left: -24px;
+  padding-left: 36px;
+}
+.select2-container--humhub .select2-results__option .select2-results__option .select2-results__option .select2-results__option .select2-results__option {
+  margin-left: -36px;
+  padding-left: 48px;
+}
+.select2-container--humhub .select2-results__option .select2-results__option .select2-results__option .select2-results__option .select2-results__option .select2-results__option {
+  margin-left: -48px;
+  padding-left: 60px;
+}
+.select2-container--humhub .select2-results__option .select2-results__option .select2-results__option .select2-results__option .select2-results__option .select2-results__option .select2-results__option {
+  margin-left: -60px;
+  padding-left: 72px;
+}
+.select2-container--humhub .select2-results__group {
+  color: #777777;
+  display: block;
+  padding: 6px 12px;
+  font-size: 12px;
+  line-height: 1.42857143;
+  white-space: nowrap;
+}
+.select2-container--humhub.select2-container--focus .select2-selection,
+.select2-container--humhub.select2-container--open .select2-selection {
+  border: 2px solid #21A1B3;
+  outline: 0;
+  box-shadow: none;
+}
+.select2-container--humhub.select2-container--open {
+  /**
+         * Make the dropdown arrow point up while the dropdown is visible.
+         */
+  /**
+         * Handle border radii of the container when the dropdown is showing.
+         */
+}
+.select2-container--humhub.select2-container--open .select2-selection .select2-selection__arrow b {
+  border-color: transparent transparent #999 transparent;
+  border-width: 0 4px 4px 4px;
+}
+.select2-container--humhub .select2-selection__clear {
+  color: #999;
+  cursor: pointer;
+  float: right;
+  font-weight: bold;
+  margin-right: 10px;
+}
+.select2-container--humhub .select2-selection__clear:hover {
+  color: #333;
+}
+.select2-container--humhub.select2-container--disabled .select2-selection {
+  border-color: #ccc;
+  -webkit-box-shadow: none;
+  box-shadow: none;
+}
+.select2-container--humhub.select2-container--disabled .select2-selection,
+.select2-container--humhub.select2-container--disabled .select2-search__field {
+  cursor: not-allowed;
+}
+.select2-container--humhub.select2-container--disabled .select2-selection,
+.select2-container--humhub.select2-container--disabled .select2-selection--multiple .select2-selection__choice {
+  background-color: #eeeeee;
+}
+.select2-container--humhub.select2-container--disabled .select2-selection__clear,
+.select2-container--humhub.select2-container--disabled .select2-selection--multiple .select2-selection__choice__remove {
+  display: none;
+}
+.select2-container--humhub .select2-dropdown {
+  -webkit-box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
+  border-color: #d7d7d7;
+  overflow-x: hidden;
+  margin-top: -1px;
+}
+.select2-container--humhub .select2-dropdown--above {
+  margin-top: 1px;
+}
+.select2-container--humhub .select2-results > .select2-results__options {
+  max-height: 400px;
+  overflow-y: auto;
+}
+.select2-container--humhub .select2-selection--single {
+  height: 34px;
+  line-height: 1.42857143;
+  padding: 6px 24px 6px 12px;
+  /**
+         * Adjust the single Select2's dropdown arrow button appearance.
+         */
+}
+.select2-container--humhub .select2-selection--single .select2-selection__arrow {
+  position: absolute;
+  bottom: 0;
+  right: 12px;
+  top: 0;
+  width: 4px;
+}
+.select2-container--humhub .select2-selection--single .select2-selection__arrow b {
+  border-color: #999 transparent transparent transparent;
+  border-style: solid;
+  border-width: 4px 4px 0 4px;
+  height: 0;
+  left: 0;
+  margin-left: -4px;
+  margin-top: -4px/2;
+  position: absolute;
+  top: 50%;
+  width: 0;
+}
+.select2-container--humhub .select2-selection--single .select2-selection__rendered {
+  color: #555555;
+  padding: 0;
+}
+.select2-container--humhub .select2-selection--single .select2-selection__placeholder {
+  color: #999;
+}
+.select2-container--humhub .select2-selection--multiple {
+  min-height: 34px;
+  padding: 2px;
+  /**
+         * Make Multi Select2's choices match humhub 3's default button styles.
+         */
+  /**
+         * Minus 2px borders.
+         */
+  /**
+         * Clear the selection.
+         */
+}
+.select2-container--humhub .select2-selection--multiple .select2-selection__rendered {
+  box-sizing: border-box;
+  display: block;
+  line-height: 1.42857143;
+  list-style: none;
+  margin: 0;
+  overflow: hidden;
+  padding: 0;
+  width: 100%;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.select2-container--humhub .select2-selection--multiple .select2-selection__placeholder {
+  color: #999;
+  float: left;
+  margin-top: 5px;
+}
+.select2-container--humhub .select2-selection--multiple .select2-selection__choice {
+  color: #555555;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0 6px;
+  background-color: #21A1B3;
+  color: #fff;
+  border-radius: 3px;
+  font-size: 12px !important;
+  padding: 0 5px 2px 2px;
+  float: left;
+  margin: 2px;
+  height: 28px;
+}
+.select2-container--humhub .select2-selection--multiple .select2-selection__choice img,
+.select2-container--humhub .select2-selection--multiple .select2-selection__choice div {
+  margin-right: 5px;
+}
+.select2-container--humhub .select2-selection--multiple .select2-selection__choice span.no-image {
+  line-height: 27px;
+  padding-left: 5px;
+}
+.select2-container--humhub .select2-selection--multiple .select2-selection__choice i {
+  margin: 0px 2px;
+  line-height: 27px;
+}
+.select2-container--humhub .select2-selection--multiple .select2-selection__choice .picker-close {
+  cursor: pointer;
+}
+.select2-container--humhub .select2-selection--multiple .select2-search--inline .select2-search__field {
+  background: transparent;
+  padding: 0 5px;
+  width: auto !important;
+  height: 32px;
+  line-height: 1.42857143;
+  margin-top: 0;
+  min-width: 5em;
+}
+.select2-container--humhub .select2-selection--multiple .select2-selection__choice__remove {
+  color: #999;
+  cursor: pointer;
+  display: none;
+  font-weight: bold;
+  margin-right: 6px / 2;
+}
+.select2-container--humhub .select2-selection--multiple .select2-selection__choice__remove:hover {
+  color: #333;
+}
+.select2-container--humhub .select2-selection--multiple .select2-selection__clear {
+  margin-top: 6px;
+}
+.select2-container--humhub.input-sm,
+.select2-container--humhub.input-lg {
+  border-radius: 0;
+  font-size: 12px;
+  height: auto;
+  line-height: 1;
+  padding: 0;
+}
+.select2-container--humhub.input-sm .select2-selection--single,
+.input-group-sm .select2-container--humhub .select2-selection--single,
+.form-group-sm .select2-container--humhub .select2-selection--single {
+  border-radius: 3px;
+  font-size: 12px;
+  height: 30px;
+  line-height: 1.5;
+  padding: 5px 22px 5px 10px;
+  /* 2 */
+}
+.select2-container--humhub.input-sm .select2-selection--single .select2-selection__arrow b,
+.input-group-sm .select2-container--humhub .select2-selection--single .select2-selection__arrow b,
+.form-group-sm .select2-container--humhub .select2-selection--single .select2-selection__arrow b {
+  margin-left: -5px;
+}
+.select2-container--humhub.input-sm .select2-selection--multiple,
+.input-group-sm .select2-container--humhub .select2-selection--multiple,
+.form-group-sm .select2-container--humhub .select2-selection--multiple {
+  min-height: 30px;
+}
+.select2-container--humhub.input-sm .select2-selection--multiple .select2-selection__choice,
+.input-group-sm .select2-container--humhub .select2-selection--multiple .select2-selection__choice,
+.form-group-sm .select2-container--humhub .select2-selection--multiple .select2-selection__choice {
+  font-size: 12px;
+  line-height: 1.5;
+  margin: 4px 0 0 10px/2;
+  padding: 0 5px;
+}
+.select2-container--humhub.input-sm .select2-selection--multiple .select2-search--inline .select2-search__field,
+.input-group-sm .select2-container--humhub .select2-selection--multiple .select2-search--inline .select2-search__field,
+.form-group-sm .select2-container--humhub .select2-selection--multiple .select2-search--inline .select2-search__field {
+  padding: 0 10px;
+  font-size: 12px;
+  height: 28px;
+  line-height: 1.5;
+}
+.select2-container--humhub.input-sm .select2-selection--multiple .select2-selection__clear,
+.input-group-sm .select2-container--humhub .select2-selection--multiple .select2-selection__clear,
+.form-group-sm .select2-container--humhub .select2-selection--multiple .select2-selection__clear {
+  margin-top: 5px;
+}
+.select2-container--humhub.input-lg .select2-selection--single,
+.input-group-lg .select2-container--humhub .select2-selection--single,
+.form-group-lg .select2-container--humhub .select2-selection--single {
+  border-radius: 6px;
+  font-size: 18px;
+  height: 46px;
+  line-height: 1.3333333;
+  padding: 10px 31px 10px 16px;
+  /* 1 */
+}
+.select2-container--humhub.input-lg .select2-selection--single .select2-selection__arrow,
+.input-group-lg .select2-container--humhub .select2-selection--single .select2-selection__arrow,
+.form-group-lg .select2-container--humhub .select2-selection--single .select2-selection__arrow {
+  width: 5px;
+}
+.select2-container--humhub.input-lg .select2-selection--single .select2-selection__arrow b,
+.input-group-lg .select2-container--humhub .select2-selection--single .select2-selection__arrow b,
+.form-group-lg .select2-container--humhub .select2-selection--single .select2-selection__arrow b {
+  border-width: 5px 5px 0 5px;
+  margin-left: -5px;
+  margin-left: -10px;
+  margin-top: -5px/2;
+}
+.select2-container--humhub.input-lg .select2-selection--multiple,
+.input-group-lg .select2-container--humhub .select2-selection--multiple,
+.form-group-lg .select2-container--humhub .select2-selection--multiple {
+  min-height: 46px;
+}
+.select2-container--humhub.input-lg .select2-selection--multiple .select2-selection__choice,
+.input-group-lg .select2-container--humhub .select2-selection--multiple .select2-selection__choice,
+.form-group-lg .select2-container--humhub .select2-selection--multiple .select2-selection__choice {
+  font-size: 18px;
+  line-height: 1.3333333;
+  border-radius: 4px;
+  margin: 9px 0 0 16px/2;
+  padding: 0 10px;
+}
+.select2-container--humhub.input-lg .select2-selection--multiple .select2-search--inline .select2-search__field,
+.input-group-lg .select2-container--humhub .select2-selection--multiple .select2-search--inline .select2-search__field,
+.form-group-lg .select2-container--humhub .select2-selection--multiple .select2-search--inline .select2-search__field {
+  padding: 0 16px;
+  font-size: 18px;
+  height: 44px;
+  line-height: 1.3333333;
+}
+.select2-container--humhub.input-lg .select2-selection--multiple .select2-selection__clear,
+.input-group-lg .select2-container--humhub .select2-selection--multiple .select2-selection__clear,
+.form-group-lg .select2-container--humhub .select2-selection--multiple .select2-selection__clear {
+  margin-top: 10px;
+}
+.select2-container--humhub.input-lg.select2-container--open .select2-selection--single {
+  /**
+         * Make the dropdown arrow point up while the dropdown is visible.
+         */
+}
+.select2-container--humhub.input-lg.select2-container--open .select2-selection--single .select2-selection__arrow b {
+  border-color: transparent transparent #999 transparent;
+  border-width: 0 5px 5px 5px;
+}
+.input-group-lg .select2-container--humhub.select2-container--open .select2-selection--single {
+  /**
+         * Make the dropdown arrow point up while the dropdown is visible.
+         */
+}
+.input-group-lg .select2-container--humhub.select2-container--open .select2-selection--single .select2-selection__arrow b {
+  border-color: transparent transparent #999 transparent;
+  border-width: 0 5px 5px 5px;
+}
+.select2-container--humhub[dir="rtl"] {
+  /**
+         * Single Select2
+         *
+         * 1. Makes sure that .select2-selection__placeholder is positioned
+         *    correctly.
+         */
+  /**
+         * Multiple Select2
+         */
+}
+.select2-container--humhub[dir="rtl"] .select2-selection--single {
+  padding-left: 24px;
+  padding-right: 12px;
+}
+.select2-container--humhub[dir="rtl"] .select2-selection--single .select2-selection__rendered {
+  padding-right: 0;
+  padding-left: 0;
+  text-align: right;
+  /* 1 */
+}
+.select2-container--humhub[dir="rtl"] .select2-selection--single .select2-selection__clear {
+  float: left;
+}
+.select2-container--humhub[dir="rtl"] .select2-selection--single .select2-selection__arrow {
+  left: 12px;
+  right: auto;
+}
+.select2-container--humhub[dir="rtl"] .select2-selection--single .select2-selection__arrow b {
+  margin-left: 0;
+}
+.select2-container--humhub[dir="rtl"] .select2-selection--multiple .select2-selection__choice,
+.select2-container--humhub[dir="rtl"] .select2-selection--multiple .select2-selection__placeholder {
+  float: right;
+}
+.select2-container--humhub[dir="rtl"] .select2-selection--multiple .select2-selection__choice {
+  margin-left: 0;
+  margin-right: 12px/2;
+}
+.select2-container--humhub[dir="rtl"] .select2-selection--multiple .select2-selection__choice__remove {
+  margin-left: 2px;
+  margin-right: auto;
+}
+/*------------------------------------*\
+    #ADDITIONAL GOODIES
+\*------------------------------------*/
+/**
+ * Address humhub's validation states
+ *
+ * If a Select2 widget parent has one of humhub's validation state modifier
+ * classes, adjust Select2's border colors and focus states accordingly.
+ * You may apply said classes to the Select2 dropdown (body > .select2-container)
+ * via JavaScript match humhubs' to make its styles match.
+ *
+ * @see http://gethumhub.com/css/#forms-control-validation
+ */
+.has-warning .select2-dropdown,
+.has-warning .select2-selection {
+  border-color: #FFC107;
+}
+.has-warning .select2-container--focus .select2-selection,
+.has-warning .select2-container--open .select2-selection {
+  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #ffdb6d;
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #ffdb6d;
+  border-color: #d39e00;
+}
+.has-warning.select2-drop-active {
+  border-color: #d39e00;
+}
+.has-warning.select2-drop-active.select2-drop.select2-drop-above {
+  border-top-color: #d39e00;
+}
+.has-error .select2-dropdown,
+.has-error .select2-selection {
+  border-color: #FC4A64;
+}
+.has-error .select2-container--focus .select2-selection,
+.has-error .select2-container--open .select2-selection {
+  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #feaeba;
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #feaeba;
+  border-color: #fb1839;
+}
+.has-error.select2-drop-active {
+  border-color: #fb1839;
+}
+.has-error.select2-drop-active.select2-drop.select2-drop-above {
+  border-top-color: #fb1839;
+}
+.has-success .select2-dropdown,
+.has-success .select2-selection {
+  border-color: #97d271;
+}
+.has-success .select2-container--focus .select2-selection,
+.has-success .select2-container--open .select2-selection {
+  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #d0ebbe;
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #d0ebbe;
+  border-color: #7bc64a;
+}
+.has-success.select2-drop-active {
+  border-color: #7bc64a;
+}
+.has-success.select2-drop-active.select2-drop.select2-drop-above {
+  border-top-color: #7bc64a;
+}
+/**
+ * Select2 widgets in humhub Input Groups
+ *
+ * When Select2 widgets are combined with other elements using humhubs
+ * "Input Group" component, we don't want specific edges of the Select2
+ * container to have a border-radius.
+ *
+ * Use .select2-humhub-prepend and .select2-humhub-append on
+ * a humhub 3 .input-group to let the contained Select2 widget know which
+ * edges should not be rounded as they are directly followed by another element.
+ *
+ * @see http://gethumhub.com/components/#input-groups
+ */
+/**
+ * Mimick humhubs .input-group .form-control styles.
+ *
+ * @see https://github.com/twbs/humhub/blob/master/less/input-groups.less
+ */
+.input-group .select2-container--humhub {
+  display: table;
+  table-layout: fixed;
+  position: relative;
+  z-index: 2;
+  float: left;
+  width: 100%;
+  margin-bottom: 0;
+}
+.input-group.select2-humhub-prepend .select2-container--humhub .select2-selection {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+.input-group.select2-humhub-append .select2-container--humhub .select2-selection {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+/**
+ * Adjust alignment of humhub buttons in humhub Input Groups to address
+ * Multi Select2's height which - depending on how many elements have been selected -
+ * may grow taller than its initial size.
+ *
+ * @see http://gethumhub.com/components/#input-groups
+ */
+.select2-humhub-append .select2-container--humhub,
+.select2-humhub-prepend .select2-container--humhub,
+.select2-humhub-append .input-group-btn,
+.select2-humhub-prepend .input-group-btn,
+.select2-humhub-append .input-group-btn .btn,
+.select2-humhub-prepend .input-group-btn .btn {
+  vertical-align: top;
+}
+/**
+ * Temporary fix for https://github.com/select2/select2-humhub-theme/issues/9
+ *
+ * Provides `!important` for certain properties of the class applied to the
+ * original `<select>` element to hide it.
+ *
+ * @see https://github.com/select2/select2/pull/3301
+ * @see https://github.com/fk/select2/commit/31830c7b32cb3d8e1b12d5b434dee40a6e753ada
+ */
+.form-control.select2-hidden-accessible {
+  position: absolute !important;
+  width: 1px !important;
+}
+/**
+ * Display override for inline forms
+*/
+.form-inline .select2-container--humhub {
+  display: inline-block;
+}
+ul.tag_input {
+  list-style: none;
+  background-color: #fff;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+  -webkit-transition: border-color ease-in-out 0.15s, box-shadow ease-in-out 0.15s;
+  transition: border-color ease-in-out 0.15s, box-shadow ease-in-out 0.15s;
+  padding: 0 0 9px 4px;
+}
+ul.tag_input li img {
+  margin: 0 5px 0 0;
+}
+.tag_input_field {
+  outline: none;
+  border: none !important;
+  padding: 5px 4px 0 !important;
+  width: 170px;
+  margin: 2px 0 0 !important;
+}
+.userInput,
+.spaceInput {
+  background-color: #21A1B3;
+  font-weight: 600;
+  color: #fff;
+  border-radius: 3px;
+  font-size: 12px !important;
+  padding: 2px;
+  float: left;
+  margin: 3px 4px 0 0;
+}
+.userInput i,
+.spaceInput i {
+  padding: 0 6px;
+  font-size: 14px;
+  cursor: pointer;
+  line-height: 8px;
+}
+/**
+ * Define or overwrite your theme variables here.
+ *
+ * Check for @humhub/static/less/variables.less file for all available variables.
+ * 
+ * You can also access your variables within your view files by calling Yii::$app->view->theme->variable('myVariable');
+ *
+ * You can disable the import of humhub theme components by using variables of the format @prev-{component} e.g.:
+ * This will prevent comment.less component from beeing imported.
+ * e.g.:
+ * @prev-comment: true;
+ *
+**/
+/**
+ * Define your mixins within this file.
+**/
+/**
+ * Define or overwrite your theme selectors within this file.
+**/


### PR DESCRIPTION
Since #6457 was only a partial solution for https://github.com/humhub/humhub/pull/6375 as it

1. uses a non-standard name for `findMembership` and
1. deletes the cache only when memberships are updated, and
1. does the latter in an insufficient way (ignores both [`deleteAll()` and `saveAll()`](https://github.com/humhub/humhub/pull/6457#issuecomment-1650977793) and [linked content](https://github.com/humhub/humhub/pull/6457#issuecomment-1655336797)),

there is an improved attempt in #6463 to address this in a broader way, and ultimately #6482, which addresses some more issues.

To break #6463 down, I've created this PR for review, and I've submitted towards the `statable` branch, as #6430 also bilds on top of #6463. Once, #6463 is merged in `statable` too, both can be merged int `develop`, which I recommend to happen before v1.15 is released.

**What kind of change does this PR introduce?**

- Bugfix
- Feature
- Refactor

**Does this PR introduce a breaking change?**

- No. However, module developers SHOULD adapt to use the new implementation of `findInstance`, rather than `findOne` where the searched object is only identified by either `id` or `guid` (see additional examples in #6463).

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [x] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [ ] All tests are passing
- [x] New/updated tests are included
- [x] Changelog was modified
