### PR TITLE
Enh: Add Application interface and make sure the `onInit` event is fi…

### DIFF
--- a/CHANGELOG-DEV.md
+++ b/CHANGELOG-DEV.md
@@ -3,6 +3,7 @@ HumHub Changelog
 
 1.15.0-beta.2 (Unreleased)
 --------------------------
+- Enh #6505: Introduce Application interface; now also fire the `onInit` event when the web application has initialized
 - Fix #6502: Link notification for pending space approval to manage page
 - Fix #6472: Initialization of account profile field type "Markdown"
 - Fix #6471: Wording "Default Homepage" in Space Default Settings

--- a/protected/humhub/components/Application.php
+++ b/protected/humhub/components/Application.php
@@ -15,7 +15,7 @@ use yii\base\Exception;
 /**
  * @inheritdoc
  */
-class Application extends \yii\web\Application
+class Application extends \yii\web\Application implements \humhub\interfaces\Application
 {
 
     /**
@@ -63,6 +63,7 @@ class Application extends \yii\web\Application
         }
 
         parent::init();
+        $this->trigger(self::EVENT_ON_INIT);
     }
 
     /**

--- a/protected/humhub/components/console/Application.php
+++ b/protected/humhub/components/console/Application.php
@@ -18,14 +18,8 @@ use yii\helpers\Url;
  *
  * @author luke
  */
-class Application extends \yii\console\Application
+class Application extends \yii\console\Application implements \humhub\interfaces\Application
 {
-
-    /**
-     * @event ActionEvent an event raised on init of application.
-     */
-    const EVENT_ON_INIT = 'onInit';
-
     /**
      * @var string|array the homepage url
      */

--- a/protected/humhub/config/__autocomplete.php
+++ b/protected/humhub/config/__autocomplete.php
@@ -13,7 +13,7 @@
  */
 class Yii {
     /**
-     * @var \yii\web\Application|\yii\console\Application|\humhub\components\Application|__Application|__WebApplication
+     * @var \yii\web\Application|\yii\console\Application|\humhub\components\Application|\humhub\components\console\Application|\humhub\interfaces\Application|__Application|__WebApplication
      */
     public static $app;
 }

--- a/protected/humhub/interfaces/Application.php
+++ b/protected/humhub/interfaces/Application.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * @link      https://www.humhub.org/
+ * @copyright Copyright (c) 2023 HumHub GmbH & Co. KG
+ * @license   https://www.humhub.com/licences
+ */
+
+namespace humhub\interfaces;
+
+/**
+ * Description of Application
+ *
+ * @since 1.15
+ */
+interface Application
+{
+    /**
+     * @event ActionEvent an event raised on init of application.
+     */
+    public const EVENT_ON_INIT = 'onInit';
+}


### PR DESCRIPTION
**What kind of change does this PR introduce?**
- Bugfix
- Feature
- Refactor

**Does this PR introduce a breaking change?**

- No

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [x] [All tests are passing](#issuecomment-new)
- [x] No new/updated tests are required
- [x] Changelog was modified

**Other information:**

It does not make sense that the event `onInit` is only called in the console app, but not the web app. This PR fixes this issue and introduces a common interface for `\humhub\components\Application` and `\humhub\components\console\Application` in order to use `\humhub\components\console\Application::class` as a unified event class, that can still distinct from a module used in an other yii2 application environment.
