### PR TITLE
Fix a disabled button after post a content record with state "Draft" …

### DIFF
--- a/CHANGELOG-DEV.md
+++ b/CHANGELOG-DEV.md
@@ -20,6 +20,7 @@ HumHub Changelog
 - Enh #6498: Implement option "disabled" for picker fields
 - Enh #6506: Allow event data from module config
 - Fix #6510: Fix online status position on people page
+- Fix #6526: Fix a disabled button after post a content record with state "Draft" or "Scheduled"
 
 1.15.0-beta.1 (July 31, 2023)
 -----------------------------

--- a/protected/humhub/modules/content/resources/js/humhub.content.form.js
+++ b/protected/humhub/modules/content/resources/js/humhub.content.form.js
@@ -226,7 +226,8 @@ humhub.module('content.form', function(module, require, $) {
         const initial = stateInput.data('initial');
         if (initial !== undefined) {
             stateInput.val(initial.state);
-            button.html(initial.buttonTitle);
+            button.data('htmlOld', initial.buttonTitle).removeAttr('style');
+            loader.reset(button);
         }
         this.$.find('input[name^=scheduled]').remove();
         this.$.find('.label-content-state').hide();


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] All tests are passing
- [x] Changelog was modified

**Other information:**
The button should be enabled after post "Draft" or "Scheduled" content:
![bug_after_post](https://github.com/humhub/humhub/assets/6995524/9e5c3970-63a7-47a2-ba11-d70ca684e746)