### PR TITLE
Avoid PHP error when trying to download a file without guid in the URL params

### DIFF
--- a/CHANGELOG-DEV.md
+++ b/CHANGELOG-DEV.md
@@ -4,6 +4,7 @@ HumHub Changelog
 1.15.0-beta.3 (Unreleased)
 -------------------------------
 - Enh #6619: Add a link to "Module Administration" from Marketplace
+- Enh #6621: Avoid PHP error when trying to download a file without guid in the URL params (return 404 exception instead)
 
 1.15.0-beta.2 (October 5, 2023)
 -------------------------------

--- a/protected/humhub/modules/file/actions/DownloadAction.php
+++ b/protected/humhub/modules/file/actions/DownloadAction.php
@@ -10,15 +10,14 @@ namespace humhub\modules\file\actions;
 
 use Firebase\JWT\JWT;
 use Firebase\JWT\Key;
+use humhub\modules\file\libs\FileHelper;
+use humhub\modules\file\models\File;
 use humhub\modules\file\Module;
 use humhub\modules\user\models\User;
 use Yii;
-use yii\helpers\Url;
-use yii\web\HttpException;
 use yii\base\Action;
-use humhub\modules\file\models\File;
-use humhub\modules\file\libs\FileHelper;
 use yii\filters\HttpCache;
+use yii\web\HttpException;
 
 /**
  * DownloadAction
@@ -126,7 +125,7 @@ class DownloadAction extends Action
      *
      * @throws HttpException
      */
-    protected function loadFile(string $guid, ?string $token = null)
+    protected function loadFile(?string $guid, ?string $token = null)
     {
         $file = File::findOne(['guid' => $guid]);
 


### PR DESCRIPTION
Avoid PHP error when trying to download a file without guid in the URL params (return 404 exception instead)

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included
- [x] Changelog was modified

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
