### PR TITLE
Fix: Content relations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ HumHub Changelog
 
 1.15.1 (Unreleased)
 --------------------------------
+- Fix #6698: Content relations
 - Fix #6644: Fix push service
 - Fix #6645: File dropdown not visible at the bottom of the page
 - Fix #6639: Apply image inline styles in email message

--- a/protected/humhub/components/behaviors/PolymorphicRelation.php
+++ b/protected/humhub/components/behaviors/PolymorphicRelation.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @link https://www.humhub.org/
  * @copyright Copyright (c) 2017 HumHub GmbH & Co. KG
@@ -24,10 +25,11 @@ use yii\db\IntegrityException;
  * PolymorphicRelations behavior provides simple support for polymorphic relations in ActiveRecords.
  *
  * @since 0.5
+ *
+ * @property ActiveRecord|object|null $polymorphicRelation
  */
 class PolymorphicRelation extends Behavior
 {
-
     /**
      * @var string the class name attribute
      */
@@ -39,24 +41,24 @@ class PolymorphicRelation extends Behavior
     public $pkAttribute = 'object_id';
 
     /**
-     * @var boolean if set to true an exception is thrown if `object_model` and `object_id` is set but does not exist
+     * @var boolean if set to true, an exception is thrown if `object_model` and `object_id` is set but does not exist
      */
     public $strict = false;
 
     /**
-     * @var array the related object needs to be a "instanceof" at least one of these given classnames
+     * @var array the related object needs to be an "instanceof" at least one of these given classnames
      */
     public $mustBeInstanceOf = [];
 
     /**
-     * @var mixed the cached object
+     * @var ActiveRecord|object|null the cached object
      */
     private $cached = null;
 
     /**
      * Returns the Underlying Object
      *
-     * @return mixed
+     * @return ActiveRecord|object|null
      * @throws IntegrityException
      */
     public function getPolymorphicRelation()
@@ -90,11 +92,24 @@ class PolymorphicRelation extends Behavior
      */
     public function setPolymorphicRelation($object)
     {
+        if ($this->cached === $object) {
+            return;
+        }
+
         if ($this->validateUnderlyingObjectType($object)) {
+            $cached = $this->cached;
             $this->cached = $object;
+
             if ($object instanceof ActiveRecord) {
-                $this->owner->setAttribute($this->classAttribute, self::getObjectModel($object));
-                $this->owner->setAttribute($this->pkAttribute, $object->getPrimaryKey());
+                $class = get_class($object);
+                if ($cached === null || get_class($cached) !== $class) {
+                    $this->owner->setAttribute($this->classAttribute, $class);
+                }
+
+                $pk = $object->getPrimaryKey();
+                if ($cached === null || $cached->getPrimaryKey() !== $pk) {
+                    $this->owner->setAttribute($this->pkAttribute, $pk);
+                }
             }
         }
     }
@@ -107,7 +122,7 @@ class PolymorphicRelation extends Behavior
     }
 
     /**
-     * Resets the already loaded $_cached instance of related object
+     * Resets the already loaded $_cached instance of the related object
      */
     public function resetPolymorphicRelation()
     {
@@ -115,9 +130,10 @@ class PolymorphicRelation extends Behavior
     }
 
     /**
-     * Validates if given object is of allowed type
+     * Validates if given object is of an allowed type
      *
      * @param mixed $object
+     *
      * @return boolean
      */
     private function validateUnderlyingObjectType($object)
@@ -141,6 +157,7 @@ class PolymorphicRelation extends Behavior
      *
      * @param $className
      * @param $primaryKey
+     *
      * @return null|ActiveRecord
      */
     public static function loadActiveRecord($className, $primaryKey)

--- a/protected/humhub/modules/content/components/ContentActiveRecord.php
+++ b/protected/humhub/modules/content/components/ContentActiveRecord.php
@@ -203,9 +203,10 @@ class ContentActiveRecord extends ActiveRecord implements ContentOwner, Movable,
 
             if (!$content) {
                 $content = new Content();
-                $content->setPolymorphicRelation($this);
                 $this->populateRelation('content', $content);
             }
+
+            $content->setPolymorphicRelation($this);
 
             return $content;
         }
@@ -384,7 +385,7 @@ class ContentActiveRecord extends ActiveRecord implements ContentOwner, Movable,
     {
         if (is_subclass_of($this->wallEntryClass, StreamEntryWidget::class, true)) {
             $params['model'] = $this;
-        } else if (!empty($this->wallEntryClass)) {
+        } elseif (!empty($this->wallEntryClass)) {
             $params['contentObject'] = $this; // legacy WallEntry widget
         }
 
@@ -407,7 +408,7 @@ class ContentActiveRecord extends ActiveRecord implements ContentOwner, Movable,
 
         if (is_subclass_of($this->wallEntryClass, WallEntry::class)) {
             $class = $this->wallEntryClass;
-            $widget = new $class;
+            $widget = new $class();
             $widget->contentObject = $this;
             return $widget;
         }

--- a/protected/humhub/modules/content/services/ContentStateService.php
+++ b/protected/humhub/modules/content/services/ContentStateService.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @link https://www.humhub.org/
  * @copyright Copyright (c) 2023 HumHub GmbH & Co. KG
@@ -17,7 +18,7 @@ use yii\base\Component;
  */
 class ContentStateService extends Component
 {
-    const EVENT_INIT = 'init';
+    public const EVENT_INIT = 'init';
 
     public Content $content;
 
@@ -45,7 +46,9 @@ class ContentStateService extends Component
      */
     public function allowState(int $state)
     {
-        $this->states[] = $state;
+        if (!in_array($state, $this->states, true)) {
+            $this->states[] = $state;
+        }
     }
 
     /**
@@ -141,7 +144,7 @@ class ContentStateService extends Component
             }
         }
 
-        $this->content->state = $state;
+        $this->content->setAttribute('state', $state);
         return true;
     }
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

This PR addresses the circumstance, where the cached record in the polymorphic relationship of a content model does not correspond to the instance of the `ContentActiveRecord` that is accessing it's `content` property.

Furthermore, it address the fact, that the `ContentStateService::set()` method is calling a deprecated `setState()` method on it's content object, which then in turn again calls `ContentStateService::set()`. The endless loop is only prevented thanks to PHP avoiding calling the same `__set($name)` call recursively. So the loop happens only once.

Also v1.14 is affected by this.


## PR Admin

Could this still be added to v1.15 or even 1.14? Happy to rebase, if yes.

### What kind of change does this PR introduce?

- Bugfix

### Does this PR introduce a breaking change?

- No

###The PR fulfills these requirements

- [ ] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] All [tests](#issuecomment-new) are passing
- [ ] New/updated tests are included
- [ ] Changelog was modified

