### PR TITLE
Fix `MigrateController::$migrationPathMap`

### DIFF
--- a/CHANGELOG-DEV.md
+++ b/CHANGELOG-DEV.md
@@ -3,6 +3,7 @@ HumHub Changelog
 
 1.16.0 (Unreleased)
 -------------------
+- Fix #6693: `MigrateController::$migrationPathMap` stored rolling sum of migrations 
 - Enh #6697: Make state badge customizable
 - Fix #6636: Module Manager test
 - Enh #6530: Small performance improvements

--- a/MIGRATE-DEV.md
+++ b/MIGRATE-DEV.md
@@ -36,6 +36,7 @@ Version 1.15
 - Permission to configure modules is now restricted to users allowed to manage settings (was previously restricted to users allowed to manage modules). [More info here](https://github.com/humhub/humhub/issues/6174).
 
 ### Type restrictions
+- `\humhub\commands\MigrateController` enforces types on fields, method parameters, & return types
 - `\humhub\libs\BaseSettingsManager` and its child classes on fields, method parameters, & return types
 - `\humhub\libs\Helpers::checkClassType()` (see [#6548](https://github.com/humhub/humhub/pull/6548))
   - rather than throwing a `\yii\base\Exception`, it now throws some variations of `yii\base\InvalidArgumentException`


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

`MigrateController::$migrationPathMap` would store the sum of the migrations encountered so far while collecting the migrations of the different migration paths. This makes no sense at all. :-)

This PR fixes that only the migrations of a given `$path` are stored under `MigrateController::$migrationPathMap[$path]`.

In addition, type cleanup is applied.

## PR Admin

### What kind of change does this PR introduce?

- Bugfix
- Refactor

### Does this PR introduce a breaking change?

- Yes

If yes, please describe the impact and migration path for existing applications:

Type restrictions as documented in `MIGRATE-DEV.md`. However, there's no inheritance of the class in the core and unlikely in modules. So risk is low.

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [x] All [tests](#issuecomment-new) are passing
- [ ] New/updated tests are included
- [x] Changelog was modified
