### PR TITLE
Fix #6547 Invalid class name validated as valid and improve validation

### DIFF
--- a/CHANGELOG-DEV.md
+++ b/CHANGELOG-DEV.md
@@ -10,6 +10,7 @@ HumHub Changelog
 - Enh #6553: Support log assertions
 - Fix #6551: Migration's transaction with invalid savepoint
 - Fix #6549: Empty profile field type causing an unspecific error
+- Fix #6547: Invalid class name validated as valid and improve validation
 - Enh #6529: Add boolean return-type to `*safe*` methods in migrations
 - Fix #6516: Humhub test case would fail on skipped tests
 - Enh #6478: Add pseudo test class to allow population of DB with standard test data

--- a/MIGRATE-DEV.md
+++ b/MIGRATE-DEV.md
@@ -21,6 +21,14 @@ Version 1.15 (Unreleased)
 
 ### Type restrictions
 - `\humhub\libs\BaseSettingsManager` and its child classes on fields, method parameters, & return types
+- `\humhub\libs\Helpers::checkClassType()` (see [#6548](https://github.com/humhub/humhub/pull/6548))
+  - rather than throwing a `\yii\base\Exception`, it now throws some variations of `yii\base\InvalidArgumentException`
+    with different Exception Codes as documented in the function's documentation:
+      - `\humhub\exceptions\InvalidArgumentClassException`
+      - `\humhub\exceptions\InvalidArgumentTypeException`
+      - `\humhub\exceptions\InvalidArgumentValueException`
+  - the return type has changed from `false` to `string|null`
+  - the second parameter `$type` is now mandatory
 
 ### Deprecations
 #### New

--- a/protected/humhub/components/behaviors/PolymorphicRelation.php
+++ b/protected/humhub/components/behaviors/PolymorphicRelation.php
@@ -8,6 +8,7 @@
 namespace humhub\components\behaviors;
 
 use Exception;
+use humhub\libs\Helpers;
 use humhub\modules\content\components\ContentActiveRecord;
 use humhub\modules\content\components\ContentAddonActiveRecord;
 use ReflectionClass;
@@ -121,14 +122,12 @@ class PolymorphicRelation extends Behavior
      */
     private function validateUnderlyingObjectType($object)
     {
-        if (count($this->mustBeInstanceOf) == 0) {
+        if (empty($this->mustBeInstanceOf)) {
             return true;
         }
 
-        foreach ($this->mustBeInstanceOf as $instance) {
-            if ($object instanceof $instance) { //|| $object->asa($instance) !== null
-                return true;
-            }
+        if (Helpers::checkClassType($object, $this->mustBeInstanceOf, false)) { //|| $object->asa($instance) !== null
+            return true;
         }
 
         Yii::error('Got invalid underlying object type! (' . get_class($object) . ')');

--- a/protected/humhub/exceptions/InvalidArgumentClassException.php
+++ b/protected/humhub/exceptions/InvalidArgumentClassException.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * @link      https://www.humhub.org/
+ * @copyright Copyright (c) 2023 HumHub GmbH & Co. KG
+ * @license   https://www.humhub.com/licences
+ */
+
+namespace humhub\exceptions;
+
+/**
+ * @since 1.15
+ */
+class InvalidArgumentClassException extends InvalidArgumentTypeException
+{
+    protected function formatValid(): string
+    {
+        if (empty($this->valid)) {
+            $this->valid = ['mixed'];
+        }
+
+        if (count($this->valid) > 1) {
+            return 'one of the following types: ' . implode(', ', $this->valid);
+        }
+
+        if (strpos($this->valid[0], ' ') === false) {
+            return 'of type ' . reset($this->valid);
+        }
+
+        return reset($this->valid);
+    }
+
+    protected function formatGiven(): string
+    {
+        $given = parent::formatGiven();
+
+        if ($given === 'string') {
+            $given = $this->InvalidArgumentExceptionTrait_formatGiven();
+        }
+
+        return $given;
+    }
+
+    public function getName(): string
+    {
+        if (method_exists(parent::class, 'getName')) {
+            return parent::getName() . " Type";
+        }
+
+        return 'Invalid Type';
+    }
+}

--- a/protected/humhub/libs/Helpers.php
+++ b/protected/humhub/libs/Helpers.php
@@ -8,9 +8,11 @@
 
 namespace humhub\libs;
 
+use humhub\exceptions\InvalidArgumentClassException;
+use humhub\exceptions\InvalidArgumentTypeException;
 use humhub\exceptions\InvalidArgumentValueException;
 use Yii;
-use yii\base\Exception;
+use yii\base\InvalidArgumentException;
 
 /**
  * This class contains a lot of html helpers for the views
@@ -19,6 +21,15 @@ use yii\base\Exception;
  */
 class Helpers
 {
+    public const CLASS_CHECK_INVALID_CLASSNAME_PARAMETER = 1;
+    public const CLASS_CHECK_INVALID_TYPE_PARAMETER = 2;
+    public const CLASS_CHECK_VALUE_IS_EMPTY = 4;
+    public const CLASS_CHECK_INVALID_TYPE = 8;
+    public const CLASS_CHECK_NON_EXISTING_CLASS = 16;
+    public const CLASS_CHECK_TYPE_NOT_IN_LIST = 32;
+    public const CLASS_CHECK_VALUE_IS_INSTANCE = 64;
+    public const CLASS_CHECK_VALUE_IS_NULL = 128;
+
     /**
      * Shorten a text string
      *
@@ -179,27 +190,238 @@ class Helpers
     /**
      * Checks if the class has this class as one of its parents
      *
-     * @param string $className
-     * @param string $type
-     * @return boolean
+     * Code of the thrown Exception is a bit-mask consisting of the following bits
+     * - self::CLASS_CHECK_INVALID_CLASSNAME_PARAMETER: Invalid $className parameter
+     * - self::CLASS_CHECK_INVALID_TYPE_PARAMETER: Invalid $type parameter
+     * - self::CLASS_CHECK_VALUE_IS_EMPTY: Empty parameter
+     * - self::CLASS_CHECK_INVALID_TYPE: Invalid type
+     * - self::CLASS_CHECK_NON_EXISTING_CLASS: Non-existing class
+     * - self::CLASS_CHECK_TYPE_NOT_IN_LIST: Class that is not in $type parameter
+     * - self::CLASS_CHECK_VALUE_IS_INSTANCE: $className is an object instance
+     * - self::CLASS_CHECK_VALUE_IS_NULL: NULL value
+     *
+     * @param string|object|null|mixed $className Object or classname to be checked. Null may be valid if included in $type.
+     *        Everything else is invalid and either throws an error (default) or returns NULL, if $throw is false.
+     * @param string|string[] $types (List of) class, interface or trait names that are allowed.
+     *        If NULL is included, NULL values are also allowed.
+     * @param bool $throw Determines if an Exception should be thrown if $className doesn't match $type, or simply return NULL.
+     *        Invalid $types always throw an error!
+     * @param bool $strict If set to true, no invalid characters are removed from a $className string.
+     *        If set to false, please make sure you use the function's return value, rather than $className, as they might diverge
+     *
+     * @return string|null
+     * @throws InvalidArgumentTypeException|InvalidArgumentClassException|InvalidArgumentValueException
+     * @noinspection PhpDocMissingThrowsInspection
+     * @noinspection PhpUnhandledExceptionInspection
      */
-    public static function CheckClassType($className, $type = '')
+    public static function checkClassType($className, $types, bool $throw = true, ?bool $strict = true): ?string
     {
-        $className = preg_replace('/[^a-z0-9_\-\\\]/i', '', $className);
+        if (empty($types)) {
+            throw new InvalidArgumentValueException('$type', ['string', 'string[]'], $types, self::CLASS_CHECK_INVALID_TYPE_PARAMETER + self::CLASS_CHECK_VALUE_IS_EMPTY);
+        }
 
-        if (is_array($type)) {
-            foreach ($type as $t) {
-                if (class_exists($className) && is_a($className, $t, true)) {
-                    return true;
+        $types = (array)$types;
+        $valid = [];
+        $allowNull = false;
+
+        // validate the type array
+        foreach ($types as $index => &$item) {
+            if ($item === null) {
+                $allowNull = true;
+                continue;
+            }
+
+            if (is_object($item)) {
+                $valid[get_class($item)] = false;
+                continue;
+            }
+
+            if (!is_string($item)) {
+                throw new InvalidArgumentValueException(sprintf('$type[%s]', $index), ['class', 'object'], $item, self::CLASS_CHECK_INVALID_TYPE_PARAMETER + self::CLASS_CHECK_INVALID_TYPE);
+            }
+
+            $isTrait = false;
+
+            if (!class_exists($item) && !interface_exists($item, false) && !($isTrait = trait_exists($item, false))) {
+                throw new InvalidArgumentValueException(sprintf('$type[%s]', $index), 'a valid class/interface/trait name or an object instance', $item, self::CLASS_CHECK_INVALID_TYPE_PARAMETER + self::CLASS_CHECK_NON_EXISTING_CLASS);
+            }
+
+            $valid[$item] = $isTrait;
+        }
+        // make sure the reference is not going to be overwritten
+        unset($item);
+
+        // save the types for throwing exceptions
+        $types = array_keys($valid);
+        if ($allowNull) {
+            $types[] = null;
+        }
+
+        // check for null input
+        if ($className === null) {
+            // check if null is allowed
+            if ($allowNull) {
+                return null;
+            }
+
+            if (!$throw) {
+                return null;
+            }
+
+            throw new InvalidArgumentTypeException(
+                '$className',
+                $types,
+                $className,
+                self::CLASS_CHECK_INVALID_CLASSNAME_PARAMETER + self::CLASS_CHECK_VALUE_IS_EMPTY + self::CLASS_CHECK_INVALID_TYPE + self::CLASS_CHECK_VALUE_IS_NULL
+            );
+        }
+
+        // check for other empty input
+        if (empty($className)) {
+            if ((!$strict && $allowNull) || !$throw) {
+                return null;
+            }
+
+            throw is_string($className)
+                    ? new InvalidArgumentClassException(
+                        '$className',
+                        $types,
+                        $className,
+                        self::CLASS_CHECK_INVALID_CLASSNAME_PARAMETER + self::CLASS_CHECK_VALUE_IS_EMPTY + self::CLASS_CHECK_INVALID_TYPE + self::CLASS_CHECK_TYPE_NOT_IN_LIST
+                    )
+                    : new InvalidArgumentTypeException(
+                        '$className',
+                        $types,
+                        $className,
+                        self::CLASS_CHECK_INVALID_CLASSNAME_PARAMETER + self::CLASS_CHECK_VALUE_IS_EMPTY + self::CLASS_CHECK_INVALID_TYPE
+                    )
+            ;
+        }
+
+        // Validation for object instances
+        if (is_object($className)) {
+            foreach ($valid as $matchingClass => $isTrait) {
+                if ($isTrait) {
+                    if (in_array($matchingClass, static::classUsesTraits($className, false), true)) {
+                        return get_class($className);
+                    }
+                } elseif ($className instanceof $matchingClass) {
+                    return get_class($className);
                 }
             }
-        } else {
-            if (class_exists($className) && is_a($className, $type, true)) {
-                return true;
+
+            if (!$throw) {
+                return null;
+            }
+
+            throw new InvalidArgumentClassException(
+                '$className',
+                $types,
+                $className,
+                self::CLASS_CHECK_INVALID_CLASSNAME_PARAMETER + self::CLASS_CHECK_TYPE_NOT_IN_LIST + self::CLASS_CHECK_VALUE_IS_INSTANCE
+            );
+        }
+
+        if (!is_string($className)) {
+            if (!$throw) {
+                return null;
+            }
+
+            throw new InvalidArgumentTypeException(
+                '$className',
+                $types,
+                $className,
+                self::CLASS_CHECK_INVALID_CLASSNAME_PARAMETER + self::CLASS_CHECK_INVALID_TYPE
+            );
+        }
+
+        $cleaned = preg_replace('/[^a-z0-9_\-\\\]/i', '', $className);
+
+        if ($strict && $cleaned !== $className) {
+            if (!$throw) {
+                return null;
+            }
+
+            throw new InvalidArgumentClassException(
+                '$className',
+                'a valid class name or an object instance',
+                $className,
+                self::CLASS_CHECK_INVALID_CLASSNAME_PARAMETER
+            );
+        }
+
+        $className = $cleaned;
+
+        if (!class_exists($className)) {
+            if (!$throw) {
+                return null;
+            }
+
+            throw new InvalidArgumentValueException(
+                '$className',
+                'a valid class name or an object instance',
+                $className,
+                self::CLASS_CHECK_INVALID_CLASSNAME_PARAMETER + self::CLASS_CHECK_NON_EXISTING_CLASS
+            );
+        }
+
+        foreach ($valid as $matchingClass => $isTrait) {
+            if ($isTrait) {
+                if (in_array($matchingClass, static::classUsesTraits($className, false), true)) {
+                    return $className;
+                }
+            } elseif (is_a($className, $matchingClass, true)) {
+                return $className;
             }
         }
 
-        throw new Exception("Invalid class type! (" . $className . ")");
+        if (!$throw) {
+            return null;
+        }
+
+        throw new InvalidArgumentClassException(
+            '$className',
+            $types,
+            $className,
+            self::CLASS_CHECK_INVALID_CLASSNAME_PARAMETER + self::CLASS_CHECK_TYPE_NOT_IN_LIST
+        );
+    }
+
+    /**
+     * @param string|object $class
+     * @param bool $autoload
+     *
+     * @return array|null
+     * @see https://www.php.net/manual/en/function.class-uses.php#122427
+     */
+    public static function &classUsesTraits($class, bool $autoload = true): ?array
+    {
+        $traits = [];
+
+        // Get all the traits of $class and its parent classes
+        do {
+            $class_name = is_object($class) ? get_class($class) : $class;
+
+            if (class_exists($class_name, $autoload)) {
+                $traits = array_merge(class_uses($class, $autoload), $traits);
+            }
+        } while ($class = get_parent_class($class));
+
+        // Get traits of all parent traits
+        $traits_to_search = $traits;
+        while (!empty($traits_to_search)) {
+            $new_traits = class_uses(array_pop($traits_to_search), $autoload);
+            $traits = array_merge($new_traits, $traits);
+            $traits_to_search = array_merge($new_traits, $traits_to_search);
+        };
+
+        if (count($traits) === 0) {
+            $traits = null;
+        } else {
+            $traits = array_unique($traits);
+        }
+
+        return $traits;
     }
 
     /**

--- a/protected/humhub/modules/comment/controllers/CommentController.php
+++ b/protected/humhub/modules/comment/controllers/CommentController.php
@@ -64,7 +64,8 @@ class CommentController extends Controller
             $modelClass = Yii::$app->request->get('objectModel', Yii::$app->request->post('objectModel'));
             $modelPk = (int)Yii::$app->request->get('objectId', Yii::$app->request->post('objectId'));
 
-            Helpers::CheckClassType($modelClass, [Comment::class, ContentActiveRecord::class]);
+            /** @var Comment|ContentActiveRecord $modelClass */
+            $modelClass = Helpers::checkClassType($modelClass, [Comment::class, ContentActiveRecord::class]);
             $this->target = $modelClass::findOne(['id' => $modelPk]);
 
             if (!$this->target) {

--- a/protected/humhub/modules/content/components/ContentAddonController.php
+++ b/protected/humhub/modules/content/components/ContentAddonController.php
@@ -86,7 +86,8 @@ class ContentAddonController extends Controller
             throw new HttpException(500, 'Model & ID parameter required!');
         }
 
-        Helpers::CheckClassType($modelClass, [ContentAddonActiveRecord::class, ContentActiveRecord::class]);
+        /** @var ContentAddonActiveRecord|ContentActiveRecord $modelClass */
+        $modelClass = Helpers::checkClassType($modelClass, [ContentAddonActiveRecord::class, ContentActiveRecord::class]);
         $target = $modelClass::findOne(['id' => $pk]);
 
         if ($target === null) {
@@ -112,14 +113,16 @@ class ContentAddonController extends Controller
 
     /**
      * Loads Content Addon
-     * We also validates that the content addon corresponds to the loaded content.
+     * We also validate that the content addon corresponds to the loaded content.
      *
      * @param string $className
      * @param int $pk
      */
     public function loadContentAddon($className, $pk)
     {
-        if (!Helpers::CheckClassType($className, ContentAddonActiveRecord::class)) {
+        /** @var ContentAddonActiveRecord|null $className */
+        $className = Helpers::checkClassType($className, ContentAddonActiveRecord::class);
+        if ($className === null) {
             throw new Exception("Given className is not a content addon model!");
         }
 

--- a/protected/humhub/modules/file/actions/UploadAction.php
+++ b/protected/humhub/modules/file/actions/UploadAction.php
@@ -12,6 +12,7 @@ use humhub\libs\Html;
 use humhub\modules\file\libs\ImageHelper;
 use Yii;
 use yii\base\Action;
+use yii\db\ActiveRecord;
 use yii\web\UploadedFile;
 use humhub\libs\Helpers;
 use humhub\modules\file\models\FileUpload;
@@ -136,8 +137,8 @@ class UploadAction extends Action
         }
 
 
-        if ($model != '' && $pk != '' && Helpers::CheckClassType($model, \yii\db\ActiveRecord::class)) {
-
+        /** @var ActiveRecord|string $model */
+        if ($model != '' && $pk != '' && $model = Helpers::checkClassType($model, ActiveRecord::class)) {
             $record = $model::findOne(['id' => $pk]);
             if ($record !== null && ($record instanceof ContentActiveRecord || $record instanceof ContentAddonActiveRecord)) {
                 if ($record->content->canEdit()) {

--- a/protected/humhub/modules/user/models/ProfileField.php
+++ b/protected/humhub/modules/user/models/ProfileField.php
@@ -154,9 +154,8 @@ class ProfileField extends ActiveRecord
         if ($this->_fieldType != null)
             return $this->_fieldType;
 
-        if ($this->field_type_class != '' && Helpers::CheckClassType($this->field_type_class, fieldtype\BaseType::class)) {
-            $type = $this->field_type_class;
-            $this->_fieldType = new $type;
+        if ($this->field_type_class != '' && $type = Helpers::checkClassType($this->field_type_class, fieldtype\BaseType::class)) {
+            $this->_fieldType = new $type();
             $this->_fieldType->setProfileField($this);
             return $this->_fieldType;
         }

--- a/protected/humhub/modules/user/models/fieldtype/BaseType.php
+++ b/protected/humhub/modules/user/models/fieldtype/BaseType.php
@@ -31,17 +31,17 @@ class BaseType extends Model
 
     /**
      * @event Event an event raised after init. Can be used to add custom field types.
-     * 
+     *
      * Example config.php:
      *     'events' => [
      *         [BaseType::class, BaseType::EVENT_INIT, [Events::class, 'onFieldTypesInit']]
      *     ]
-     * 
+     *
      * Example Events.php:
      *     public static function onFieldTypesInit($event) {
      *         $event->sender->addFieldType(CustomFieldType::class, "Custom field");
      *     }
-     * 
+     *
      * @since 1.12
      */
     const EVENT_INIT = "fieldTypesInit";
@@ -172,19 +172,18 @@ class BaseType extends Model
     {
         $types = [];
         foreach ($this->getFieldTypes() as $className => $title) {
-            if (Helpers::CheckClassType($className, static::class)) {
-                /** @var BaseType $instance */
-                $instance = new $className;
-                if ($profileField !== null) {
-                    $instance->profileField = $profileField;
+            $className = Helpers::checkClassType($className, static::class);
+            /** @var BaseType $instance */
+            $instance = new $className();
+            if ($profileField !== null) {
+                $instance->profileField = $profileField;
 
-                    // Seems current type, so try load data
-                    if ($profileField->field_type_class == $className) {
-                        $instance->loadFieldConfig();
-                    }
+                // Seems current type, so try load data
+                if ($profileField->field_type_class == $className) {
+                    $instance->loadFieldConfig();
                 }
-                $types[] = $instance;
             }
+            $types[] = $instance;
         }
 
         return $types;

--- a/protected/humhub/tests/codeception/unit/libs/HelpersTest.php
+++ b/protected/humhub/tests/codeception/unit/libs/HelpersTest.php
@@ -1,0 +1,260 @@
+<?php
+
+/*
+ * @link https://www.humhub.org/
+ * @copyright Copyright (c) 2018 HumHub GmbH & Co. KG
+ * @license https://www.humhub.com/licences
+ */
+
+/**
+ * @noinspection PhpIllegalPsrClassPathInspection
+ */
+
+namespace humhub\tests\codeception\unit\libs;
+
+use Codeception\Test\Unit;
+use humhub\exceptions\InvalidArgumentClassException;
+use humhub\exceptions\InvalidArgumentTypeException;
+use humhub\exceptions\InvalidArgumentValueException;
+use humhub\libs\Helpers;
+use PHPUnit\Framework\Exception;
+use yii\base\ArrayableTrait;
+use yii\base\BaseObject;
+use yii\base\Configurable;
+use yii\base\Model;
+
+/**
+ * Class MimeHelperTest
+ *
+ * @noinspection IdentifierGrammar
+ */
+class HelpersTest extends Unit
+{
+    public function testClassTypeCheckCase1()
+    {
+        $message = 'Argument $type passed to humhub\libs\Helpers::checkClassType must be one of string, string[] - NULL given.';
+
+        $this->expectException(InvalidArgumentValueException::class);
+        $this->expectExceptionMessage($message);
+        $this->expectExceptionCode(Helpers::CLASS_CHECK_INVALID_TYPE_PARAMETER + Helpers::CLASS_CHECK_VALUE_IS_EMPTY);
+
+        Helpers::checkClassType(null, null);
+    }
+
+    public function testClassTypeCheckCase2()
+    {
+        $message = 'Argument $type passed to humhub\libs\Helpers::checkClassType must be one of string, string[] - empty string given.';
+
+        $this->expectException(InvalidArgumentValueException::class);
+        $this->expectExceptionMessage($message);
+        $this->expectExceptionCode(Helpers::CLASS_CHECK_INVALID_TYPE_PARAMETER + Helpers::CLASS_CHECK_VALUE_IS_EMPTY);
+
+        Helpers::checkClassType(null, '');
+    }
+
+    public function testClassTypeCheckCase3()
+    {
+        $message = 'Argument $type passed to humhub\libs\Helpers::checkClassType must be one of string, string[] - [] given.';
+
+        $this->expectException(InvalidArgumentValueException::class);
+        $this->expectExceptionMessage($message);
+        $this->expectExceptionCode(Helpers::CLASS_CHECK_INVALID_TYPE_PARAMETER + Helpers::CLASS_CHECK_VALUE_IS_EMPTY);
+
+        Helpers::checkClassType(null, []);
+    }
+
+    public function testClassTypeCheckCase4()
+    {
+        $message = 'Argument $type passed to humhub\libs\Helpers::checkClassType must be one of string, string[] - 0 given.';
+
+        $this->expectException(InvalidArgumentValueException::class);
+        $this->expectExceptionMessage($message);
+        $this->expectExceptionCode(Helpers::CLASS_CHECK_INVALID_TYPE_PARAMETER + Helpers::CLASS_CHECK_VALUE_IS_EMPTY);
+
+        Helpers::checkClassType(null, 0);
+    }
+
+    public function testClassTypeCheckCase5()
+    {
+        $message = 'Argument $type passed to humhub\libs\Helpers::checkClassType must be one of string, string[] - \'0\' given.';
+
+        $this->expectException(InvalidArgumentValueException::class);
+        $this->expectExceptionMessage($message);
+        $this->expectExceptionCode(Helpers::CLASS_CHECK_INVALID_TYPE_PARAMETER + Helpers::CLASS_CHECK_VALUE_IS_EMPTY);
+
+        Helpers::checkClassType(null, '0');
+    }
+
+
+    public function testClassTypeCheckCase6()
+    {
+        $message = 'Argument $type[0] passed to humhub\libs\Helpers::checkClassType must be a valid class/interface/trait name or an object instance - humhub\tests\codeception\unit\libs\NonExistingClassName given.';
+
+        $this->expectException(InvalidArgumentValueException::class);
+        $this->expectExceptionMessage($message);
+        $this->expectExceptionCode(Helpers::CLASS_CHECK_INVALID_TYPE_PARAMETER + Helpers::CLASS_CHECK_NON_EXISTING_CLASS);
+
+        /** @noinspection PhpUndefinedClassInspection */
+        Helpers::checkClassType(null, NonExistingClassName::class);
+    }
+
+    public function testClassTypeCheckCase7()
+    {
+        $message = 'Argument $type[1] passed to humhub\libs\Helpers::checkClassType must be a valid class/interface/trait name or an object instance - humhub\tests\codeception\unit\libs\NonExistingClassName given.';
+
+        $this->expectException(InvalidArgumentValueException::class);
+        $this->expectExceptionMessage($message);
+        $this->expectExceptionCode(Helpers::CLASS_CHECK_INVALID_TYPE_PARAMETER + Helpers::CLASS_CHECK_NON_EXISTING_CLASS);
+
+        /** @noinspection PhpUndefinedClassInspection */
+        Helpers::checkClassType(null, [BaseObject::class, NonExistingClassName::class]);
+    }
+
+    public function testClassTypeCheckCaseNull()
+    {
+        static::assertNull(
+            Helpers::checkClassType(null, BaseObject::class, false)
+        );
+
+        static::assertNull(
+            Helpers::checkClassType(null, [BaseObject::class, null])
+        );
+
+        $message = 'Argument $className passed to humhub\libs\Helpers::checkClassType must be of type yii\base\BaseObject - NULL given.';
+
+        $this->expectException(InvalidArgumentTypeException::class);
+        $this->expectExceptionMessage($message);
+        $this->expectExceptionCode(Helpers::CLASS_CHECK_INVALID_CLASSNAME_PARAMETER + Helpers::CLASS_CHECK_VALUE_IS_EMPTY + Helpers::CLASS_CHECK_INVALID_TYPE + Helpers::CLASS_CHECK_VALUE_IS_NULL);
+
+        Helpers::checkClassType(null, BaseObject::class);
+    }
+
+    public function testClassTypeCheckCaseEmptyString()
+    {
+        static::assertNull(
+            Helpers::checkClassType('', BaseObject::class, false)
+        );
+
+        static::assertNull(
+            Helpers::checkClassType('', [BaseObject::class, null], true, false)
+        );
+
+        $message = 'Argument $className passed to humhub\libs\Helpers::checkClassType must be of type yii\base\BaseObject - empty string given.';
+
+        $this->expectException(InvalidArgumentClassException::class);
+        $this->expectExceptionMessage($message);
+        $this->expectExceptionCode(Helpers::CLASS_CHECK_INVALID_CLASSNAME_PARAMETER + Helpers::CLASS_CHECK_VALUE_IS_EMPTY + Helpers::CLASS_CHECK_INVALID_TYPE + Helpers::CLASS_CHECK_TYPE_NOT_IN_LIST);
+
+        Helpers::checkClassType('', BaseObject::class);
+    }
+
+    public function testClassTypeCheckCaseString()
+    {
+        /** @noinspection PhpUndefinedClassInspection */
+        static::assertNull(
+            Helpers::checkClassType(NonExistingClassName::class, BaseObject::class, false)
+        );
+
+        $message = 'Argument $className passed to humhub\libs\Helpers::checkClassType must be a valid class name or an object instance - humhub\tests\codeception\unit\libs\NonExistingClassName given.';
+
+        $this->expectException(InvalidArgumentValueException::class);
+        $this->expectExceptionMessage($message);
+        $this->expectExceptionCode(Helpers::CLASS_CHECK_INVALID_CLASSNAME_PARAMETER + Helpers::CLASS_CHECK_NON_EXISTING_CLASS);
+
+        /** @noinspection PhpUndefinedClassInspection */
+        Helpers::checkClassType(NonExistingClassName::class, BaseObject::class);
+    }
+
+    public function testClassTypeCheckCaseWrongClass()
+    {
+        static::assertNull(
+            Helpers::checkClassType(Exception::class, BaseObject::class, false)
+        );
+
+        $message = 'Argument $className passed to humhub\libs\Helpers::checkClassType must be of type yii\base\BaseObject - PHPUnit\Framework\Exception given.';
+
+        $this->expectException(InvalidArgumentClassException::class);
+        $this->expectExceptionMessage($message);
+        $this->expectExceptionCode(Helpers::CLASS_CHECK_INVALID_CLASSNAME_PARAMETER + Helpers::CLASS_CHECK_TYPE_NOT_IN_LIST);
+
+        Helpers::checkClassType(Exception::class, BaseObject::class);
+    }
+
+    public function testClassTypeCheckCaseWrongInstance()
+    {
+        static::assertNull(
+            Helpers::checkClassType(new Exception('hello'), BaseObject::class, false)
+        );
+
+        $message = 'Argument $className passed to humhub\libs\Helpers::checkClassType must be of type yii\base\BaseObject - PHPUnit\Framework\Exception given.';
+
+        $this->expectException(InvalidArgumentClassException::class);
+        $this->expectExceptionMessage($message);
+        $this->expectExceptionCode(Helpers::CLASS_CHECK_INVALID_CLASSNAME_PARAMETER + Helpers::CLASS_CHECK_TYPE_NOT_IN_LIST + Helpers::CLASS_CHECK_VALUE_IS_INSTANCE);
+
+        Helpers::checkClassType(new Exception('hello'), BaseObject::class);
+    }
+
+    public function testClassTypeCheckCaseCorrectClass()
+    {
+        static::assertEquals(
+            Exception::class,
+            Helpers::checkClassType(Exception::class, Exception::class)
+        );
+
+        static::assertEquals(
+            Exception::class,
+            Helpers::checkClassType(Exception::class, [new \Exception()])
+        );
+
+        static::assertEquals(
+            BaseObject::class,
+            Helpers::checkClassType(BaseObject::class, Configurable::class)
+        );
+
+        static::assertEquals(
+            Model::class,
+            Helpers::checkClassType(Model::class, ArrayableTrait::class)
+        );
+
+        static::assertEquals(
+            Exception::class,
+            Helpers::checkClassType('#%' . Exception::class, Exception::class, false, false)
+        );
+
+        static::assertNull(
+            Helpers::checkClassType('#%' . Exception::class, Exception::class, false, true)
+        );
+
+        $message = 'Argument $className passed to humhub\libs\Helpers::checkClassType must be a valid class name or an object instance - #%PHPUnit\Framework\Exception given.';
+
+        $this->expectException(InvalidArgumentClassException::class);
+        $this->expectExceptionMessage($message);
+        $this->expectExceptionCode(Helpers::CLASS_CHECK_INVALID_CLASSNAME_PARAMETER);
+
+        Helpers::checkClassType('#%' . Exception::class, Exception::class);
+    }
+
+    public function testClassTypeCheckCaseCorrectInstance()
+    {
+        static::assertEquals(
+            Exception::class,
+            Helpers::checkClassType(new Exception('hello'), Exception::class)
+        );
+
+        static::assertEquals(
+            Exception::class,
+            Helpers::checkClassType(new Exception('hello'), [new \Exception()])
+        );
+
+        static::assertEquals(
+            BaseObject::class,
+            Helpers::checkClassType(new BaseObject(), Configurable::class)
+        );
+
+        static::assertEquals(
+            Model::class,
+            Helpers::checkClassType(new Model(), ArrayableTrait::class)
+        );
+    }
+}


### PR DESCRIPTION
Besides fixing #6547, this version of `\humhub\libs\Helpers::checkClassType()` allows
- providing an object instance, rather than a class name, to be tested
- allows to return a negative result, rather than throwing an exception
- allows to distinguish between an invalid parameter `$className` and an invalid parameter `$type` (different code in Exception)

Depends and includes
- #6566

## PR Admin

### What kind of change does this PR introduce?

- Bugfix (Fix #6547)
- Feature
- Code style update

### Does this PR introduce a breaking change?

- Yes

The current version of the function throws a `\yii\base\Exception` if the type is not met.
The new version of the function throws a `\humhub\exceptions\InvalidArgumentException`, which derives from `\yii\base\InvalidArgumentException` and `\yii\base\InvalidParamException`, but not `\yii\base\Exception`.

As such, if the calling code is handling the exception (which is not the case anywhere in the core code) with the specific exception class `\yii\base\Exception` (and not the more generic `\Exception` or even `\Throwable`), then the `catch` clause needs to be updated/extended.

**Note:** the [change in the method name](https://github.com/humhub/humhub/compare/develop...metaworx:humhub:enh/improve-class-type-validation?expand=1#diff-764f074e8da6eac0b7a0597550ed7fa54638193a0f93d21181ed8ef5c3a18fc4R189) (case change) **does not constitute** a breaking change, as method names are case-insensitive. Nonetheless, the core code has been updated accordingly.

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [x] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [x] [All tests are passing](#issuecomment-new)
- [ ] New/updated tests are included
- [x] Changelog was modified

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
