### PR TITLE
Fix Avoid PHP 8.1+ deprecated null parameter on preg_replace in richtext converters

### DIFF
--- a/CHANGELOG-DEV.md
+++ b/CHANGELOG-DEV.md
@@ -23,6 +23,7 @@ HumHub Changelog
 - Fix #6510: Fix online status position on people page
 - Fix #6526: Fix a disabled button after post a content record with state "Draft" or "Scheduled"
 - Fix #6537: Sort profile fields on People directory filters
+- Fix #6558: Avoid PHP 8.1+ deprecated null parameter on preg_replace in richtext converters
 
 1.15.0-beta.1 (July 31, 2023)
 -----------------------------

--- a/protected/humhub/modules/content/widgets/richtext/AbstractRichText.php
+++ b/protected/humhub/modules/content/widgets/richtext/AbstractRichText.php
@@ -2,13 +2,13 @@
 
 namespace humhub\modules\content\widgets\richtext;
 
+use humhub\components\ActiveRecord;
+use humhub\components\Event;
 use humhub\libs\Html;
 use humhub\modules\content\widgets\richtext\extensions\RichTextExtension;
-use Yii;
-use humhub\components\Event;
 use humhub\widgets\JsWidget;
+use Yii;
 use yii\base\InvalidArgumentException;
-use humhub\components\ActiveRecord;
 
 /**
  * AbstractRichText serves as the base class for rich text implementations.

--- a/protected/humhub/modules/content/widgets/richtext/converter/BaseRichTextConverter.php
+++ b/protected/humhub/modules/content/widgets/richtext/converter/BaseRichTextConverter.php
@@ -263,7 +263,7 @@ abstract class BaseRichTextConverter extends GithubMarkdown
     {
         $evt = new Event(['result' => $text]);
         Event::trigger($this, static::EVENT_BEFORE_PARSE, $evt);
-        $text = $evt->result;
+        $text = (string)$evt->result;
 
         // Remove leading new backslash new lines e.g. "Test\\\n" -> "Test"
         $text = preg_replace('/\\\\(\n|\r){1,2}$/', '', $text);
@@ -445,7 +445,7 @@ REGEXP;
 
     protected function renderImage($block)
     {
-        $text = $block['text'];
+        $text = (string)$block['text'];
 
         // Remove image alignment extension from image alt text
         $block['text'] = preg_replace('/>?<?$/', '', $text);
@@ -531,7 +531,7 @@ REGEXP;
      */
     protected function br2nl($text)
     {
-        return preg_replace('/\<br(\s*)?\/?\>/i', "\n", $text);
+        return preg_replace('/\<br(\s*)?\/?\>/i', "\n", (string)$text);
     }
 
     /**

--- a/protected/humhub/modules/content/widgets/richtext/converter/RichTextToShortTextConverter.php
+++ b/protected/humhub/modules/content/widgets/richtext/converter/RichTextToShortTextConverter.php
@@ -113,7 +113,7 @@ class RichTextToShortTextConverter extends RichTextToPlainTextConverter
      */
     protected function onAfterParse($text): string
     {
-        $result = $text;
+        $result = (string)$text;
 
         if (!$this->getOption(static::OPTION_PRESERVE_SPACES, false)) {
             $result = trim(preg_replace('/\s+/', ' ', $result));


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included
- [x] Changelog was modified

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
