### PR TITLE
[WIP] Enh: Set running migration to `Yii::$app->currentMigration` (ignore for now)

### DIFF
--- a/CHANGELOG-DEV.md
+++ b/CHANGELOG-DEV.md
@@ -3,6 +3,7 @@ HumHub Changelog
 
 1.16.0 (Unreleased)
 -------------------
+- Enh #6719: Set running migration to Yii::$app->currentMigration
 - Fix #6693: `MigrateController::$migrationPathMap` stored rolling sum of migrations 
 - Enh #6697: Make state badge customizable
 - Fix #6636: Module Manager test

--- a/protected/humhub/components/ApplicationTrait.php
+++ b/protected/humhub/components/ApplicationTrait.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * @link      https://www.humhub.org/
  * @copyright Copyright (c) 2023 HumHub GmbH & Co. KG
@@ -8,6 +9,7 @@
 namespace humhub\components;
 
 use humhub\interfaces\MailerInterface;
+use yii\db\MigrationInterface;
 use yii\helpers\Url;
 
 trait ApplicationTrait
@@ -26,6 +28,12 @@ trait ApplicationTrait
      * @var string Minimum PHP version that may works but probably with small issues
      */
     public $minSupportedPhpVersion;
+
+    /**
+     * @var MigrationInterface|null Will be set to the instance of the currently running migration
+     * @see Migration::up() and Migration::down()
+     */
+    public ?MigrationInterface $currentMigration = null;
 
     /**
      * @inheritdoc

--- a/protected/humhub/components/Migration.php
+++ b/protected/humhub/components/Migration.php
@@ -60,7 +60,11 @@ class Migration extends \yii\db\Migration
      */
     public function up()
     {
-        return $this->saveUpDown([$this, 'safeUp']);
+        Yii::$app->currentMigration = $this;
+        $result = $this->saveUpDown([$this, 'safeUp']);
+        Yii::$app->currentMigration = null;
+
+        return $result;
     }
 
     /**
@@ -69,7 +73,11 @@ class Migration extends \yii\db\Migration
      */
     public function down()
     {
-        return $this->saveUpDown([$this, 'safeDown']);
+        Yii::$app->currentMigration = $this;
+        $result = $this->saveUpDown([$this, 'safeDown']);
+        Yii::$app->currentMigration = null;
+
+        return $result;
     }
 
     /**
@@ -482,9 +490,19 @@ class Migration extends \yii\db\Migration
      */
     public function integerReferenceKey(): ColumnSchemaBuilder
     {
-        return $this->integer(11)
-            ->notNull()
-            ;
+        return $this->integer(11)->notNull();
+    }
+
+    /**
+     * Returns the field configuration for a FK field
+     *
+     * @return ColumnSchemaBuilder
+     * @since 1.16
+     * @noinspection PhpUnused
+     */
+    public function integerReferenceKeyUnsigned(): ColumnSchemaBuilder
+    {
+        return $this->integerReferenceKey()->unsigned();
     }
 
     /**


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

Newly introduced automations (e.g. `afterSave()`) may depend on fields that are only about to be installed by the migrations. However, if those automations are called during initialization of the app, they will fail. The current PR sets a property `Yii::$app->currentMigration` to the currently executed migration. Hence, an automation can (not) execute some code if currently migrations (or a specific migration) is being executed.

### What kind of change does this PR introduce?

- Feature

### Does this PR introduce a breaking change?

- No

### The PR fulfills these requirements

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [x] All tests are passing
- [ ] New/updated tests are included
- [x] Changelog was modified

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
