### PR TITLE
Enh #6623: Add a hint in the "Dropdown space order" settings to infor…

### DIFF
--- a/CHANGELOG-DEV.md
+++ b/CHANGELOG-DEV.md
@@ -5,6 +5,7 @@ HumHub Changelog
 -------------------------------
 - Enh #6619: Add a link to "Module Administration" from Marketplace
 - Enh #6621: Avoid PHP error when trying to download a file without guid in the URL params (return 404 exception instead)
+- Enh #6623: Add a hint in the "Dropdown space order" settings to inform that a manual sort is always applied first
 
 1.15.0-beta.2 (October 5, 2023)
 -------------------------------

--- a/protected/humhub/modules/admin/models/forms/DesignSettingsForm.php
+++ b/protected/humhub/modules/admin/models/forms/DesignSettingsForm.php
@@ -99,7 +99,7 @@ class DesignSettingsForm extends Model
     public function attributeHints()
     {
         return [
-            'spaceOrder' => Yii::t('AdminModule.settings', 'Custom sort order can be defined in the space advanced settings.'),
+            'spaceOrder' => Yii::t('AdminModule.settings', 'Custom sort order can be defined in the Space advanced settings.'),
         ];
     }
 

--- a/protected/humhub/modules/admin/models/forms/DesignSettingsForm.php
+++ b/protected/humhub/modules/admin/models/forms/DesignSettingsForm.php
@@ -85,7 +85,7 @@ class DesignSettingsForm extends Model
             'paginationSize' => Yii::t('AdminModule.settings', 'Default pagination size (Entries per page)'),
             'displayNameFormat' => Yii::t('AdminModule.settings', 'User Display Name'),
             'displayNameSubFormat' => Yii::t('AdminModule.settings', 'User Display Name Subtitle'),
-            'spaceOrder' => Yii::t('AdminModule.settings', 'Dropdown space order'),
+            'spaceOrder' => Yii::t('AdminModule.settings', '"My Spaces" Sorting'),
             'logo' => Yii::t('AdminModule.settings', 'Logo upload'),
             'icon' => Yii::t('AdminModule.settings', 'Icon upload'),
             'dateInputDisplayFormat' => Yii::t('AdminModule.settings', 'Date input format'),
@@ -99,7 +99,7 @@ class DesignSettingsForm extends Model
     public function attributeHints()
     {
         return [
-            'spaceOrder' => Yii::t('AdminModule.settings', 'A manual sort is always applied first to spaces whose sort order has been configured.'),
+            'spaceOrder' => Yii::t('AdminModule.settings', 'Custom sort order can be defined in the space advanced settings.'),
         ];
     }
 

--- a/protected/humhub/modules/admin/models/forms/DesignSettingsForm.php
+++ b/protected/humhub/modules/admin/models/forms/DesignSettingsForm.php
@@ -8,16 +8,16 @@
 
 namespace humhub\modules\admin\models\forms;
 
+use humhub\libs\DynamicConfig;
+use humhub\libs\LogoImage;
 use humhub\modules\file\validators\ImageSquareValidator;
 use humhub\modules\stream\actions\Stream;
+use humhub\modules\ui\view\helpers\ThemeHelper;
 use humhub\modules\user\models\ProfileField;
 use humhub\modules\web\pwa\widgets\SiteIcon;
 use Yii;
 use yii\base\Model;
 use yii\web\UploadedFile;
-use humhub\libs\LogoImage;
-use humhub\libs\DynamicConfig;
-use humhub\modules\ui\view\helpers\ThemeHelper;
 
 /**
  * DesignSettingsForm
@@ -93,6 +93,15 @@ class DesignSettingsForm extends Model
         ];
     }
 
+    /**
+     * @inerhitdoc
+     */
+    public function attributeHints()
+    {
+        return [
+            'spaceOrder' => Yii::t('AdminModule.settings', 'A manual sort is always applied first to spaces whose sort order has been configured.'),
+        ];
+    }
 
     /**
      * @inheritdoc

--- a/protected/humhub/modules/admin/views/setting/design.php
+++ b/protected/humhub/modules/admin/views/setting/design.php
@@ -2,9 +2,9 @@
 
 use humhub\libs\LogoImage;
 use humhub\modules\admin\models\forms\DesignSettingsForm;
+use humhub\modules\ui\form\widgets\ActiveForm;
 use humhub\modules\web\pwa\widgets\SiteIcon;
 use humhub\widgets\Button;
-use humhub\modules\ui\form\widgets\ActiveForm;
 use yii\helpers\Html;
 use yii\helpers\Url;
 
@@ -51,7 +51,10 @@ $iconUrl = SiteIcon::getUrl(140);
 
     </div>
 
-    <?= $form->field($model, 'spaceOrder')->dropDownList(['0' => Yii::t('AdminModule.settings', 'Alphabetical'), '1' => Yii::t('AdminModule.settings', 'Last visit')]); ?>
+    <?= $form->field($model, 'spaceOrder')->dropDownList([
+        '0' => Yii::t('AdminModule.settings', 'Custom sort order (alphabetical if not defined)'),
+        '1' => Yii::t('AdminModule.settings', 'Last visit'),
+    ]); ?>
 
     <?= $form->field($model, 'defaultStreamSort')->dropDownList($model->getDefaultStreamSortOptions()); ?>
 


### PR DESCRIPTION
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe:

Add a hint in the "Dropdown space order" settings to inform that a manual sort is always applied first

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [x] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included
- [x] Changelog was modified

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Issue: https://github.com/humhub/humhub/issues/6623