### PR TITLE
Fix: Ensure e-mails would always have a sender address set

### DIFF
--- a/CHANGELOG-DEV.md
+++ b/CHANGELOG-DEV.md
@@ -3,9 +3,10 @@ HumHub Changelog
 
 1.16.0 (Unreleased)
 -------------------
-- Enh #6451: Introduce Archiveable, Deletable, Editable, Readable, & Viewable Interfaces
-- Enh #6512: Show error messages when DB connection configuration is invalid
+- Fix #6519: Ensure e-mails would always have a sender address set
 - Fix #6516: Humhub test case would fail on skipped tests
+- Enh #6512: Show error messages when DB connection configuration is invalid
+- Enh #6451: Introduce Archiveable, Deletable, Editable, Readable, & Viewable Interfaces
 
 1.15.0-beta.2 (Unreleased)
 --------------------------

--- a/protected/humhub/components/Application.php
+++ b/protected/humhub/components/Application.php
@@ -8,15 +8,18 @@
 
 namespace humhub\components;
 
+use humhub\interfaces\ApplicationInterface;
 use Yii;
-use yii\helpers\Url;
-use yii\base\Exception;
+use Exception;
 
 /**
+ * Description of Application
+ *
  * @inheritdoc
  */
-class Application extends \yii\web\Application implements \humhub\interfaces\Application
+class Application extends \yii\web\Application implements ApplicationInterface
 {
+    use ApplicationTrait;
 
     /**
      * @inheritdoc
@@ -24,38 +27,12 @@ class Application extends \yii\web\Application implements \humhub\interfaces\App
     public $controllerNamespace = 'humhub\\controllers';
 
     /**
-     * @var string|array the homepage url
-     */
-    private $_homeUrl = null;
-
-    /**
-     * @var string Minimum PHP version that recommended to work without issues
-     */
-    public $minRecommendedPhpVersion;
-
-    /**
-     * @var string Minimum PHP version that may works but probably with small issues
-     */
-    public $minSupportedPhpVersion;
-
-    /**
-     * @inheritdoc
-     */
-    public function __construct($config = [])
-    {
-        // Remove obsolete config params:
-        unset($config['components']['formatterApp']);
-
-        parent::__construct($config);
-    }
-
-    /**
      * @inheritdoc
      */
     public function init()
     {
         if (version_compare(phpversion(), $this->minSupportedPhpVersion, '<')) {
-            throw new \Exception(sprintf(
+            throw new Exception(sprintf(
                 'Installed PHP Version is too old! Required minimum version is PHP %s (Installed: %s)',
                 $this->minSupportedPhpVersion,
                 phpversion()
@@ -82,28 +59,6 @@ class Application extends \yii\web\Application implements \humhub\interfaces\App
         }
 
         parent::bootstrap();
-    }
-
-    /**
-     * @return string the homepage URL
-     */
-    public function getHomeUrl()
-    {
-        if ($this->_homeUrl === null) {
-            return Url::to(['/dashboard/dashboard']);
-        } elseif (is_array($this->_homeUrl)) {
-            return Url::to($this->_homeUrl);
-        } else {
-            return $this->_homeUrl;
-        }
-    }
-
-    /**
-     * @param string|array $value the homepage URL
-     */
-    public function setHomeUrl($value)
-    {
-        $this->_homeUrl = $value;
     }
 
     /**

--- a/protected/humhub/components/ApplicationTrait.php
+++ b/protected/humhub/components/ApplicationTrait.php
@@ -1,0 +1,64 @@
+<?php
+/*
+ * @link      https://www.humhub.org/
+ * @copyright Copyright (c) 2023 HumHub GmbH & Co. KG
+ * @license   https://www.humhub.com/licences
+ */
+
+namespace humhub\components;
+
+use humhub\interfaces\MailerInterface;
+use yii\helpers\Url;
+
+trait ApplicationTrait
+{
+    /**
+     * @var string|array the homepage url
+     */
+    protected $_homeUrl = null;
+
+    /**
+     * @var string Minimum PHP version that recommended to work without issues
+     */
+    public $minRecommendedPhpVersion;
+
+    /**
+     * @var string Minimum PHP version that may works but probably with small issues
+     */
+    public $minSupportedPhpVersion;
+
+    /**
+     * @inheritdoc
+     */
+    public function __construct($config = [])
+    {
+        // Remove obsolete config params:
+        unset($config['components']['formatterApp']);
+
+        parent::__construct($config);
+    }
+
+    /**
+     * @return string the homepage URL
+     */
+    public function getHomeUrl(): string
+    {
+        if ($this->_homeUrl === null) {
+            return Url::to(['/dashboard/dashboard']);
+        }
+
+        if (is_array($this->_homeUrl)) {
+            return Url::to($this->_homeUrl);
+        }
+
+        return $this->_homeUrl;
+    }
+
+    /**
+     * @param string|array $value the homepage URL
+     */
+    public function setHomeUrl($value)
+    {
+        $this->_homeUrl = $value;
+    }
+}

--- a/protected/humhub/components/ApplicationTrait.php
+++ b/protected/humhub/components/ApplicationTrait.php
@@ -61,4 +61,9 @@ trait ApplicationTrait
     {
         $this->_homeUrl = $value;
     }
+
+    public function getMailer(): MailerInterface
+    {
+        return parent::getMailer();
+    }
 }

--- a/protected/humhub/components/console/Application.php
+++ b/protected/humhub/components/console/Application.php
@@ -8,43 +8,25 @@
 
 namespace humhub\components\console;
 
+use humhub\components\ApplicationTrait;
+use humhub\interfaces\ApplicationInterface;
 use humhub\libs\BaseSettingsManager;
 use Yii;
 use yii\console\Exception;
-use yii\helpers\Url;
 
 /**
  * Description of Application
  *
- * @author luke
+ * @inheritdoc
  */
-class Application extends \yii\console\Application implements \humhub\interfaces\Application
+class Application extends \yii\console\Application implements ApplicationInterface
 {
-    /**
-     * @var string|array the homepage url
-     */
-    private $_homeUrl = null;
-
-    /**
-     * @var string Minimum PHP version that recommended to work without issues
-     */
-    public $minRecommendedPhpVersion;
-
-    /**
-     * @var string Minimum PHP version that may works but probably with small issues
-     */
-    public $minSupportedPhpVersion;
+    use ApplicationTrait;
 
     /**
      * @inheritdoc
      */
-    public function __construct($config = [])
-    {
-        // Remove obsolete config params:
-        unset($config['components']['formatterApp']);
-
-        parent::__construct($config);
-    }
+    public $controllerNamespace = 'humhub\\controllers';
 
     /**
      * @inheritdoc
@@ -102,27 +84,4 @@ class Application extends \yii\console\Application implements \humhub\interfaces
             'fixture' => 'yii\console\controllers\FixtureController',
         ];
     }
-
-    /**
-     * @return string the homepage URL
-     */
-    public function getHomeUrl()
-    {
-        if ($this->_homeUrl === null) {
-            return Url::to(['/dashboard/dashboard']);
-        } elseif (is_array($this->_homeUrl)) {
-            return Url::to($this->_homeUrl);
-        } else {
-            return $this->_homeUrl;
-        }
-    }
-
-    /**
-     * @param string|array $value the homepage URL
-     */
-    public function setHomeUrl($value)
-    {
-        $this->_homeUrl = $value;
-    }
-
 }

--- a/protected/humhub/components/mail/Mailer.php
+++ b/protected/humhub/components/mail/Mailer.php
@@ -8,8 +8,10 @@
 
 namespace humhub\components\mail;
 
+use humhub\interfaces\MailerInterface;
 use Symfony\Component\Mime\Crypto\SMimeSigner;
 use Yii;
+use yii\mail\MessageInterface;
 
 /**
  * Mailer implements a mailer based on SymfonyMailer.
@@ -18,7 +20,7 @@ use Yii;
  * @since 1.2
  * @author Luke
  */
-class Mailer extends \yii\symfonymailer\Mailer
+class Mailer extends \yii\symfonymailer\Mailer implements MailerInterface
 {
     /**
      * @inheritdoc
@@ -68,13 +70,7 @@ class Mailer extends \yii\symfonymailer\Mailer
     {
         $message = parent::compose($view, $params);
 
-        // Set HumHub default from values
-        if (empty($message->getFrom())) {
-            $message->setFrom([Yii::$app->settings->get('mailer.systemEmailAddress') => Yii::$app->settings->get('mailer.systemEmailName')]);
-            if ($replyTo = Yii::$app->settings->get('mailer.systemEmailReplyTo')) {
-                $message->setReplyTo($replyTo);
-            }
-        }
+        self::ensureHumHubDefaultFromValues($message);
 
         if ($this->signingCertificatePath !== null && $this->signingPrivateKeyPath !== null) {
             if ($this->signer === null) {
@@ -92,6 +88,25 @@ class Mailer extends \yii\symfonymailer\Mailer
         return $message;
     }
 
+    /**
+     * @param MessageInterface $message
+     *
+     * @return void
+     */
+    public static function ensureHumHubDefaultFromValues(MessageInterface $message): MessageInterface
+    {
+        // Set HumHub default from values
+        if ($message->getFrom()) {
+            return $message;
+        }
+
+        $message->setFrom([Yii::$app->settings->get('mailer.systemEmailAddress') => Yii::$app->settings->get('mailer.systemEmailName')]);
+        if ($replyTo = Yii::$app->settings->get('mailer.systemEmailReplyTo')) {
+            $message->setReplyTo($replyTo);
+        }
+
+        return $message;
+    }
 
     /**
      * @inheritdoc

--- a/protected/humhub/config/__autocomplete.php
+++ b/protected/humhub/config/__autocomplete.php
@@ -13,7 +13,7 @@
  */
 class Yii {
     /**
-     * @var \yii\web\Application|\yii\console\Application|\humhub\components\Application|\humhub\components\console\Application|\humhub\interfaces\Application|__Application|__WebApplication
+     * @var \yii\web\Application|\yii\console\Application|\humhub\components\Application|\humhub\components\console\Application|\humhub\interfaces\ApplicationInterface|__Application|__WebApplication
      */
     public static $app;
 }

--- a/protected/humhub/interfaces/ApplicationInterface.php
+++ b/protected/humhub/interfaces/ApplicationInterface.php
@@ -19,4 +19,6 @@ interface ApplicationInterface
      * @event ActionEvent an event raised on init of application.
      */
     public const EVENT_ON_INIT = 'onInit';
+
+    public function getMailer(): MailerInterface;
 }

--- a/protected/humhub/interfaces/ApplicationInterface.php
+++ b/protected/humhub/interfaces/ApplicationInterface.php
@@ -13,7 +13,7 @@ namespace humhub\interfaces;
  *
  * @since 1.15
  */
-interface Application
+interface ApplicationInterface
 {
     /**
      * @event ActionEvent an event raised on init of application.

--- a/protected/humhub/interfaces/MailerInterface.php
+++ b/protected/humhub/interfaces/MailerInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+/*
+ * @link      https://www.humhub.org/
+ * @copyright Copyright (c) 2023 HumHub GmbH & Co. KG
+ * @license   https://www.humhub.com/licences
+ */
+
+namespace humhub\interfaces;
+
+interface MailerInterface extends \yii\mail\MailerInterface
+{
+}

--- a/protected/humhub/modules/notification/targets/MailTarget.php
+++ b/protected/humhub/modules/notification/targets/MailTarget.php
@@ -68,7 +68,6 @@ class MailTarget extends BaseTarget
                         ], $notification->getViewParams());
 
         $mail = Yii::$app->mailer->compose($this->view, $viewParams)
-                ->setFrom([Yii::$app->settings->get('mailer.systemEmailAddress') => Yii::$app->settings->get('mailer.systemEmailName')])
                 ->setTo($recipient->email)
                 ->setSubject(str_replace("\n", " ", trim($notification->getMailSubject())));
         if ($replyTo = Yii::$app->settings->get('mailer.systemEmailReplyTo')) {

--- a/protected/humhub/tests/codeception/_support/TestMailer.php
+++ b/protected/humhub/tests/codeception/_support/TestMailer.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * @link      https://www.humhub.org/
+ * @copyright Copyright (c) 2023 HumHub GmbH & Co. KG
+ * @license   https://www.humhub.com/licences
+ */
+
+namespace tests\codeception\_support;
+
+use humhub\components\mail\Mailer;
+use humhub\interfaces\MailerInterface;
+
+/**
+ * @since 1.15
+ */
+class TestMailer extends \Codeception\Lib\Connector\Yii2\TestMailer implements MailerInterface
+{
+    public function compose($view = null, array $params = [])
+    {
+        $message = parent::compose($view, $params);
+
+        return Mailer::ensureHumHubDefaultFromValues($message);
+    }
+}

--- a/protected/humhub/tests/codeception/config/config.php
+++ b/protected/humhub/tests/codeception/config/config.php
@@ -3,6 +3,7 @@
 /**
  * Application configuration shared by all test types
  */
+
 $default = [
     'name' => 'HumHub Test',
     'language' => 'en-US',
@@ -31,6 +32,13 @@ $default = [
             'showScriptName' => true,
             'scriptUrl' => '/index-test.php',
         ],
+    ],
+    'container' => [
+        'definitions' => [
+            \Codeception\Lib\Connector\Yii2\TestMailer::class => [
+                'class' => \tests\codeception\_support\TestMailer::class,
+            ]
+        ]
     ],
     'modules' => [
         'user' => [


### PR DESCRIPTION

Depending on the mailer used, the `From`-address of an e-mail would not be set (e.g. when using the test mailer from the testing framework).

Using a helper function to compose the message ensures that the sender is _always_ set.

### What kind of change does this PR introduce?

- Bugfix

### Does this PR introduce a breaking change?

- No

### The PR fulfills these requirements:

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [x] All tests are passing
- [x] Changelog was modified

**Other information:**
