### PR TITLE
Enable RuntimeCache during tests

### DIFF
--- a/protected/humhub/tests/codeception/_support/HumHubDbTestCase.php
+++ b/protected/humhub/tests/codeception/_support/HumHubDbTestCase.php
@@ -4,6 +4,7 @@ namespace tests\codeception\_support;
 
 use Codeception\Test\Unit;
 use humhub\components\behaviors\PolymorphicRelation;
+use humhub\helpers\RuntimeCacheHelper;
 use humhub\libs\BasePermission;
 use Codeception\Configuration;
 use Codeception\Exception\ModuleException;
@@ -79,6 +80,7 @@ class HumHubDbTestCase extends Unit
 
     protected function flushCache()
     {
+        RuntimeCacheHelper::flush();
         RichTextToShortTextConverter::flushCache();
         RichTextToHtmlConverter::flushCache();
         RichTextToPlainTextConverter::flushCache();

--- a/protected/humhub/tests/config/common.php
+++ b/protected/humhub/tests/config/common.php
@@ -21,9 +21,6 @@ return [
         'queue' => [
             'class' => 'humhub\modules\queue\driver\Instant',
         ],
-        'runtimeCache' => [
-            'class' => \yii\caching\DummyCache::class
-        ],
     ],
     'params' => [
         'installed' => true,


### PR DESCRIPTION
The RuntimeCache (RTC) was introduced in #6375.

However, while the RuntimeCache
- is enabled by default in the deployed config,
  https://github.com/humhub/humhub/blob/419a7f1d016b9ebbf18c5ff2a09af637741c9f0c/protected/humhub/config/common.php#L113-L116
- it is disabled for test config:
  https://github.com/humhub/humhub/blob/9a28225efd9e1e6464c261d7685866e84c3200d9/protected/humhub/tests/config/common.php#L24-L26

This makes no sense, as
- enabling the RTC tests is closer to real-life setting
- the `Yii::$app` is destroyed and recreated between every single test. And with it, the RTC. Hence, no cache flushing is required between tests (it already happens out of the box by instantiating a new cache anyway).

Hence, RuntimeCache should also be enabled during test.

**The fact that [this test is failing](https://github.com/humhub/humhub/actions/runs/5910637937/job/16032424516?pr=6527) is showing that the current RTC setting and implementation might cause issues in production. This should be addressed.**

I do not understand why they fail. Doing them live the everything works perfectly.

**What kind of change does this PR introduce?**

- Bugfix (Fix #6375)

**Does this PR introduce a breaking change?**

- No. The failing tests seem to stem from the introduction of the RTC in #6375. 

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [x] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [ ] [All tests are passing](#issuecomment-new)
- [x] New/updated tests are included
- [ ] Changelog was modified
