### PR TITLE
Enh: allow event data from config

### DIFF
--- a/CHANGELOG-DEV.md
+++ b/CHANGELOG-DEV.md
@@ -3,6 +3,7 @@ HumHub Changelog
 
 1.15.0-beta.2 (Unreleased)
 --------------------------
+- Enh #6506: Allow event data from module config
 - Fix #6502: Link notification for pending space approval to manage page
 - Fix #6472: Initialization of account profile field type "Markdown"
 - Fix #6471: Wording "Default Homepage" in Space Default Settings

--- a/protected/humhub/components/ModuleManager.php
+++ b/protected/humhub/components/ModuleManager.php
@@ -218,8 +218,10 @@ class ModuleManager extends Component
                 $eventClass = $event['class'] ?? $event[0];
                 $eventName = $event['event'] ?? $event[1];
                 $eventHandler = $event['callback'] ?? $event[2];
+                $eventData = $event['data'] ?? $event[3] ?? null;
+                $eventAppend = filter_var($event['append'] ?? $event[4] ?? true, FILTER_VALIDATE_BOOLEAN);
                 if (method_exists($eventHandler[0], $eventHandler[1])) {
-                    Event::on($eventClass, $eventName, $eventHandler);
+                    Event::on($eventClass, $eventName, $eventHandler, $eventData, $eventAppend);
                 }
             }
         }


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Feature

**Does this PR introduce a breaking change?**

- No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [x] [All tests are passing](#issuecomment-new)
- [ ] New/updated tests are included
- [x] Changelog was modified

If adding a **new feature**, the PR's description includes:

This change allows additional data to be provided to the event handler based on the configuration of the event.

**Other information:**

From an efficiency stand point, the following lines should be moved into the `if` block, with the exception of the extraction of the `$eventHandler`, of course:

https://github.com/humhub/humhub/commit/4a5951988969a0d2b9765867df7f4cdf088c3e82#diff-46a3b644fa0848e9b9ff89b55e78b267182b69d39cea2f61870c54d37d0a78a5R218-R222

I've not done that, however, in order to keep the code slightly more readable. Happy to move them though.
