### PR TITLE
Enh add UUID validaton/enforcement for `contentcontainer`, `file`, `space` and `user`

### DIFF
--- a/CHANGELOG-DEV.md
+++ b/CHANGELOG-DEV.md
@@ -4,6 +4,8 @@ HumHub Changelog
 1.16.0 (Unreleased)
 -------------------
 - Fix #6636: Module Manager test
+- Enh #6587: Apply UUID validator
+- Enh #6553: Support log assertions
 - Enh #6530: Small performance improvements
 - Fix #6511: Only test compatible modules in `onMarketplaceAfterFilterModules()`
 - Enh #6511: Backup folder path is now return from `removeModule()`

--- a/MIGRATE-DEV.md
+++ b/MIGRATE-DEV.md
@@ -34,6 +34,8 @@ Version 1.15
 - Use the verifying `Content->canArchive()` before run the methods `Content->archive()`
   and `Content->archive()`, because it was removed from within there.
 - Permission to configure modules is now restricted to users allowed to manage settings (was previously restricted to users allowed to manage modules). [More info here](https://github.com/humhub/humhub/issues/6174).
+- `$guid` properties in `contentcontainer`, `file`, `space`, and `user` models are now enforced to be valid UUIDs
+  (See `UUID::validate()`) and unique within the table.
 
 ### Type restrictions
 - `\humhub\libs\BaseSettingsManager` and its child classes on fields, method parameters, & return types

--- a/protected/humhub/modules/content/models/Content.php
+++ b/protected/humhub/modules/content/models/Content.php
@@ -15,6 +15,7 @@ use humhub\components\Module;
 use humhub\interfaces\ArchiveableInterface;
 use humhub\interfaces\EditableInterface;
 use humhub\interfaces\ViewableInterface;
+use humhub\libs\UUIDValidator;
 use humhub\modules\admin\permissions\ManageUsers;
 use humhub\modules\content\activities\ContentCreated as ActivitiesContentCreated;
 use humhub\modules\content\components\ContentActiveRecord;
@@ -180,10 +181,10 @@ class Content extends ActiveRecord implements Movable, ContentOwner, Archiveable
         return [
             [['object_id', 'visibility', 'pinned'], 'integer'],
             [['archived'], 'safe'],
-            [['guid'], 'string', 'max' => 45],
+            [['guid'], UUIDValidator::class],
+            [['guid'], 'unique'],
             [['object_model'], 'string', 'max' => 100],
             [['object_model', 'object_id'], 'unique', 'targetAttribute' => ['object_model', 'object_id'], 'message' => 'The combination of Object Model and Object ID has already been taken.'],
-            [['guid'], 'unique']
         ];
     }
 

--- a/protected/humhub/modules/content/models/ContentContainer.php
+++ b/protected/humhub/modules/content/models/ContentContainer.php
@@ -10,6 +10,7 @@ namespace humhub\modules\content\models;
 
 use humhub\components\ActiveRecord;
 use humhub\components\behaviors\PolymorphicRelation;
+use humhub\libs\UUIDValidator;
 use humhub\modules\content\components\ContentContainerActiveRecord;
 
 /**
@@ -41,10 +42,11 @@ class ContentContainer extends ActiveRecord
     {
         return [
             [['pk', 'owner_user_id'], 'integer'],
-            [['class', 'pk', 'guid'], 'required'],
-            [['guid', 'class'], 'string', 'max' => 255],
+            [['class', 'pk'], 'required'],
+            [['class'], 'string', 'max' => 255],
             [['class', 'pk'], 'unique', 'targetAttribute' => ['class', 'pk'], 'message' => 'The combination of Class and Pk has already been taken.'],
-            [['guid'], 'unique']
+            [['guid'], UUIDValidator::class],
+            [['guid'], 'unique'],
         ];
     }
 

--- a/protected/humhub/modules/content/tests/codeception/unit/models/ContentContainerTest.php
+++ b/protected/humhub/modules/content/tests/codeception/unit/models/ContentContainerTest.php
@@ -38,14 +38,19 @@ class ContentContainerTest extends ContentModelTest
         $this->assertNotEmpty($contentContainer->getErrors('pk'));
     }
 
-    public function testGuidRequired()
+    public function testGuid()
     {
         $user = User::findOne(['id' => 1]);
+
+        // make sure we have a fresh ID and GUID
+        $user->id = 9;
+        $user->guid = UUID::v4();
+
         $contentContainer = new ContentContainer();
         $contentContainer->setPolymorphicRelation($user);
 
-        $this->assertFalse($contentContainer->save());
-        $this->assertNotEmpty($contentContainer->getErrors('guid'));
+        $this->assertTrue($contentContainer->save());
+        $this->assertEmpty($contentContainer->getErrors('guid'));
     }
 
     public function testModelRequired()

--- a/protected/humhub/modules/content/tests/codeception/unit/models/ContentContainerTest.php
+++ b/protected/humhub/modules/content/tests/codeception/unit/models/ContentContainerTest.php
@@ -51,6 +51,14 @@ class ContentContainerTest extends ContentModelTest
 
         $this->assertTrue($contentContainer->save());
         $this->assertEmpty($contentContainer->getErrors('guid'));
+
+        $user = new User();
+        $user->id = 10;
+        $contentContainer = new ContentContainer();
+        $contentContainer->setPolymorphicRelation($user);
+
+        $this->assertTrue($contentContainer->save());
+        $this->assertEmpty($contentContainer->getErrors('guid'));
     }
 
     public function testModelRequired()

--- a/protected/humhub/modules/file/migrations/m230618_135512_file_add_guid_unique_index.php
+++ b/protected/humhub/modules/file/migrations/m230618_135512_file_add_guid_unique_index.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * @link      https://www.humhub.org/
+ * @copyright Copyright (c) 2023 HumHub GmbH & Co. KG
+ * @license   https://www.humhub.com/licences
+ */
+
+use humhub\components\Migration;
+use humhub\modules\file\models\File;
+
+/**
+ * Add and film GUID column
+ */
+class m230618_135512_file_add_guid_unique_index extends Migration
+{
+    // protected properties
+    protected string $table;
+
+    public function __construct($config = [])
+    {
+        $this->table = File::tableName();
+        parent::__construct($config);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function safeUp(): void
+    {
+        $this->safeCreateIndex("ux-$this->table-guid", $this->table, ['guid'], true);
+    }
+}

--- a/protected/humhub/modules/file/models/File.php
+++ b/protected/humhub/modules/file/models/File.php
@@ -13,6 +13,7 @@ use humhub\components\behaviors\GUID;
 use humhub\components\behaviors\PolymorphicRelation;
 use humhub\interfaces\ViewableInterface;
 use humhub\libs\StdClass;
+use humhub\libs\UUIDValidator;
 use humhub\modules\content\components\ContentActiveRecord;
 use humhub\modules\content\components\ContentAddonActiveRecord;
 use humhub\modules\file\components\StorageManager;
@@ -142,6 +143,8 @@ class File extends FileCompat implements ViewableInterface
             ],
             [['category', 'size', 'state', 'sort_order'], 'integer'],
             [['file_name', 'title'], 'string', 'max' => 255],
+            [['guid'], UUIDValidator::class],
+            [['guid'], 'unique'],
         ];
     }
 

--- a/protected/humhub/modules/space/models/Space.php
+++ b/protected/humhub/modules/space/models/Space.php
@@ -9,6 +9,7 @@
 namespace humhub\modules\space\models;
 
 use humhub\components\behaviors\GUID;
+use humhub\libs\UUIDValidator;
 use humhub\modules\content\components\ContentContainerActiveRecord;
 use humhub\modules\content\components\ContentContainerSettingsManager;
 use humhub\modules\content\models\Content;
@@ -119,13 +120,15 @@ class Space extends ContentContainerActiveRecord implements Searchable
         $rules = [
             [['join_policy', 'visibility', 'status', 'sort_order', 'auto_add_new_members', 'default_content_visibility'], 'integer'],
             [['name'], 'required'],
+            [['name'], 'string', 'max' => 45, 'min' => 2],
             [['description', 'about', 'color'], 'string'],
             [['tagsField', 'blockedUsersField'], 'safe'],
             [['description'], 'string', 'max' => 100],
             [['join_policy'], 'in', 'range' => [0, 1, 2]],
             [['visibility'], 'in', 'range' => [0, 1, 2]],
             [['visibility'], 'checkVisibility'],
-            [['guid', 'name'], 'string', 'max' => 45, 'min' => 2],
+            [['guid'], UUIDValidator::class],
+            [['guid'], 'unique'],
             [['url'], UrlValidator::class, 'space' => $this],
         ];
 

--- a/protected/humhub/modules/user/models/User.php
+++ b/protected/humhub/modules/user/models/User.php
@@ -9,6 +9,7 @@
 namespace humhub\modules\user\models;
 
 use humhub\components\behaviors\GUID;
+use humhub\libs\UUIDValidator;
 use humhub\modules\admin\Module as AdminModule;
 use humhub\modules\admin\permissions\ManageGroups;
 use humhub\modules\admin\permissions\ManageSpaces;
@@ -159,7 +160,8 @@ class User extends ContentContainerActiveRecord implements IdentityInterface, Se
             [['status'], 'in', 'range' => array_keys(self::getStatusOptions()), 'on' => self::SCENARIO_EDIT_ADMIN],
             [['visibility'], 'in', 'range' => array_keys(self::getVisibilityOptions()), 'on' => self::SCENARIO_EDIT_ADMIN],
             [['tagsField', 'blockedUsersField'], 'safe'],
-            [['guid'], 'string', 'max' => 45],
+            [['guid'], UUIDValidator::class],
+            [['guid'], 'unique'],
             [['time_zone'], 'validateTimeZone'],
             [['auth_mode'], 'string', 'max' => 10],
             [['language'], 'string', 'max' => 5],
@@ -167,7 +169,6 @@ class User extends ContentContainerActiveRecord implements IdentityInterface, Se
             [['email'], 'unique'],
             [['email'], 'email'],
             [['email'], 'string', 'max' => 150],
-            [['guid'], 'unique'],
             [['username'], 'validateForbiddenUsername', 'on' => [self::SCENARIO_REGISTRATION]],
         ];
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

This PR enforces a valid UUID for `guid` column for `contentcontainer`, `file`, `space` and `user`. Currently arbitrary and non-unique string values up to 45 chars are allowed. This can lead to potential conflicts.

## PR Admin

### What kind of change does this PR introduce?

- Feature

### Does this PR introduce a breaking change?

- Yes

If yes, please describe the impact and migration path for existing applications:

`guid` column for `contentcontainer`, `file`, `space` and `user` are now enforced to be valid UUIDs.

### The PR fulfills these requirements

- [x] It's submitted to the `develop` branch
- [x] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [ ] All [tests](#issuecomment-new) are passing
- [x] New/updated tests are included
- [x] Changelog was modified
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
