### PR TITLE
Enh: Support log assertions

### DIFF
--- a/CHANGELOG-DEV.md
+++ b/CHANGELOG-DEV.md
@@ -3,6 +3,7 @@ HumHub Changelog
 
 1.16.0 (Unreleased)
 -------------------
+- Enh #6553: Support log assertions
 - Enh #6530: Small performance improvements
 - Fix #6511: Only test compatible modules in `onMarketplaceAfterFilterModules()`
 - Enh #6511: Backup folder path is now return from `removeModule()`

--- a/protected/humhub/tests/codeception/_support/ArrayTarget.php
+++ b/protected/humhub/tests/codeception/_support/ArrayTarget.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * @link      https://www.humhub.org/
+ * @copyright Copyright (c) 2023 HumHub GmbH & Co. KG
+ * @license   https://www.humhub.com/licences
+ */
+
+namespace tests\codeception\_support;
+
+use yii\log\Target;
+
+class ArrayTarget extends Target
+{
+    protected array $messageStore = [];
+
+    /**
+     * @inheritDoc
+     */
+    public function export()
+    {
+        $this->messageStore = array_merge($this->messageStore, $this->messages);
+        $this->messages = [];
+    }
+
+    public function flush()
+    {
+        $this->messageStore = [];
+    }
+
+
+    /**
+     * @param int|string[]|null $levels
+     * @param array|null $categories
+     * @param array|null $except
+     *
+     * @return array
+     */
+    public function &getMessages($levels = 0, ?array $categories = null, ?array $except = null): array
+    {
+        $messages = static::filterMessages($this->messageStore, $levels ?? 0, $categories ?? [], $except ?? []);
+
+        return $messages;
+    }
+}

--- a/protected/humhub/tests/codeception/_support/HumHubDbTestCase.php
+++ b/protected/humhub/tests/codeception/_support/HumHubDbTestCase.php
@@ -85,6 +85,14 @@ class HumHubDbTestCase extends Unit
         parent::setUp();
     }
 
+    protected function tearDown(): void
+    {
+        static::logReset();
+
+        parent::tearDown();
+    }
+
+
     /**
      * Initializes modules defined in @tests/codeception/config/test.config.php
      * Note the config key in test.config.php is modules and not humhubModules!
@@ -262,7 +270,7 @@ class HumHubDbTestCase extends Unit
         $this->assertEquals($subject, str_replace(["\n", "\r"], '', $message->getSubject()));
     }
 
-    public function assertEvents(array $events, string $message = ''): void
+    public function assertEvents(array $events = [], string $message = ''): void
     {
         static::assertEquals($events, $this->firedEvents, $message);
 

--- a/protected/humhub/tests/codeception/_support/HumHubHelperTrait.php
+++ b/protected/humhub/tests/codeception/_support/HumHubHelperTrait.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * @link      https://www.humhub.org/
  * @copyright Copyright (c) 2023 HumHub GmbH & Co. KG
@@ -12,11 +13,27 @@ use humhub\modules\content\widgets\richtext\converter\RichTextToHtmlConverter;
 use humhub\modules\content\widgets\richtext\converter\RichTextToMarkdownConverter;
 use humhub\modules\content\widgets\richtext\converter\RichTextToPlainTextConverter;
 use humhub\modules\content\widgets\richtext\converter\RichTextToShortTextConverter;
+use PHPUnit\Framework\Constraint\LogicalNot;
+use PHPUnit\Framework\Exception;
 use Yii;
+use yii\base\ErrorException;
+use yii\base\InvalidConfigException;
 use yii\helpers\FileHelper;
+use yii\log\Dispatcher;
 
+use function PHPUnit\Framework\assertEquals;
+
+/**
+ * Humhub Test Helper Functions
+ *
+ * @since 1.15
+ */
 trait HumHubHelperTrait
 {
+    protected static ?ArrayTarget $logTarget = null;
+    protected static ?\yii\log\Logger $logOldLogger = null;
+    private static $logOldDispatcher;
+
     protected function flushCache(?string $caller = null)
     {
         codecept_debug(sprintf('[%s] Flushing cache', $caller ?? __METHOD__));
@@ -54,5 +71,293 @@ trait HumHubHelperTrait
                 unlink($file); // delete file
             }
         }
+    }
+
+    /**
+     * Start capturing log entries, in order to later check them with `assertLog*` and `assertNotLog*` functions
+     *
+     **********************************************************************************************************************
+     *
+     *  ## Assert Log Messages
+     *
+     *  In order to use the assertLog* functions, all you need to do is:
+     *  - call `static::logInitialize();` before you expect the log output
+     *  - run the code that should generate the log entries
+     *  - call any of the `assertLog*` or `assertNotLog*` functions to test for the (un)expected log message
+     *  - optionally call `static::logFlush();` if you want to run more log-generating code
+     *  - optionally call `static::logReset();` when you no longer need the log to be captured within the test. Though, this
+     *    will automatically be called during `tearDown()`.
+     *
+     *  If you need all log entries, call `static::logFilterMessageTexts()` with no arguments, or if you want the complete
+     *  log information, use `static::logFilterMessages()`. For the format of the returned array elements to the latter,
+     *  please see `\yii\log\Logger::$messages`.
+     *
+     *  For some kind of sample implementation, please see `\humhub\tests\codeception\unit\LogAssertionsSelfTest`
+     * **********************************************************************************************************************
+     *
+     * @throws InvalidConfigException
+     * @since 1.16
+     * @see \yii\log\Logger::$messages
+     * @see \humhub\tests\codeception\unit\LogAssertionsSelfTest
+     */
+    protected static function logInitialize()
+    {
+        if (self::$logTarget !== null) {
+            return;
+        }
+
+        // save application's dispatcher
+        self::$logOldDispatcher = Yii::$app->getLog();
+
+        // create a new dispatcher target to store the log entries
+        self::$logTarget = Yii::createObject([
+            'class' => ArrayTarget::class,
+            'levels' => [
+                'error',
+                'warning',
+                'info',
+                'trace', // aka debug
+                // 'profile',
+            ],
+            'except' => [],
+            'logVars' => [],
+        ]);
+
+        // create a new proxy logger that forwards log entries both to the current logger as well as to the above target
+        Yii::setLogger(new Logger(['proxy' => Yii::getLogger()]));
+
+        /**
+         * will automagically connect to the logger set above
+         *
+         * @see Dispatcher::__construct
+         * @see Dispatcher::getLogger
+         */
+        Yii::$app->set('log', Yii::createObject(['class' => Dispatcher::class, 'targets' => [static::class => self::$logTarget]]));
+    }
+
+    /**
+     * Flush the captured log entries without stopping to capture them
+     *
+     * @since 1.16
+     * @see static::logInitialize()
+     */
+    protected static function logFlush()
+    {
+        if (self::$logTarget === null) {
+            return;
+        }
+
+        Yii::getLogger()->flush();
+        self::$logTarget->messages = [];
+        self::$logTarget->flush();
+    }
+
+    /**
+     * Delete any captured log entry and stop capturing new entries. Automatically called by `static::tearDown()`
+     *
+     * @throws InvalidConfigException
+     * @since 1.16
+     * @see static::logInitialize()
+     * @see static::tearDown()
+     */
+    protected static function logReset()
+    {
+        if (self::$logTarget === null) {
+            return;
+        }
+
+        if (Yii::$app->getLog()->targets[static::class] ?? null === self::$logTarget) {
+            Yii::$app->set('log', self::$logOldDispatcher);
+        }
+        self::$logOldDispatcher = null;
+
+        $logger = Yii::getLogger();
+
+        if ($logger instanceof Logger) {
+            Yii::setLogger($logger->proxy);
+        } else {
+            Yii::setLogger(null);
+        }
+
+        self::$logTarget = null;
+    }
+
+    /**
+     * Returns the array of captured log message arrays
+     *
+     * @param int|int[]|null $levels Array or bitmask of verbosity levels to be returned:
+     *                                  Logger::LEVEL_ERROR, Logger::LEVEL_WARNING, Logger::LEVEL_INFO, Logger::LEVEL_TRACE
+     * @param string[]|null $categories Array of categories to be returned or null for any
+     * @param string[]|null $exceptCategories Array of categories NOT to be returned, or null for no exclusion
+     *
+     * @return array of message, following the format of `\yii\log\Logger::$messages`
+     * @throws ErrorException
+     * @since 1.16
+     * @see static::logInitialize()
+     * @see \yii\log\Logger::$messages
+     */
+    public static function &logFilterMessages($levels = null, ?array $categories = null, ?array $exceptCategories = null): array
+    {
+        if (self::$logTarget === null) {
+            throw new ErrorException("Log has not been initialized");
+        }
+
+        Yii::getLogger()->flush();
+        self::$logTarget->export();
+
+        return self::$logTarget->getMessages($levels ?? 0, $categories, $exceptCategories);
+    }
+
+    /**
+     * Returns an array of captured log messages as string (without the category or level)
+     *
+     * @throws ErrorException
+     * @since 1.16
+     * @see static::logInitialize()
+     * @see static::logFilterMessages()
+     */
+    public static function logFilterMessageTexts($levels = null, ?array $categories = null, ?array $exceptCategories = null): array
+    {
+        return array_column(static::logFilterMessages($levels, $categories, $exceptCategories), 0);
+    }
+
+    /**
+     * @param string|null $logMessage If not null, at least one of the filtered messages must match `$logMessage` exactly
+     *
+     * @throws ErrorException
+     * @see static::logInitialize()
+     * @see static::logFilterMessages()
+     * @since 1.16
+     */
+    public static function assertLog(?string $logMessage = null, $levels = null, ?array $categories = null, ?array $exceptCategories = null, $errorMessage = null)
+    {
+        $messages = static::logFilterMessageTexts($levels, $categories, $exceptCategories);
+
+        if ($logMessage === null) {
+            static::assertNotEmpty($messages, $errorMessage ?? print_r(static::logFilterMessageTexts(), true));
+        } else {
+            static::assertContains($logMessage, $messages, $errorMessage ?? print_r(static::logFilterMessageTexts(), true));
+        }
+    }
+
+    /**
+     * @param string|null $logMessage If not null, at least one of the filtered messages must match `$logMessage` exactly
+     *
+     * @throws ErrorException
+     * @see static::logInitialize()
+     * @see static::logFilterMessages()
+     * @since 1.16
+     */
+    public static function assertLogCount(int $expectedCount, ?string $logMessage = null, $levels = null, ?array $categories = null, ?array $exceptCategories = null, $errorMessage = null)
+    {
+        $messages = static::logFilterMessageTexts($levels, $categories, $exceptCategories);
+
+        if ($logMessage !== null) {
+            $messages = array_filter($messages, static fn($text) => $text === $logMessage);
+        }
+
+        static::assertCount($expectedCount, $messages, $errorMessage ?? print_r(static::logFilterMessageTexts(), true));
+    }
+
+    /**
+     * @param string|null $logMessage If not null, at least one of the filtered messages must match `$logMessage` exactly
+     *
+     * @throws ErrorException
+     * @since 1.16
+     * @see static::logInitialize()
+     * @see static::logFilterMessages()
+     */
+    public static function assertNotLog(?string $logMessage = null, $levels = null, ?array $categories = null, ?array $exceptCategories = null, $errorMessage = null)
+    {
+        $messages = static::logFilterMessageTexts($levels, $categories, $exceptCategories);
+
+        if ($logMessage === null) {
+            static::assertEmpty($messages, $errorMessage ?? print_r(static::logFilterMessageTexts(), true));
+        } else {
+            static::assertNotContains($logMessage, $messages, $errorMessage ?? print_r(static::logFilterMessageTexts(), true));
+        }
+    }
+
+    /**
+     * @param string $regex At least one of the filtered messages must match the given `$regex` pattern
+     *
+     * @throws ErrorException|Exception
+     * @since 1.16
+     * @see static::logInitialize()
+     * @see static::logFilterMessages()
+     */
+    public static function assertLogRegex(string $regex, $levels = null, ?array $categories = null, ?array $exceptCategories = null, $errorMessage = null)
+    {
+        $messages = static::logFilterMessageTexts($levels, $categories, $exceptCategories);
+
+        static::asserContainsRegex($regex, $messages, $errorMessage ?? print_r(static::logFilterMessageTexts(), true));
+    }
+
+    /**
+     * @param string $regex At least one of the filtered messages must match the given `$regex` pattern
+     *
+     * @throws ErrorException|Exception
+     * @since 1.16
+     * @see static::logInitialize()
+     * @see static::logFilterMessages()
+     */
+    public static function assertLogRegexCount(int $expectedCount, string $regex, $levels = null, ?array $categories = null, ?array $exceptCategories = null, $errorMessage = null)
+    {
+        $messages = static::logFilterMessageTexts($levels, $categories, $exceptCategories);
+
+        if (count($messages)) {
+            try {
+                preg_match($regex, '');
+            } catch (ErrorException $e) {
+                throw new Exception("Invalid regex given: '{$regex}'");
+            }
+
+            $messages = array_filter($messages, static fn($text) => preg_match($regex, $text));
+        }
+
+        static::assertCount($expectedCount, $messages, $errorMessage ?? print_r(static::logFilterMessageTexts(), true));
+    }
+
+    /**
+     * @param string $regex None of the filtered messages may match the given `$regex` pattern
+     *
+     * @throws ErrorException|Exception
+     * @since 1.16
+     * @see static::logInitialize()
+     * @see static::logFilterMessages()
+     */
+    public static function assertNotLogRegex(string $regex, $levels = null, ?array $categories = null, ?array $exceptCategories = null, $errorMessage = null)
+    {
+        $messages = static::logFilterMessageTexts($levels, $categories, $exceptCategories);
+
+        static::assertNotContainsRegex($regex, $messages, $errorMessage ?? print_r(static::logFilterMessageTexts(), true));
+    }
+
+    /**
+     * Asserts that `$haystack` contains an element that matches the `$regex`
+     *
+     * @since 1.16
+     * @throws Exception
+     */
+    public static function asserContainsRegex(string $regex, iterable $haystack, string $message = ''): void
+    {
+        $constraint = new TraversableContainsRegex($regex);
+
+        static::assertThat($haystack, $constraint, $message);
+    }
+
+    /**
+     * Asserts that `$haystack` does not contain an element that matches the `$regex`
+     *
+     * @since 1.16
+     * @throws Exception
+     */
+    public static function assertNotContainsRegex(string $regex, iterable $haystack, string $message = ''): void
+    {
+        $constraint = new LogicalNot(
+            new TraversableContainsRegex($regex),
+        );
+
+        static::assertThat($haystack, $constraint, $message);
     }
 }

--- a/protected/humhub/tests/codeception/_support/Logger.php
+++ b/protected/humhub/tests/codeception/_support/Logger.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * @link      https://www.humhub.org/
+ * @copyright Copyright (c) 2023 HumHub GmbH & Co. KG
+ * @license   https://www.humhub.com/licences
+ */
+
+namespace tests\codeception\_support;
+
+use yii\log\Logger as YiiLogger;
+
+class Logger extends \Codeception\Lib\Connector\Yii2\Logger
+{
+    public ?YiiLogger $proxy = null;
+
+    public function log($message, $level, $category = 'application')
+    {
+        YiiLogger::log($message, $level, $category);
+
+        if ($this->proxy) {
+            $this->proxy->log($message, $level, $category);
+        }
+    }
+}

--- a/protected/humhub/tests/codeception/_support/TraversableContainsRegex.php
+++ b/protected/humhub/tests/codeception/_support/TraversableContainsRegex.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * @link      https://www.humhub.org/
+ * @copyright Copyright (c) 2023 HumHub GmbH & Co. KG
+ * @license   https://www.humhub.com/licences
+ */
+
+declare(strict_types=1);
+
+namespace tests\codeception\_support;
+
+use PHPUnit\Framework\Constraint\TraversableContains;
+use PHPUnit\Framework\Exception;
+use PHPUnit\Util\RegularExpression as RegularExpressionUtil;
+
+/**
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ */
+final class TraversableContainsRegex extends TraversableContains
+{
+    public function toString(): string
+    {
+        return sprintf(
+            'matches PCRE pattern "%s"',
+            $this->value(),
+        );
+    }
+
+    /**
+     * Evaluates the constraint for parameter $other. Returns true if the
+     * constraint is met, false otherwise.
+     *
+     * @param mixed $other value or object to evaluate
+     */
+    protected function matches($other): bool
+    {
+        $value = $this->value();
+
+        foreach ($other as $element) {
+            while (!is_string($element)) {
+                if ($element instanceof \Stringable || (is_object($element) && !method_exists($element, '__toString'))) {
+                    $element = $element->__toString();
+                    break;
+                }
+
+                continue 2;
+            }
+
+            $match = RegularExpressionUtil::safeMatch($value, $element);
+
+            if ($match === false) {
+                throw new Exception(
+                    "Invalid regex given: '{$value}'",
+                );
+            }
+
+            return $match === 1;
+        }
+
+        return false;
+    }
+}

--- a/protected/humhub/tests/codeception/unit/LogAssertionsSelfTest.php
+++ b/protected/humhub/tests/codeception/unit/LogAssertionsSelfTest.php
@@ -1,0 +1,340 @@
+<?php
+
+/*
+ * @link      https://www.humhub.org/
+ * @copyright Copyright (c) 2023 HumHub GmbH & Co. KG
+ * @license   https://www.humhub.com/licences
+ */
+
+/**
+ * @noinspection PhpClassConstantAccessedViaChildClassInspection
+ */
+
+namespace humhub\tests\codeception\unit;
+
+use Codeception\Lib\Console\Output;
+use Codeception\Util\Debug;
+use PHPUnit\Framework\Exception;
+use tests\codeception\_support\HumHubDbTestCase;
+use tests\codeception\_support\Logger;
+use Yii;
+
+/**
+ * Self-test of the Log Assertions available to other tests
+ *
+ * While this could be used as an example for the assertLog* functions, please note that none of the local methods are
+ * required for anything else than for this self-test.
+ *
+ * @since 1.16
+ * @see static::logInitialize()
+ */
+class LogAssertionsSelfTest extends HumHubDbTestCase
+{
+    protected static ?Output $originalOutput = null;
+    protected static Output $output;
+
+    /**
+     * @var resource|bool
+     */
+    protected static $streamFilter;
+
+    public static ?string $data = null;
+
+
+    public static function setUpBeforeClass(...$args): void
+    {
+        self::$output = new class ($config = ['interactive' => false, 'colors' => false]) extends Output {
+            public bool $forward = false;
+
+            public function doWrite(string $message, bool $newline)
+            {
+                if ($this->forward) {
+                    parent::doWrite($message, $newline);
+                }
+
+                if ($newline) {
+                    $message .= \PHP_EOL;
+                }
+
+                LogAssertionsSelfTest::addData($message);
+            }
+        };
+
+        self::$output->waitForDebugOutput = false;
+
+        if (Debug::isEnabled()) {
+            $rcDebug = new \ReflectionClass(Debug::class);
+            self::$originalOutput = $rcDebug->getStaticPropertyValue('output');
+            self::$output->forward = true;
+        } else {
+            self::$originalOutput = new class ($config = ['interactive' => false, 'colors' => false]) extends Output {
+                public function debug($message)
+                {
+                    // don't do anything
+                }
+            };
+        }
+
+        parent::setUpBeforeClass();
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Debug::setOutput(self::$output);
+
+        static::clean();
+    }
+
+    protected function tearDown(): void
+    {
+        // reset output to original
+        Debug::setOutput(self::$originalOutput);
+
+        static::clean();
+
+        parent::tearDown();
+    }
+
+    public function testNormalDebugMessage()
+    {
+        Yii::error("Foo", "error");
+        self::assertEquals("  [error] 'Foo'\n", static::getClean());
+
+        Yii::warning("Foo", "warning");
+        self::assertEquals("  [warning] 'Foo'\n", static::getClean());
+
+        Yii::info("Foo", "info");
+        self::assertEquals("  [info] 'Foo'\n", static::getClean());
+
+        /**
+         * debug messages are not prited
+         * @see \Codeception\Lib\Connector\Yii2\Logger::log()
+         */
+        Yii::debug("Foo", "debug");
+        self::assertEquals(null, static::getClean());
+    }
+
+    public function testInitializationRequired()
+    {
+        $this->expectException(yii\base\ErrorException::class);
+        $this->expectExceptionMessage('Log has not been initialized');
+
+        static::assertLogCount(1);
+    }
+
+    /**
+     * @noinspection UnsetConstructsCanBeMergedInspection
+     */
+    public function testAssertingDebugMessage()
+    {
+        static::logInitialize();
+
+        static::assertLogCount(0);
+
+        Yii::error("Foo", "LogAssertionsSelfTest_error");
+        self::assertEquals("  [LogAssertionsSelfTest_error] 'Foo'\n", static::getClean());
+        static::assertLogCount(1);
+        static::assertLogCount(1, null, Logger::LEVEL_ERROR);
+        static::assertLogCount(0, null, Logger::LEVEL_WARNING | Logger::LEVEL_INFO | Logger::LEVEL_TRACE);
+        static::assertLogCount(1, 'Foo');
+        static::assertLog('Foo');
+        static::assertLog('Foo', Logger::LEVEL_ERROR);
+        static::assertLog('Foo', Logger::LEVEL_ERROR, ['LogAssertionsSelfTest_error']);
+        static::assertLog('Foo', null, ['LogAssertionsSelfTest_error']);
+        static::assertLog(null, Logger::LEVEL_ERROR);
+        static::assertLog(null, Logger::LEVEL_ERROR, ['LogAssertionsSelfTest_error']);
+        static::assertLog(null, null, ['LogAssertionsSelfTest_error']);
+        static::assertLog(null, null, null, ['LogAssertionsSelfTest_warning']);
+        static::assertLog();
+        static::assertNotLog('Bar');
+        static::assertNotLog(null, Logger::LEVEL_WARNING);
+        static::assertNotLog(null, null, ['LogAssertionsSelfTest_warning']);
+        static::assertNotLog('Bar', null, ['LogAssertionsSelfTest_error', 'LogAssertionsSelfTest_warning']);
+        static::assertNotLog('Foo', null, null, ['LogAssertionsSelfTest_error']);
+
+        Yii::warning("Foo", "LogAssertionsSelfTest_warning");
+        self::assertEquals("  [LogAssertionsSelfTest_warning] 'Foo'\n", static::getClean());
+        static::assertLogCount(2);
+        static::assertLogCount(1, null, Logger::LEVEL_ERROR);
+        static::assertLogCount(1, null, Logger::LEVEL_WARNING);
+        static::assertLogCount(2, null, Logger::LEVEL_ERROR | Logger::LEVEL_WARNING);
+        static::assertLogCount(0, null, Logger::LEVEL_INFO | Logger::LEVEL_TRACE);
+        static::assertLogCount(2, 'Foo');
+        static::assertLog('Foo', Logger::LEVEL_ERROR, ['LogAssertionsSelfTest_error']);
+        static::assertLog('Foo', Logger::LEVEL_WARNING, ['LogAssertionsSelfTest_warning']);
+        static::assertNotLog('Bar');
+
+        Yii::info("Bar", "LogAssertionsSelfTest");
+        self::assertEquals("  [LogAssertionsSelfTest] 'Bar'\n", static::getClean());
+        static::assertLogCount(3);
+        static::assertLogCount(1, null, Logger::LEVEL_ERROR);
+        static::assertLogCount(1, null, Logger::LEVEL_WARNING);
+        static::assertLogCount(1, null, Logger::LEVEL_INFO);
+        static::assertLogCount(2, null, Logger::LEVEL_ERROR | Logger::LEVEL_WARNING);
+        static::assertLogCount(2, null, Logger::LEVEL_ERROR | Logger::LEVEL_INFO);
+        static::assertLogCount(2, null, Logger::LEVEL_WARNING | Logger::LEVEL_INFO);
+        static::assertLogCount(1, null, Logger::LEVEL_INFO | Logger::LEVEL_TRACE);
+        static::assertLogCount(0, null, Logger::LEVEL_TRACE);
+        static::assertLogCount(2, 'Foo');
+        static::assertLogCount(1, 'Bar');
+        static::assertLog('Bar', Logger::LEVEL_INFO, ['LogAssertionsSelfTest']);
+
+        /**
+         * debug messages are not printed
+         * @see \Codeception\Lib\Connector\Yii2\Logger::log()
+         */
+        Yii::debug("Foo", "LogAssertionsSelfTest");
+        self::assertEquals(null, static::getClean());
+        static::assertLogCount(4);
+        static::assertLogCount(1, null, Logger::LEVEL_ERROR);
+        static::assertLogCount(1, null, Logger::LEVEL_WARNING);
+        static::assertLogCount(1, null, Logger::LEVEL_INFO);
+        static::assertLogCount(1, null, Logger::LEVEL_TRACE);
+        static::assertLogCount(2, null, Logger::LEVEL_ERROR | Logger::LEVEL_WARNING);
+        static::assertLogCount(2, null, Logger::LEVEL_ERROR | Logger::LEVEL_INFO);
+        static::assertLogCount(2, null, Logger::LEVEL_WARNING | Logger::LEVEL_INFO);
+        static::assertLogCount(2, null, Logger::LEVEL_INFO | Logger::LEVEL_TRACE);
+        static::assertLogCount(3, 'Foo');
+        static::assertLogCount(1, 'Bar');
+        static::assertLogCount(2, null, null, ['LogAssertionsSelfTest']);
+        static::assertLog('Bar', Logger::LEVEL_INFO, ['LogAssertionsSelfTest']);
+        static::assertLog('Foo', Logger::LEVEL_TRACE, ['LogAssertionsSelfTest']);
+        static::assertLog('Bar', null, ['LogAssertionsSelfTest']);
+        static::assertLog('Foo', null, ['LogAssertionsSelfTest']);
+
+        static::assertNotLog('Fo');
+        static::assertNotLog('FooBar');
+
+        static::assertLogRegex('@oo@');
+        static::assertNotLogRegex('@Oo@');
+        static::assertLogRegex('@Oo@i');
+        static::assertLogRegexCount(1, '@foo|Ba@');
+
+        static::assertEquals(
+            [
+            'Foo',
+            'Foo',
+            'Bar',
+            'Foo',
+            ],
+            static::logFilterMessageTexts()
+        );
+
+        $messages = static::logFilterMessages();
+
+        /**
+         * Cleanup
+         *
+         * @see \yii\log\Logger::$messages
+         * */
+        foreach ($messages as &$message) {
+            // unset timestamp
+            unset($message[3]);
+
+            // traces
+            //unset($message[4]);
+
+            // memory usage
+            unset($message[5]);
+        }
+
+        static::assertEquals(
+            [
+            0 => [
+                0 => 'Foo',
+                1 => 1,
+                2 => 'LogAssertionsSelfTest_error',
+                4 => [],
+            ],
+            1 =>  [
+                0 => 'Foo',
+                1 => 2,
+                2 => 'LogAssertionsSelfTest_warning',
+                4 =>  [],
+            ],
+            2 =>  [
+                0 => 'Bar',
+                1 => 4,
+                2 => 'LogAssertionsSelfTest',
+                4 =>  [],
+            ],
+            3 =>  [
+                0 => 'Foo',
+                1 => 8,
+                2 => 'LogAssertionsSelfTest',
+                4 =>  [],
+            ]
+            ],
+            $messages
+        );
+
+        static::logFlush();
+        static::assertLogCount(0);
+
+        /**
+         * Note: this is also automatically done in @see HumHubDbTestCase::tearDown()
+         * As such, it is mainly useful to stop capturing within a test.
+         */
+        static::logReset();
+    }
+
+    /**
+     * @noinspection UnsetConstructsCanBeMergedInspection
+     */
+    public function testInvalidRegex1()
+    {
+        static::logInitialize();
+
+        Yii::debug("Foo", "LogAssertionsSelfTest");
+        self::assertEquals(null, static::getClean());
+        static::assertLogCount(1);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage("Invalid regex given: '@Oo'");
+
+        static::assertLogRegex('@Oo');
+    }
+
+    /**
+     * @noinspection UnsetConstructsCanBeMergedInspection
+     */
+    public function testInvalidRegex2()
+    {
+        static::logInitialize();
+
+        Yii::debug("Foo", "LogAssertionsSelfTest");
+        self::assertEquals(null, static::getClean());
+        static::assertLogCount(1);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage("Invalid regex given: '@Oo'");
+
+        static::assertLogRegexCount(1, '@Oo');
+    }
+
+    public static function get(): ?string
+    {
+        return self::$data;
+    }
+
+    public static function getClean(): ?string
+    {
+        $data = self::$data;
+
+        self::clean();
+
+        return $data;
+    }
+
+    public static function clean(): void
+    {
+        self::$data = null;
+    }
+
+    public static function addData(string $data): void
+    {
+        static::$data .= $data;
+    }
+}


### PR DESCRIPTION
So far, there is no possibility to easily check in a test if a specific log entry has been issued.

This PR allows a test to assert that
- a specific message by providing
  - log level
  - category (includes and excludes)
  - message text or message regex
- a given message has _not_ been issued


### What kind of change does this PR introduce?

- Feature

### Does this PR introduce a breaking change?

- No

### The PR fulfills these requirements

- [x] It's submitted to the `next` branch, _not_ the `master` branch if no hotfix
- [x] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [x] All [tests](#issuecomment-new) are passing
- [x] New/updated tests are included
- [x] Changelog was modified

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

### Depends on and includes
-  ~~#6564~~
- #6562