### PR TITLE
 Fix #6720 Regression re isDatabaseInstalled

### DIFF
--- a/protected/humhub/components/ApplicationTrait.php
+++ b/protected/humhub/components/ApplicationTrait.php
@@ -102,9 +102,9 @@ trait ApplicationTrait
      */
     public function isDatabaseInstalled(bool $checkConnection = false): bool
     {
-        $dieOnError = isset(Yii::$app->params['databaseInstalled']) && $this->params['databaseInstalled'];
+        $dieOnError = $this->params['databaseInstalled'] ?? null;
 
-        if (!$checkConnection) {
+        if (!$checkConnection && $dieOnError !== null) {
             return $dieOnError;
         }
 

--- a/protected/humhub/config/common.php
+++ b/protected/humhub/config/common.php
@@ -173,7 +173,6 @@ $config = [
     ],
     'params' => [
         'installed' => false,
-        'databaseInstalled' => false,
         'databaseDefaultStorageEngine' => 'InnoDB',
         'dynamicConfigFile' => '@config/dynamic.php',
         'moduleAutoloadPaths' => ['@app/modules', '@humhub/modules'],

--- a/protected/humhub/tests/codeception/unit/ApplicationBaseTest.php
+++ b/protected/humhub/tests/codeception/unit/ApplicationBaseTest.php
@@ -6,12 +6,12 @@
  * @license   https://www.humhub.com/licences
  */
 
-namespace humhub\tests\codeception\unit\components;
+namespace humhub\tests\codeception\unit;
 
 use tests\codeception\_support\HumHubDbTestCase;
 use Yii;
 
-class BaseSettingsManagerTest extends HumHubDbTestCase
+class ApplicationBaseTest extends HumHubDbTestCase
 {
     public function testIsDatabaseInstalled()
     {


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

Since `protected/humhub/config/common.php` defined `Yii::$app->params['databaseInstalled']` to be false, `Yii::$app->isDatabaseInstalled()` would return false, unless the value is overwritten by `@config/dynamic.php`.

During tests, `@config/dynamic.php` does not set the paramter to true.

The current solution is to remove the paramter alltogether from the default set of config. As such, the value remains undefined unless set in `@config/dynamic.php`.

`Yii::$app->isDatabaseInstalled()` will now check the real database connection not only if the `$checkConnection` parameter is set to true, but also if the parameter has not yet been defined.



## PR Admin

### What kind of change does this PR introduce?

- Bugfix

### Does this PR introduce a breaking change?

- No


### The PR fulfills these requirements

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [x] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [ ] All tests are passing
- [x] New/updated tests are included
- [ ] Changelog was modified
