### PR TITLE
Enh: run migrations manually

### DIFF
--- a/CHANGELOG-DEV.md
+++ b/CHANGELOG-DEV.md
@@ -3,6 +3,7 @@ HumHub Changelog
 
 1.16.0 (Unreleased)
 -------------------
+- Enh #6711: run migrations manually
 - Enh #6720: Consolidate `isInstalled()`, `setInstalled()`, and `setDatabaseInstalled`
 - Fix #6693: `MigrateController::$migrationPathMap` stored rolling sum of migrations
 - Enh #6697: Make state badge customizable

--- a/protected/humhub/commands/MigrateController.php
+++ b/protected/humhub/commands/MigrateController.php
@@ -11,6 +11,7 @@ namespace humhub\commands;
 use humhub\components\Module;
 use humhub\helpers\DatabaseHelper;
 use Yii;
+use yii\base\InvalidRouteException;
 use yii\console\Exception;
 use yii\db\MigrationInterface;
 use yii\web\Application;
@@ -202,17 +203,22 @@ class MigrateController extends \yii\console\controllers\MigrateController
     /**
      * Executes all pending migrations
      *
+     * @param string $action 'up' or 'new'
+     * @param \yii\base\Module|null $module Module to get the migrations from, or Null for Application
+     *
      * @return string output
+     * @throws Exception
+     * @throws InvalidRouteException
      */
-    public static function webMigrateAll(): string
+    public static function webMigrateAll(string $action = 'up', ?\yii\base\Module $module = null): string
     {
         ob_start();
-        $controller = new self('migrate', Yii::$app);
+        $controller = new self('migrate', $module ?? Yii::$app);
         $controller->db = Yii::$app->db;
         $controller->interactive = false;
         $controller->includeModuleMigrations = true;
         $controller->color = false;
-        $controller->runAction('up');
+        $controller->runAction($action);
 
         return ob_get_clean() ?: '';
     }

--- a/protected/humhub/modules/admin/controllers/SettingController.php
+++ b/protected/humhub/modules/admin/controllers/SettingController.php
@@ -36,7 +36,6 @@ use humhub\modules\notification\models\forms\NotificationSettings;
  */
 class SettingController extends Controller
 {
-
     /**
      * @inheritdoc
      */
@@ -125,11 +124,9 @@ class SettingController extends Controller
      */
     public function actionCaching()
     {
-        $form = new CacheSettingsForm;
+        $form = new CacheSettingsForm();
         if ($form->load(Yii::$app->request->post()) && $form->validate() && $form->save()) {
-            Yii::$app->cache->flush();
-            Yii::$app->assetManager->clear();
-            Yii::$app->view->theme->activate();
+            self::flushCache();
             $this->view->success(Yii::t('AdminModule.settings', 'Saved and flushed cache'));
             return $this->redirect(['/admin/setting/caching']);
         }
@@ -145,7 +142,7 @@ class SettingController extends Controller
      */
     public function actionStatistic()
     {
-        $form = new StatisticSettingsForm;
+        $form = new StatisticSettingsForm();
         if ($form->load(Yii::$app->request->post()) && $form->validate() && $form->save()) {
             $this->view->saved();
             return $this->redirect([
@@ -178,7 +175,7 @@ class SettingController extends Controller
      */
     public function actionMailingServer()
     {
-        $form = new MailingSettingsForm;
+        $form = new MailingSettingsForm();
         if ($form->load(Yii::$app->request->post()) && $form->validate() && $form->save()) {
             return $this->redirect(['/admin/setting/mailing-server-test']);
         }
@@ -220,7 +217,7 @@ class SettingController extends Controller
 
     public function actionDesign()
     {
-        $form = new DesignSettingsForm;
+        $form = new DesignSettingsForm();
         if ($form->load(Yii::$app->request->post()) && $form->validate() && $form->save()) {
             $this->view->saved();
             return $this->redirect([
@@ -238,7 +235,7 @@ class SettingController extends Controller
      */
     public function actionFile()
     {
-        $form = new FileSettingsForm;
+        $form = new FileSettingsForm();
         if ($form->load(Yii::$app->request->post()) && $form->validate() && $form->save()) {
             $this->view->saved();
             return $this->redirect([
@@ -272,7 +269,7 @@ class SettingController extends Controller
      */
     public function actionProxy()
     {
-        $form = new ProxySettingsForm;
+        $form = new ProxySettingsForm();
 
 
         if ($form->load(Yii::$app->request->post()) && $form->validate() && $form->save()) {
@@ -318,7 +315,7 @@ class SettingController extends Controller
             $dating = "the begining of time";
         }
 
-        $form = new LogsSettingsForm;
+        $form = new LogsSettingsForm();
         $limitAgeOptions = $form->options;
         if ($form->load(Yii::$app->request->post()) && $form->validate() && $form->save()) {
 
@@ -343,7 +340,7 @@ class SettingController extends Controller
      */
     public function actionOembedEdit()
     {
-        $form = new OEmbedProviderForm;
+        $form = new OEmbedProviderForm();
 
         $name = Yii::$app->request->get('name');
         $providers = UrlOembed::getProviders();
@@ -399,4 +396,21 @@ class SettingController extends Controller
             ]);
     }
 
+    /**
+     * @since 1.16
+     * @return string Activity output that can be used for logging
+     */
+    public static function flushCache(): string
+    {
+        $output = "Flushing cache ...";
+        Yii::$app->cache->flush();
+
+        $output .= "\nFlushing asset manager ...";
+        Yii::$app->assetManager->clear();
+
+        $output .= "\nFlushing theme cache ...";
+        Yii::$app->view->theme->activate();
+
+        return $output;
+    }
 }

--- a/protected/humhub/modules/admin/views/information/database.php
+++ b/protected/humhub/modules/admin/views/information/database.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @link https://www.humhub.org/
  * @copyright Copyright (c) 2017 HumHub GmbH & Co. KG
@@ -6,13 +7,17 @@
  */
 
 use humhub\libs\Html;
+use humhub\modules\admin\controllers\InformationController;
+use humhub\modules\ui\view\components\View;
 
 /**
- * @var $this \humhub\modules\ui\view\components\View
+ * @var $this View
  * @var $databaseName string
- * @var $migrate string
+ * @var $migrationStatus int
+ * @var $migrationOutput string
  * @var $rebuildSearchRunning boolean
  */
+
 ?>
 <div>
     <p>
@@ -27,10 +32,42 @@ use humhub\libs\Html;
     </p>
 </div>
 
-<p><?= Yii::t('AdminModule.information', 'Database migration results:'); ?></p>
-
-<div class="well">
+<div>
+<?php if ($migrationStatus === InformationController::DB_ACTION_PENDING): ?>
+    <p><?= Yii::t('AdminModule.information', 'Outstanding database migrations:'); ?></p>
+    <div class="well">
     <pre>
-        <?= $migrate; ?>
+        <?= $migrationOutput ?>
     </pre>
+    </div>
+    <p><br>
+        <?= Html::a(
+            Yii::t('AdminModule.information', 'Refresh'),
+            ['/admin/information/database'],
+            [
+                'id' => 'migrationRun',
+                'class' => 'btn btn-primary pull-right',
+            ]
+        ); ?>
+    </p>
+<?php elseif ($migrationStatus === InformationController::DB_ACTION_RUN): ?>
+    <p><?= Yii::t('AdminModule.information', 'Database migration results:'); ?></p>
+    <div class="well">
+    <pre>
+        <?= $migrationOutput ?>
+    </pre>
+    </div>
+    <p><br>
+        <?= Html::a(
+            Yii::t('AdminModule.information', 'Update Database'),
+            ['/admin/information/database', 'migrate' => 1],
+            [
+                'id' => 'migrationRun',
+                'class' => 'btn btn-primary pull-right',
+            ]
+        ); ?>
+    </p>
+<?php else: ?>
+    <p><?= Yii::t('AdminModule.information', 'Your database is <b>up-to-date</b>.'); ?></p>
+<?php endif; ?>
 </div>


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

Currently, when navigating to Administration -> Information -> Database, any pending migration is applied immediately and leaves the administrator no choice of whether to actually apply them now.

- This PR loads and displays the pending migration and gives the user the option to apply them.
- Once migrations are applied, the user can reload the migration info (useful, if some migrations failed) and apply them again.
- If no migration is applied, no option to apply them is offered.
- If migrations are applied, cache is automatically cleared as well.

## PR Admin

### What kind of change does this PR introduce?

- Feature

### Does this PR introduce a breaking change?

- No

### The PR fulfills these requirements

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [x] All tests are passing
- [ ] New/updated tests are included
- [x] Changelog was modified
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
