### PR TITLE
Enh: Make state badge customizable

### DIFF
--- a/CHANGELOG-DEV.md
+++ b/CHANGELOG-DEV.md
@@ -3,6 +3,7 @@ HumHub Changelog
 
 1.16.0 (Unreleased)
 -------------------
+- Enh #6697: Make state badge customizable
 - Fix #6636: Module Manager test
 - Enh #6530: Small performance improvements
 - Fix #6511: Only test compatible modules in `onMarketplaceAfterFilterModules()`

--- a/protected/humhub/modules/content/widgets/StateBadge.php
+++ b/protected/humhub/modules/content/widgets/StateBadge.php
@@ -30,11 +30,7 @@ class StateBadge extends Widget
      */
     public function run()
     {
-        if ($this->model === null) {
-            return '';
-        }
-
-        switch ($this->model->content->state) {
+        switch ($this->getState()) {
             case Content::STATE_DRAFT:
                 return Html::tag('span', Yii::t('ContentModule.base', 'Draft'),
                     ['class' => 'label label-danger label-state-draft']
@@ -53,5 +49,18 @@ class StateBadge extends Widget
         }
 
         return '';
+    }
+
+    /**
+     * @return int|null
+     * @since 1.16
+     */
+    public function getState(): ?int
+    {
+        if ($this->model === null) {
+            return null;
+        }
+
+        return $this->model->content->state;
     }
 }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

Currently, the `\humhub\modules\content\widgets\StateBadge` does require the `StateBadge::$model` to be a ContentActiveRecord. However, states may also be used on other records.

This PR allows to override where the widget gets the state from. Two steps are required:
1. Extend the StateBadge class, overriding the `getState()` method returning the value from the custom source, e.g.
   ```php
    public function getState(): ?int
    {
        return $this->model->state;
    }
   ```
4. Register an event to overwrite the class, e.g. in `config.php` add
   ````php
   [
            'class' => \humhub\modules\content\widgets\StateBadge::class,
            'event' => \humhub\components\Widget::EVENT_CREATE,
            'callback' => [
                MyStateBadge::class,
                'onWidgetCreate',
            ]
   ]
   ```

A full example of the class, including additional states would be:

```php
<?php

/**
 * @copyright    2023. metaworx resonare rüegg, Martin Rüegg, Switzerland
 * @license      https://gitlab.com/metaworx/open-source/humhub/metamarket/-/raw/master/LICENCE.md MIT
 * @package      metaworx\humhub\modules\metamarket
 */

namespace metaworx\humhub\modules\metamarket\widgets;

use humhub\libs\Html;
use humhub\libs\WidgetCreateEvent;
use humhub\modules\content\models\Content;
use humhub\modules\content\widgets\StateBadge;
use metaworx\humhub\modules\metamarket\models\AdPublication;
use metaworx\humhub\modules\metamarket\models\AdStatus;
use Yii;

/**
 * @property AdPublication $model
 */
class AdStateBadge
    extends StateBadge
{
    // protected properties
    protected ?int $state = null;

    public function getState(): ?int
    {
        return $this->state ??= $this->model->ad->status;
    }

    public function afterRun($result)
    {
        if ($result === '')
        {
            switch ($this->getState())
            {
            case Content::STATE_PUBLISHED:
                if ($this->model->isOwner())
                {
                    $result = Html::tag(
                        'span', Yii::t('ContentModule.base', 'Published'),
                        ['class' => 'label label-info label-state-published']
                    );
                }
                break;

            case AdStatus::AD_STATUS_EXPIRED:
                $result = Html::tag(
                    'span', Yii::t('MetamarketModule.base', 'Expired'),
                    ['class' => 'label label-warning label-state-expired']
                );
                break;

            case AdStatus::AD_STATUS_BLOCKED:
                $result = Html::tag(
                    'span', Yii::t('MetamarketModule.base', 'Blocked'),
                    ['class' => 'label label-danger label-state-blocked']
                );
                break;

            default:
                $result = 'test';
            }
        }

        return parent::afterRun($result);
    }

    public static function onWidgetCreate(WidgetCreateEvent $event)
    {
        $event->config['class'] = self::class;
    }

}
```

## PR Admin

Could this still be added to v1.15 or even 1.14? Happy to rebase, if yes.

### What kind of change does this PR introduce?

- Feature

### Does this PR introduce a breaking change?

- No

###The PR fulfills these requirements

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] All [tests](#issuecomment-new) are passing
- [ ] New/updated tests are included
- [x] Changelog was modified
