### PR TITLE
Fix humhub test case would fail on skipped tests

### DIFF
--- a/CHANGELOG-DEV.md
+++ b/CHANGELOG-DEV.md
@@ -3,6 +3,7 @@ HumHub Changelog
 
 1.15.0-beta.2 (Unreleased)
 --------------------------
+- Fix #6516: Humhub test case would fail on skipped tests
 - Enh #6478: Add pseudo test class to allow population of DB with standard test data
 - Enh #6480: Convert assert* and db* methods to static, in line with general usage pattern
 - Enh #6505: Introduce Application interface; now also fire the `onInit` event when the web application has initialized

--- a/protected/humhub/tests/codeception/_support/HumHubDbTestCase.php
+++ b/protected/humhub/tests/codeception/_support/HumHubDbTestCase.php
@@ -48,6 +48,8 @@ use yii\db\Query;
  */
 class HumHubDbTestCase extends Unit
 {
+    use HumHubHelperTrait;
+
     protected $fixtureConfig;
 
     public $appConfig = '@tests/codeception/config/unit.php';
@@ -57,8 +59,6 @@ class HumHubDbTestCase extends Unit
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         if (Yii::$app === null) {
             $c = new \ReflectionClass($this);
             $m = $c->getMethod($this->getName(false));
@@ -75,40 +75,8 @@ class HumHubDbTestCase extends Unit
         $this->reloadSettings(__METHOD__);
         $this->flushCache(__METHOD__);
         $this->deleteMails(__METHOD__);
-    }
 
-    protected function reloadSettings(?string $caller = null)
-    {
-        codecept_debug(sprintf('[%s] Reloading settings', $caller ?? __METHOD__));
-        Yii::$app->settings->reload();
-
-        foreach (Yii::$app->modules as $module) {
-            if ($module instanceof \humhub\components\Module) {
-                $module->settings->reload();
-            }
-        }
-    }
-
-    protected function flushCache(?string $caller = null)
-    {
-        codecept_debug(sprintf('[%s] Flushing cache', $caller ?? __METHOD__));
-        RichTextToShortTextConverter::flushCache();
-        RichTextToHtmlConverter::flushCache();
-        RichTextToPlainTextConverter::flushCache();
-        RichTextToMarkdownConverter::flushCache();
-        UrlOembed::flush();
-    }
-
-    protected function deleteMails(?string $caller = null)
-    {
-        codecept_debug(sprintf('[%s] Deleting mails', $caller ?? __METHOD__));
-        $path = Yii::getAlias('@runtime/mail');
-        $files = glob($path . '/*'); // get all file names
-        foreach ($files as $file) { // iterate files
-            if (is_file($file)) {
-                unlink($file); // delete file
-            }
-        }
+        parent::setUp();
     }
 
     /**

--- a/protected/humhub/tests/codeception/_support/HumHubHelper.php
+++ b/protected/humhub/tests/codeception/_support/HumHubHelper.php
@@ -9,6 +9,7 @@ use humhub\modules\content\widgets\richtext\converter\RichTextToMarkdownConverte
 use humhub\modules\content\widgets\richtext\converter\RichTextToPlainTextConverter;
 use humhub\modules\content\widgets\richtext\converter\RichTextToShortTextConverter;
 use Yii;
+use yii\helpers\FileHelper;
 use yii\symfonymailer\Message;
 
 /**
@@ -19,22 +20,15 @@ use yii\symfonymailer\Message;
  */
 class HumHubHelper extends Module
 {
+    use HumHubHelperTrait;
 
     protected $config = [];
 
     public function _before(\Codeception\TestInterface $test)
     {
         Yii::$app->getUrlManager()->setScriptUrl('/index-test.php');
-        $this->flushCache();
-    }
-
-    protected function flushCache()
-    {
-        RichTextToShortTextConverter::flushCache();
-        RichTextToHtmlConverter::flushCache();
-        RichTextToPlainTextConverter::flushCache();
-        RichTextToMarkdownConverter::flushCache();
-        UrlOembed::flush();
+        $this->reloadSettings(__METHOD__);
+        $this->flushCache(__METHOD__);
     }
 
     public function fetchInviteToken($mail)

--- a/protected/humhub/tests/codeception/_support/HumHubHelperTrait.php
+++ b/protected/humhub/tests/codeception/_support/HumHubHelperTrait.php
@@ -1,0 +1,58 @@
+<?php
+/*
+ * @link      https://www.humhub.org/
+ * @copyright Copyright (c) 2023 HumHub GmbH & Co. KG
+ * @license   https://www.humhub.com/licences
+ */
+
+namespace tests\codeception\_support;
+
+use humhub\models\UrlOembed;
+use humhub\modules\content\widgets\richtext\converter\RichTextToHtmlConverter;
+use humhub\modules\content\widgets\richtext\converter\RichTextToMarkdownConverter;
+use humhub\modules\content\widgets\richtext\converter\RichTextToPlainTextConverter;
+use humhub\modules\content\widgets\richtext\converter\RichTextToShortTextConverter;
+use Yii;
+use yii\helpers\FileHelper;
+
+trait HumHubHelperTrait
+{
+    protected function flushCache(?string $caller = null)
+    {
+        codecept_debug(sprintf('[%s] Flushing cache', $caller ?? __METHOD__));
+        $cachePath = Yii::getAlias('@runtime/cache');
+        if ($cachePath && is_dir($cachePath)) {
+            FileHelper::removeDirectory($cachePath);
+        }
+        Yii::$app->cache->flush();
+        RichTextToShortTextConverter::flushCache();
+        RichTextToHtmlConverter::flushCache();
+        RichTextToPlainTextConverter::flushCache();
+        RichTextToMarkdownConverter::flushCache();
+        UrlOembed::flush();
+    }
+
+    protected function reloadSettings(?string $caller = null)
+    {
+        codecept_debug(sprintf('[%s] Reloading settings', $caller ?? __METHOD__));
+        Yii::$app->settings->reload();
+
+        foreach (Yii::$app->modules as $module) {
+            if ($module instanceof \humhub\components\Module) {
+                $module->settings->reload();
+            }
+        }
+    }
+
+    protected function deleteMails(?string $caller = null)
+    {
+        codecept_debug(sprintf('[%s] Deleting mails', $caller ?? __METHOD__));
+        $path = Yii::getAlias('@runtime/mail');
+        $files = glob($path . '/*'); // get all file names
+        foreach ($files as $file) { // iterate files
+            if (is_file($file)) {
+                unlink($file); // delete file
+            }
+        }
+    }
+}


### PR DESCRIPTION
When a test is annotated with `@skip` (e.g. [`testCreatePublicContentOnPrivateSpace`](https://github.com/humhub/humhub/blob/e7c61781786a6184508681984f4f6e47bac99d9c/protected/humhub/modules/content/tests/codeception/unit/models/ContentVisibilityTest.php#L114) without adding a reason, or [`testConvertTableWithoutBodyAtEnd`](https://github.com/humhub/humhub/blob/e7c61781786a6184508681984f4f6e47bac99d9c/protected/humhub/modules/content/tests/codeception/unit/widgets/RichTextHtmlConverterTest.php#L629)) the Application is not started (`Yii::$app` will be empty), yet the test itself is not skipped (the `@skip` annotation is a [feature of Codeception](url), but [not of PhpUnit](https://github.com/sebastianbergmann/phpunit/issues/3220)).

Hence, tests which are intended to be skipped can (and most likely will) cause the test to [fail](https://github.com/humhub/humhub/actions/runs/5872676823/job/15924640805?pr=6430#step:18:1456).

This PR checks for the `@skip` annotation when a test fails and the application has not been instantiated. In that case, it will throw a propper `SkippedTestError`.

### What kind of change does this PR introduce?

- Bugfix

### Does this PR introduce a breaking change?

- No


### The PR fulfills these requirements:

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [x] [All tests are passing](#issuecomment-new)
- [x] New/updated tests are included
- [x] Changelog was modified
