### PR TITLE
Enh: Attempt to show better error messages when DB-Connection is invalid

### DIFF
--- a/CHANGELOG-DEV.md
+++ b/CHANGELOG-DEV.md
@@ -1,6 +1,10 @@
 HumHub Changelog
 ================
 
+1.16.0 (Unreleased)
+--------------------------
+- Enh #6512: Show error messages when DB connection configuration is invalid
+
 1.15.0-beta.2 (Unreleased)
 --------------------------
 - Enh #6478: Add pseudo test class to allow population of DB with standard test data

--- a/index.php
+++ b/index.php
@@ -7,6 +7,8 @@
  */
 
 // comment out the following two lines when deployed to production
+use humhub\helpers\DatabaseHelper;
+
 defined('YII_DEBUG') or define('YII_DEBUG', true);
 defined('YII_ENV') or define('YII_ENV', 'dev');
 
@@ -22,4 +24,10 @@ $config = yii\helpers\ArrayHelper::merge(
     require(__DIR__ . '/protected/config/web.php')
 );
 
-(new humhub\components\Application($config))->run();
+try {
+    (new humhub\components\Application($config))->run();
+} catch (\Throwable $ex) {
+    if (null === DatabaseHelper::handleConnectionErrors($ex)) {
+        throw $ex;
+    }
+}

--- a/protected/humhub/commands/MigrateController.php
+++ b/protected/humhub/commands/MigrateController.php
@@ -9,6 +9,7 @@
 namespace humhub\commands;
 
 use humhub\components\Module;
+use humhub\helpers\DatabaseHelper;
 use Yii;
 use yii\console\Exception;
 use yii\web\Application;
@@ -78,9 +79,17 @@ class MigrateController extends \yii\console\controllers\MigrateController
      */
     public function beforeAction($action)
     {
-        // Make sure to define default table storage engine
-        if (in_array(Yii::$app->db->getDriverName(), ['mysql', 'mysqli'], true)) {
-            Yii::$app->db->pdo->exec('SET default_storage_engine=' . Yii::$app->params['databaseDefaultStorageEngine']);
+        // Make sure to define a default table storage engine
+        $db = Yii::$app->db;
+
+        try {
+            $db->open();
+        } catch (\Throwable $ex) {
+            DatabaseHelper::handleConnectionErrors($ex);
+        }
+
+        if (in_array($db->getDriverName(), ['mysql', 'mysqli'], true)) {
+            $db->pdo->exec('SET default_storage_engine=' . Yii::$app->params['databaseDefaultStorageEngine']);
         }
         return parent::beforeAction($action);
     }

--- a/protected/humhub/components/console/Application.php
+++ b/protected/humhub/components/console/Application.php
@@ -59,7 +59,7 @@ class Application extends \yii\console\Application implements \humhub\interfaces
             ));
         }
 
-        if (BaseSettingsManager::isDatabaseInstalled()) {
+        if (BaseSettingsManager::isDatabaseInstalled(Yii::$app->params['databaseInstalled'] ?? false)) {
             $baseUrl = Yii::$app->settings->get('baseUrl');
             if (!empty($baseUrl)) {
                 if (Yii::getAlias('@web', false) === false) {

--- a/protected/humhub/helpers/DatabaseHelper.php
+++ b/protected/humhub/helpers/DatabaseHelper.php
@@ -1,0 +1,147 @@
+<?php
+
+/*
+ * @link      https://www.humhub.org/
+ * @copyright Copyright (c) 2017-2023 HumHub GmbH & Co. KG
+ * @license   https://www.humhub.com/licences
+ */
+
+namespace humhub\helpers;
+
+use Throwable;
+use Yii;
+
+/**
+ * @since 1.15
+ */
+class DatabaseHelper
+{
+    public static function handleConnectionErrors(
+        Throwable $ex,
+        bool $print = true,
+        bool $die = true,
+        bool $forcePlainText = false
+    ): ?string {
+        static $last = false;
+
+        if (!$ex instanceof \yii\db\Exception) {
+            return null;
+        }
+
+        if ($last) {
+            return null;
+        }
+
+        $last = true;
+
+        $trace = debug_backtrace(0);
+        $trace = end($trace);
+        if ($trace && $trace['function'] === 'handleException' && $trace['args'][0] instanceof \yii\db\Exception) {
+            return null;
+        }
+
+        switch ($ex->getCode()) {
+            case 2002:
+                $error = 'Hostname not found.';
+                break;
+
+            case 1044:
+                $error = 'Database not found or not accessible.';
+                break;
+
+            case 1049:
+                $error = 'Database not found.';
+                break;
+
+            default:
+                $error = $ex->getMessage();
+        }
+
+        /**
+         * @see https://www.php.net/manual/en/ref.pdo-odbc.connection.php
+         * @see https://www.php.net/manual/en/ref.pdo-ibm.connection.php
+         * @see https://www.php.net/manual/en/ref.pdo-pgsql.connection.php
+         */
+        $dsn = preg_replace(
+            '@((?<=:|;)(?:user|uid|User ID|pwd|password)=)(.*?)(?=;(?:$|\w+=)|$)@i',
+            '$1****',
+            Yii::$app->db->dsn
+        );
+
+        try {
+            $additionalInfo = json_encode([get_class($ex), ...$ex->errorInfo], JSON_THROW_ON_ERROR);
+        } catch (\JsonException $e) {
+            $additionalInfo = 'N/A';
+        }
+
+        while ($ex->getPrevious()) {
+            $ex = $ex->getPrevious();
+        }
+
+        $htmlMessage = defined('YII_DEBUG') && YII_DEBUG
+            ? sprintf('
+<h1>Invalid database configuration</h1>
+<p><strong>%s</strong></p>
+<p>The following connection string was used:<br><code>%s</code></p>
+<br>
+<h2>Technical information</h2>
+<p><code>%s</code></p>
+<p><pre>%s</pre></p>
+', $error, $dsn, $additionalInfo, $ex)
+            : sprintf('
+<h1>Invalid database configuration</h1>
+<p><strong>%s</strong></p>
+', $error);
+
+        $txtMessage = defined('YII_DEBUG') && YII_DEBUG
+            ? sprintf('
+Invalid database configuration
+==============================
+
+%s
+
+The following connection string was used:
+%s
+
+
+Technical information
+---------------------
+%s
+
+%s
+
+', $error, $dsn, $additionalInfo, $ex)
+            : sprintf('
+Invalid database configuration
+==============================
+
+%s
+
+The following connection string was used:
+%s
+
+
+Technical information
+---------------------
+%s
+
+', $error, $dsn, $additionalInfo);
+
+        if ($print) {
+            if ($forcePlainText) {
+                echo $txtMessage;
+            } elseif (Yii::$app instanceof \yii\console\Application && Yii::$app->controller instanceof \yii\console\Controller) {
+                Yii::$app->controller->stderr($txtMessage);
+            } else {
+                header("HTTP/1.1 500 Internal Server Error");
+                echo $htmlMessage;
+            }
+        }
+
+        if (!$die) {
+            return $txtMessage;
+        }
+
+        die(1);
+    }
+}

--- a/protected/humhub/libs/BaseSettingsManager.php
+++ b/protected/humhub/libs/BaseSettingsManager.php
@@ -10,12 +10,12 @@ namespace humhub\libs;
 
 use humhub\components\SettingActiveRecord;
 use humhub\exceptions\InvalidArgumentTypeException;
+use humhub\helpers\DatabaseHelper;
 use Stringable;
 use Yii;
 use yii\base\Component;
 use yii\base\InvalidArgumentException;
 use yii\base\InvalidConfigException;
-use yii\db\conditions\LikeCondition;
 use yii\db\StaleObjectException;
 use yii\helpers\Json;
 
@@ -303,19 +303,20 @@ abstract class BaseSettingsManager extends Component
     /**
      * Checks if settings table exists or application is not installed yet
      *
-     * @return bool
      * @since 1.3
      */
-    public static function isDatabaseInstalled()
+    public static function isDatabaseInstalled(bool $dieOnError = false): bool
     {
         try {
-            if (in_array('setting', Yii::$app->db->schema->getTableNames())) {
-                return true;
-            }
+            $db = Yii::$app->db;
+            $db->open();
         } catch (\Exception $ex) {
+            if ($dieOnError) {
+                DatabaseHelper::handleConnectionErrors($ex);
+            }
             return false;
         }
 
-        return false;
+        return in_array('setting', $db->schema->getTableNames());
     }
 }

--- a/protected/yii
+++ b/protected/yii
@@ -8,6 +8,8 @@
  * @license http://www.yiiframework.com/license/
  */
 
+use humhub\helpers\DatabaseHelper;
+
 defined('YII_DEBUG') or define('YII_DEBUG', true);
 
 // fcgi doesn't have STDIN and STDOUT defined by default
@@ -25,6 +27,11 @@ $config = yii\helpers\ArrayHelper::merge(
     require(__DIR__ . '/config/console.php')
 );
 
-$application = new humhub\components\console\Application($config);
-$exitCode = $application->run();
-exit($exitCode);
+try {
+    $exitCode = (new humhub\components\console\Application($config))->run();
+    exit($exitCode);
+} catch (\Throwable $ex) {
+    if (null === DatabaseHelper::handleConnectionErrors($ex)) {
+        throw $ex;
+    }
+}


### PR DESCRIPTION

### What kind of change does this PR introduce?

- Bugfix

### Does this PR introduce a breaking change?

- No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [x] [All tests are passing](#issuecomment-new)
- [ ] New/updated tests are included
- [x] Changelog was modified

**Other information:**

When the connection information is wrong, or the database server name resolution fails, there are misleading error messages as there is actually no error handling of that situation so far.

This PR is a poor man's attempt to give the user some sort of helpful information. Yes, it does not look pretty and styled, but that's partly because the theming tries to access the db itself...

Particularly un-informative is the error when you try to run migrations with an invalid connection configuration.