### PR TITLE
Fix empty profile field type causing an unspecific error

### DIFF
--- a/CHANGELOG-DEV.md
+++ b/CHANGELOG-DEV.md
@@ -4,6 +4,7 @@ HumHub Changelog
 1.15.0-beta.2 (Unreleased)
 --------------------------
 - Fix #6551: Migration's transaction with invalid savepoint
+- Fix #6549: Empty profile field type causing an unspecific error
 - Enh #6529: Add boolean return-type to `*safe*` methods in migrations
 - Enh #6478: Add pseudo test class to allow population of DB with standard test data
 - Enh #6480: Convert assert* and db* methods to static, in line with general usage pattern

--- a/protected/humhub/modules/user/models/Profile.php
+++ b/protected/humhub/modules/user/models/Profile.php
@@ -11,6 +11,7 @@ namespace humhub\modules\user\models;
 use humhub\components\ActiveRecord;
 use humhub\modules\user\services\AuthClientUserService;
 use Yii;
+use yii\base\Exception;
 
 /**
  * This is the model class for table "profile".
@@ -50,14 +51,12 @@ use Yii;
  */
 class Profile extends ActiveRecord
 {
-
-
     /**
      * @since 1.3.2
      */
-    const SCENARIO_EDIT_ADMIN = 'editAdmin';
-    const SCENARIO_REGISTRATION = 'registration';
-    const SCENARIO_EDIT_PROFILE = 'editProfile';
+    public const SCENARIO_EDIT_ADMIN = 'editAdmin';
+    public const SCENARIO_REGISTRATION = 'registration';
+    public const SCENARIO_EDIT_PROFILE = 'editProfile';
 
 
     /**
@@ -79,10 +78,7 @@ class Profile extends ActiveRecord
             [['user_id'], 'integer'],
         ];
 
-        foreach (ProfileField::find()->all() as $profileField) {
-            if ($profileField->getFieldType()->isVirtual) {
-                continue;
-            }
+        foreach (static::getValidProfileFields(true) as $profileField) {
             $rules = array_merge($rules, $profileField->getFieldType()->getFieldRules());
         }
 
@@ -111,10 +107,9 @@ class Profile extends ActiveRecord
             $syncAttributes = (new AuthClientUserService($this->user))->getSyncAttributes();
         }
 
-        foreach (ProfileField::find()->all() as $profileField) {
+        foreach (static::getValidProfileFields() as $profileField) {
             // Some fields consist of multiple field definitions (e.g. Birthday)
             foreach ($profileField->fieldType->getFieldFormDefinition($this->user) as $fieldName => $definition) {
-
                 // Skip automatically synced attributes (readonly)
                 if (in_array($profileField->internal_name, $syncAttributes)) {
                     continue;
@@ -190,7 +185,7 @@ class Profile extends ActiveRecord
         }
 
         $labels = [];
-        foreach (ProfileField::find()->all() as $profileField) {
+        foreach (static::getValidProfileFields() as $profileField) {
             /** @var ProfileField $profileField */
             $labels = array_merge($labels, $profileField->getFieldType()->getLabels());
         }
@@ -219,7 +214,6 @@ class Profile extends ActiveRecord
         $safeAttributes = $this->safeAttributes();
 
         foreach (ProfileFieldCategory::find()->orderBy('sort_order')->all() as $profileFieldCategory) {
-
             $category = [
                 'type' => 'form',
                 'title' => Yii::t($profileFieldCategory->getTranslationCategory(), $profileFieldCategory->title),
@@ -248,7 +242,7 @@ class Profile extends ActiveRecord
 
                 $fieldDefinition = $profileField->fieldType->getFieldFormDefinition($this->user);
 
-                if(isset($fieldDefinition[$profileField->internal_name]) && !empty($profileField->description)) {
+                if (isset($fieldDefinition[$profileField->internal_name]) && !empty($profileField->description)) {
                     $fieldDefinition[$profileField->internal_name]['hint'] =  Yii::t($profileField->getTranslationCategory() ?: $profileFieldCategory->getTranslationCategory(), $profileField->description);
                 }
 
@@ -268,11 +262,7 @@ class Profile extends ActiveRecord
      */
     public function beforeSave($insert)
     {
-        foreach (ProfileField::find()->all() as $profileField) {
-            /** @var ProfileField $profileField */
-            if ($profileField->getFieldType()->isVirtual) {
-                continue;
-            }
+        foreach (static::getValidProfileFields(true) as $profileField) {
             $key = $profileField->internal_name;
             $this->$key = $profileField->getFieldType()->beforeProfileSave($this->$key);
         }
@@ -346,6 +336,56 @@ class Profile extends ActiveRecord
     }
 
     /**
+     * Returns unsorted, unfiltered list of ProfileFields, skipping those without a valid field type
+     *
+     * @param bool $skipVirtual if provided and true, virtual fields will be omitted
+     *
+     * @return array
+     * @since 1.15
+     * @noinspection PhpDocMissingThrowsInspection
+     */
+    protected static function &getValidProfileFields(bool $skipVirtual = false): array
+    {
+        $result = [];
+
+        foreach (ProfileField::find()->all() as $profileField) {
+            try {
+                $fieldType = $profileField->getFieldType();
+            } catch (Exception $e) {
+                if (YII_DEBUG) {
+                    /** @noinspection PhpUnhandledExceptionInspection */
+                    throw $e;
+                }
+
+                Yii::error($e->getMessage());
+
+                continue;
+            }
+
+            if ($fieldType === null) {
+                $message = sprintf("Field %s has no valid type associated", $profileField->internal_name);
+
+                if (YII_DEBUG) {
+                    /** @noinspection PhpUnhandledExceptionInspection */
+                    throw new \Exception($message);
+                }
+
+                Yii::error($message);
+
+                continue;
+            }
+
+            if ($skipVirtual && $fieldType->isVirtual) {
+                continue;
+            }
+
+            $result[] = $profileField;
+        }
+
+        return $result;
+    }
+
+    /**
      * Soft delete will empty all profile fields except these defined in the module configuration.
      */
     public function softDelete()
@@ -363,5 +403,4 @@ class Profile extends ActiveRecord
             Yii::error('Could not soft delete profile!');
         }
     }
-
 }


### PR DESCRIPTION
### What kind of change does this PR introduce?
- Bugfix

### Does this PR introduce a breaking change?
- No

### The PR fulfills these requirements

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [x] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [x] [All tests are passing](#issuecomment-new)
- [ ] New/updated tests are included
- [x] Changelog was modified


### Other information

The error has repeatedly happened in `\humhub\modules\user\models\Profile::rules()`. Not sure what caused the issue. Something to do with initial data or migrations failed. However, the error that a property on null value was accessed is not very helpful. Now, in `YII_DEBUG` a more meaningful exception is thrown, while without debug the field is ignored, issuing an error log entry.