### PR TITLE
Enh: harmonise term enabled/disabled vs active/inactive for modules

### DIFF
--- a/CHANGELOG-DEV.md
+++ b/CHANGELOG-DEV.md
@@ -3,6 +3,7 @@ HumHub Changelog
 
 1.16.0 (Unreleased)
 -------------------
+- Enh #6745: Harmonise term `enabled/disabled` vs `active/inactive` for modules
 - Fix #6754: Regression due to return type (#6550)
 - Enh #6550: Improve module migrations
 - Fix #6237: Migration errors during module activation are ignored

--- a/MIGRATE-DEV.md
+++ b/MIGRATE-DEV.md
@@ -14,6 +14,10 @@ Version 1.16 (Unreleased)
 - `\humhub\modules\content\components\ContentAddonActiveRecord::canRead()` use `canView()` instead
 - `\humhub\modules\content\components\ContentAddonActiveRecord::canWrite()`
 - `\humhub\modules\file\models\File::canRead()` use `canView()` instead
+- `\humhub\modules\friendship\Module::getIsEnabled()` use `isFriendshipEnabled()` instead
+  (note: `\humhub\modules\friendship\Module::getIsEnabled()` and the virtual
+  property `\humhub\modules\friendship\Module::isEnabled` now return the status of the module -
+  which yields always true for core modules.)
 
 ### Type restrictions
 - `\humhub\commands\MigrateController` enforces types on fields, method parameters, & return types

--- a/MIGRATE-DEV.md
+++ b/MIGRATE-DEV.md
@@ -18,6 +18,7 @@ Version 1.16 (Unreleased)
   (note: `\humhub\modules\friendship\Module::getIsEnabled()` and the virtual
   property `\humhub\modules\friendship\Module::isEnabled` now return the status of the module -
   which yields always true for core modules.)
+- `\humhub\modules\marketplace\Module::isEnabled()` use `isMarketplaceEnabled()` instead
 
 ### Type restrictions
 - `\humhub\commands\MigrateController` enforces types on fields, method parameters, & return types

--- a/MIGRATE-DEV.md
+++ b/MIGRATE-DEV.md
@@ -8,6 +8,9 @@ Version 1.16 (Unreleased)
 -------------------------
 
 ### Deprecations
+- `\humhub\components\Module::getIsActivated()` use `getIsEnabled()` instead
+  (note: this also affects the virtual instance property `\humhub\modules\friendship\Module::$isActivated` which should
+  now read `$isEnabled`!)
 - `\humhub\components\Module::migrate()` use `getMigrationService()->migrateUp(MigrationService::ACTION_MIGRATE)` instead
 - `\humhub\libs\BaseSettingsManager::isDatabaseInstalled()` use `Yii::$app->isDatabaseInstalled()` instead
 - `\humhub\models\Setting::isInstalled()` use `Yii::$app->isInstalled()` instead
@@ -19,6 +22,7 @@ Version 1.16 (Unreleased)
   property `\humhub\modules\friendship\Module::isEnabled` now return the status of the module -
   which yields always true for core modules.)
 - `\humhub\modules\marketplace\Module::isEnabled()` use `isMarketplaceEnabled()` instead
+- `\humhub\modules\marketplace\services\ModuleService::activate()` use `enable()` instead
 
 ### Type restrictions
 - `\humhub\commands\MigrateController` enforces types on fields, method parameters, & return types

--- a/protected/humhub/components/Module.php
+++ b/protected/humhub/components/Module.php
@@ -230,14 +230,24 @@ class Module extends \yii\base\Module
     }
 
     /**
-     * Check this module is activated
+     * Check this module is enabled
      *
      * @return bool
      */
-    public function getIsActivated(): bool
+    public function getIsEnabled(): bool
     {
         return Yii::$app->hasModule($this->id) &&
             !QueueHelper::isQueued(new DisableModuleJob(['moduleId' => $this->id]));
+    }
+
+    /**
+     * @see          static::getIsEnabled()
+     * @deprecated since 1.16; use static::getIsEnabled() instead.
+     * @noinspection PhpUnused
+     */
+    public function getIsActivated(): bool
+    {
+        return $this->getIsEnabled();
     }
 
     /**

--- a/protected/humhub/components/ModuleManager.php
+++ b/protected/humhub/components/ModuleManager.php
@@ -464,7 +464,7 @@ class ModuleManager extends Component
     }
 
     /**
-     * Checks if a moduleId exists, regardless it's activated or not
+     * Checks if a moduleId exists, regardless it's enabled or not
      *
      * @param string $id
      *

--- a/protected/humhub/libs/SelfTest.php
+++ b/protected/humhub/libs/SelfTest.php
@@ -848,7 +848,7 @@ class SelfTest
             /* @var \humhub\modules\fcmPush\Module|null $pushModule */
             $pushModule = $modules['fcm-push'] ?? null;
             if ($pushModule instanceof \humhub\modules\fcmPush\Module &&
-                $pushModule->isActivated &&
+                $pushModule->getIsEnabled() &&
                 $pushModule->getGoService()->isConfigured()) {
                 $checks[] = [
                     'title' => $title,

--- a/protected/humhub/modules/admin/widgets/AvailableModuleUpdatesInfo.php
+++ b/protected/humhub/modules/admin/widgets/AvailableModuleUpdatesInfo.php
@@ -28,7 +28,7 @@ class AvailableModuleUpdatesInfo extends Widget
      */
     public function beforeRun()
     {
-        if (!Module::isEnabled() || !Yii::$app->user->can(ManageModules::class)) {
+        if (!Module::isMarketplaceEnabled() || !Yii::$app->user->can(ManageModules::class)) {
             return false;
         }
 

--- a/protected/humhub/modules/admin/widgets/InstalledModuleActionButtons.php
+++ b/protected/humhub/modules/admin/widgets/InstalledModuleActionButtons.php
@@ -30,8 +30,8 @@ class InstalledModuleActionButtons extends Widget
      */
     public function run()
     {
-        if (!$this->module->isActivated && Yii::$app->user->can(ManageModules::class)) {
-            return Button::asLink(Yii::t('AdminModule.base', 'Activate'),
+        if (!$this->module->getIsEnabled() && Yii::$app->user->can(ManageModules::class)) {
+            return Button::asLink(Yii::t('AdminModule.base', 'Enable'),
                 Url::to(['/admin/module/enable', 'moduleId' => $this->module->id]))
                 ->cssClass('btn btn-sm btn-info')
                 ->options([

--- a/protected/humhub/modules/admin/widgets/InstalledModuleControls.php
+++ b/protected/humhub/modules/admin/widgets/InstalledModuleControls.php
@@ -90,7 +90,7 @@ class InstalledModuleControls extends Menu
             ]));
         }
 
-        if (MarketplaceModule::isEnabled()) {
+        if (MarketplaceModule::isMarketplaceEnabled()) {
             $this->addEntry(new MenuLink([
                 'id' => 'info',
                 'label' => Yii::t('AdminModule.base', 'Show in Marketplace'),

--- a/protected/humhub/modules/admin/widgets/InstalledModuleControls.php
+++ b/protected/humhub/modules/admin/widgets/InstalledModuleControls.php
@@ -38,7 +38,7 @@ class InstalledModuleControls extends Menu
 
     public function initControls()
     {
-        if ($this->module->isActivated) {
+        if ($this->module->getIsEnabled()) {
             if ($this->module instanceof ContentContainerModule) {
                 $this->addEntry(new MenuLink([
                     'id' => 'default',
@@ -52,7 +52,7 @@ class InstalledModuleControls extends Menu
 
             $this->addEntry(new MenuLink([
                 'id' => 'deactivate',
-                'label' => Yii::t('AdminModule.base', 'Deactivate'),
+                'label' => Yii::t('AdminModule.base', 'Disable'),
                 'url' => $this->getActionUrl('/admin/module/disable'),
                 'htmlOptions' => [
                     'data-method' => 'POST',
@@ -64,7 +64,7 @@ class InstalledModuleControls extends Menu
         } else {
             $this->addEntry(new MenuLink([
                 'id' => 'deactivate',
-                'label' => Yii::t('AdminModule.base', 'Activate'),
+                'label' => Yii::t('AdminModule.base', 'Enable'),
                 'url' => $this->getActionUrl('/admin/module/enable'),
                 'htmlOptions' => [
                     'data-method' => 'POST',

--- a/protected/humhub/modules/admin/widgets/InstalledModuleList.php
+++ b/protected/humhub/modules/admin/widgets/InstalledModuleList.php
@@ -43,7 +43,7 @@ class InstalledModuleList extends Widget
         $activeModules = [];
         $inactiveModules = [];
         foreach ($modules as $module) {
-            if ($module->isActivated) {
+            if ($module->getIsEnabled()) {
                 $activeModules[] = $module;
             } else {
                 $inactiveModules[] = $module;

--- a/protected/humhub/modules/content/components/ActiveQueryContent.php
+++ b/protected/humhub/modules/content/components/ActiveQueryContent.php
@@ -99,7 +99,7 @@ class ActiveQueryContent extends ActiveQuery
             $conditionUser = 'cuser.id IS NOT NULL AND (';                                         // user content
             $conditionUser .= '   (content.visibility = 1) OR';                                     // public visible content
             $conditionUser .= '   (content.visibility = 0' . $conditionUserPrivateRestriction . ')';  // private content of user
-            if (Yii::$app->getModule('friendship')->getIsEnabled()) {
+            if (Yii::$app->getModule('friendship')->isFriendshipEnabled()) {
                 $this->leftJoin('user_friendship cff', 'cuser.id=cff.user_id AND cff.friend_user_id=:fuid', [':fuid' => $user->id]);
                 $conditionUser .= ' OR (content.visibility = 0 AND cff.id IS NOT NULL)';  // users are friends
             }

--- a/protected/humhub/modules/content/components/ContentContainerModuleManager.php
+++ b/protected/humhub/modules/content/components/ContentContainerModuleManager.php
@@ -175,7 +175,7 @@ class ContentContainerModuleManager extends \yii\base\Component
     {
         return
             $module instanceof ContentContainerModule
-            && $module->isActivated
+            && $module->getIsEnabled()
             && $module->hasContentContainerType(get_class($this->contentContainer))
             && self::getDefaultState(get_class($this->contentContainer), $module->id) !== ContentContainerModuleState::STATE_NOT_AVAILABLE;
     }

--- a/protected/humhub/modules/dashboard/stream/filters/DashboardMemberStreamFilter.php
+++ b/protected/humhub/modules/dashboard/stream/filters/DashboardMemberStreamFilter.php
@@ -144,7 +144,7 @@ class DashboardMemberStreamFilter extends StreamQueryFilter
      */
     private function isFriendShipEnabled()
     {
-        return Yii::$app->getModule('friendship')->getIsEnabled();
+        return Yii::$app->getModule('friendship')->isFriendshipEnabled();
     }
 
     /**

--- a/protected/humhub/modules/friendship/Events.php
+++ b/protected/humhub/modules/friendship/Events.php
@@ -13,7 +13,7 @@ use yii\helpers\Url;
 
 /**
  * Events provides callbacks for all defined module events.
- * 
+ *
  * @author luke
  */
 class Events extends \yii\base\BaseObject
@@ -21,12 +21,12 @@ class Events extends \yii\base\BaseObject
 
     /**
      * Add friends navigation entry to account menu
-     * 
+     *
      * @param \yii\base\Event $event
      */
     public static function onAccountMenuInit($event)
     {
-        if (Yii::$app->getModule('friendship')->getIsEnabled()) {
+        if (Yii::$app->getModule('friendship')->isFriendshipEnabled()) {
             $event->sender->addItem([
                 'label' => Yii::t('FriendshipModule.base', 'Friends'),
                 'url' => Url::to(['/friendship/manage']),

--- a/protected/humhub/modules/friendship/Module.php
+++ b/protected/humhub/modules/friendship/Module.php
@@ -26,7 +26,7 @@ class Module extends \humhub\components\Module
      *
      * @return boolean is enabled
      */
-    public function getIsEnabled()
+    public function isFriendshipEnabled(): bool
     {
         if (Yii::$app->getModule('friendship')->settings->get('enable')) {
             return true;

--- a/protected/humhub/modules/friendship/controllers/RequestController.php
+++ b/protected/humhub/modules/friendship/controllers/RequestController.php
@@ -31,7 +31,7 @@ class RequestController extends Controller
      */
     public function beforeAction($action)
     {
-        if (!$this->module->getIsEnabled()) {
+        if (!$this->module->isFriendshipEnabled()) {
             throw new HttpException(404, 'Friendship system is not enabled!');
         }
 

--- a/protected/humhub/modules/friendship/notifications/FriendshipNotificationCategory.php
+++ b/protected/humhub/modules/friendship/notifications/FriendshipNotificationCategory.php
@@ -26,7 +26,7 @@ class FriendshipNotificationCategory extends NotificationCategory
 
     /**
      * Category Id
-     * @var string 
+     * @var string
      */
     public $id = 'friendship';
 
@@ -67,7 +67,7 @@ class FriendshipNotificationCategory extends NotificationCategory
      */
     public function isVisible(User $user = null)
     {
-        return Yii::$app->getModule('friendship')->getIsEnabled();
+        return Yii::$app->getModule('friendship')->isFriendshipEnabled();
     }
 
 }

--- a/protected/humhub/modules/friendship/widgets/FriendsPanel.php
+++ b/protected/humhub/modules/friendship/widgets/FriendsPanel.php
@@ -21,7 +21,7 @@ class FriendsPanel extends \yii\base\Widget
 {
 
     /**
-     * @var User the target user 
+     * @var User the target user
      */
     public $user;
 
@@ -35,7 +35,7 @@ class FriendsPanel extends \yii\base\Widget
      */
     public function run()
     {
-        if (!Yii::$app->getModule('friendship')->getIsEnabled()) {
+        if (!Yii::$app->getModule('friendship')->isFriendshipEnabled()) {
             return;
         }
 

--- a/protected/humhub/modules/friendship/widgets/FriendshipButton.php
+++ b/protected/humhub/modules/friendship/widgets/FriendshipButton.php
@@ -127,7 +127,7 @@ class FriendshipButton extends \yii\base\Widget
     public static function isVisibleForUser(User $user): bool
     {
         return !Yii::$app->user->isGuest &&
-            Yii::$app->getModule('friendship')->getIsEnabled() &&
+            Yii::$app->getModule('friendship')->isFriendshipEnabled() &&
             !$user->isCurrentUser();
     }
 

--- a/protected/humhub/modules/live/Module.php
+++ b/protected/humhub/modules/live/Module.php
@@ -76,7 +76,7 @@ class Module extends \humhub\components\Module
             $privateContainerQuery = Membership::getMemberSpaceContainerIdQuery($user);
 
             // Add friend container if friendship module is active
-            if (Yii::$app->getModule('friendship')->getIsEnabled()) {
+            if (Yii::$app->getModule('friendship')->isFriendshipEnabled()) {
                 $privateContainerQuery->union(Friendship::getFriendshipContainerIdQuery($user), true);
             }
 

--- a/protected/humhub/modules/marketplace/Events.php
+++ b/protected/humhub/modules/marketplace/Events.php
@@ -30,7 +30,7 @@ class Events extends BaseObject
      */
     public static function onConsoleApplicationInit($event)
     {
-        if (!Module::isEnabled()) {
+        if (!Module::isMarketplaceEnabled()) {
             return;
         }
 
@@ -47,7 +47,7 @@ class Events extends BaseObject
 
     public static function onMarketplaceAfterFilterModules(ModulesEvent $event)
     {
-        if (!Module::isEnabled()) {
+        if (!Module::isMarketplaceEnabled()) {
             return;
         }
 
@@ -64,7 +64,7 @@ class Events extends BaseObject
 
     public static function onAccountTopMenuInit($event)
     {
-        if (!Module::isEnabled() ||
+        if (!Module::isMarketplaceEnabled() ||
             !Yii::$app->user->isAdmin() ||
             !Yii::$app->user->can(ManageModules::class)) {
             return;

--- a/protected/humhub/modules/marketplace/Module.php
+++ b/protected/humhub/modules/marketplace/Module.php
@@ -11,8 +11,8 @@ namespace humhub\modules\marketplace;
 use humhub\components\Module as BaseModule;
 use humhub\modules\marketplace\components\HumHubApiClient;
 use humhub\modules\marketplace\components\LicenceManager;
-use humhub\modules\marketplace\models\Licence;
 use humhub\modules\marketplace\components\OnlineModuleManager;
+use humhub\modules\marketplace\models\Licence;
 use Yii;
 
 /**
@@ -62,6 +62,8 @@ class Module extends BaseModule
      * @var array A list of module ids that cannot be installed.
      */
     public $moduleBlacklist = [];
+    private $_onlineModuleManager = null;
+    private $_humhubApi = null;
 
     /**
      * @inheritdoc
@@ -70,10 +72,6 @@ class Module extends BaseModule
     {
         return Yii::t('MarketplaceModule.base', 'Marketplace');
     }
-
-    private $_onlineModuleManager = null;
-
-    private $_humhubApi = null;
 
     /**
      * @inheritDoc
@@ -93,8 +91,18 @@ class Module extends BaseModule
 
     /**
      * @return bool
+     * @deprecated since v1.16; use `static::isMarketplaceEnabled()` instead
+     * @see static::isMarketplaceEnabled()
      */
     public static function isEnabled(): bool
+    {
+        return static::isMarketplaceEnabled();
+    }
+
+    /**
+     * @return bool
+     */
+    public static function isMarketplaceEnabled(): bool
     {
         /* @var Module $marketplaceModule */
         $marketplaceModule = Yii::$app->getModule('marketplace');

--- a/protected/humhub/modules/marketplace/commands/MarketplaceController.php
+++ b/protected/humhub/modules/marketplace/commands/MarketplaceController.php
@@ -235,7 +235,7 @@ class MarketplaceController extends Controller
         /** @var Module $module */
         $module = Yii::$app->moduleManager->getModule($moduleId);
         if ($module === null || !Yii::$app->hasModule($moduleId)) {
-            $this->stdout(Yii::t('MarketplaceModule.base', "Module not found or activated!\n"), Console::FG_RED, Console::BOLD);
+            $this->stdout(Yii::t('MarketplaceModule.base', "Module not found or enabled!\n"), Console::FG_RED, Console::BOLD);
             return 1;
         }
 

--- a/protected/humhub/modules/marketplace/controllers/BrowseController.php
+++ b/protected/humhub/modules/marketplace/controllers/BrowseController.php
@@ -74,15 +74,29 @@ class BrowseController extends Controller
     }
 
     /**
-     * Activates a module after installation
+     * Enables a module after installation
+     *
+     * @deprecated since v1.16; use static::actionEnable()
+     * @see static::actionEnable()
+     * @throws NotFoundHttpException
      */
-    public function actionActivate()
+    public function actionActivate(): string
+    {
+        return $this->actionEnable();
+    }
+
+    /**
+     * Enables a module after installation
+     *
+     * @throws HttpException
+*/
+    public function actionEnable(): string
     {
         $this->forcePostRequest();
 
         $moduleService = $this->getModuleService();
 
-        if (!$moduleService->activate()) {
+        if (!$moduleService->enable()) {
             throw new NotFoundHttpException(Yii::t('MarketplaceModule.base', 'Could not find the requested module!'));
         }
 

--- a/protected/humhub/modules/marketplace/controllers/BrowseController.php
+++ b/protected/humhub/modules/marketplace/controllers/BrowseController.php
@@ -38,7 +38,7 @@ class BrowseController extends Controller
      */
     public function beforeAction($action)
     {
-        if (!Module::isEnabled()) {
+        if (!Module::isMarketplaceEnabled()) {
             throw new NotFoundHttpException(Yii::t('MarketplaceModule.base', 'Marketplace is disabled.'));
         }
 

--- a/protected/humhub/modules/marketplace/models/Module.php
+++ b/protected/humhub/modules/marketplace/models/Module.php
@@ -193,9 +193,21 @@ class Module extends Model
             !($this->isDeprecated && $marketplaceModule->hideLegacyModules);
     }
 
+    /**
+     * @deprecated since v1.16; use self::getIsEnabled()
+     * @see self::getIsEnabled()
+     */
     public function getIsActivated(): bool
     {
-        return Yii::$app->moduleManager->getModule($this->id)->isActivated;
+        return $this->getIsEnabled();
+    }
+
+    /**
+     * @since v1.16
+     */
+    public function getIsEnabled(): bool
+    {
+        return Yii::$app->moduleManager->getModule($this->id)->getIsEnabled();
     }
 
     public function getConfigUrl(): string

--- a/protected/humhub/modules/marketplace/resources/js/humhub.marketplace.js
+++ b/protected/humhub/modules/marketplace/resources/js/humhub.marketplace.js
@@ -143,9 +143,9 @@ humhub.module('marketplace', function (module, require, $) {
         modal.global.show();
 
         modal.post(evt, {data: {moduleId}}).then(function () {
-            const activateButton = modal.global.$.find('[data-action-click="marketplace.activate"]').clone();
-            if (activateButton.length) {
-                installButton.after(activateButton.addClass('btn-sm'));
+            const enableButton = modal.global.$.find('[data-action-click="marketplace.enable"]').clone();
+            if (enableButton.length) {
+                installButton.after(enableButton.addClass('btn-sm'));
             }
             installButton.remove();
         }).catch(function (e) {
@@ -153,7 +153,7 @@ humhub.module('marketplace', function (module, require, $) {
         });
     }
 
-    const activate = function(evt) {
+    const enable = function(evt) {
         const moduleId = evt.$trigger.data('module-id');
         const moduleCard = $('button[data-module-id="' + moduleId + '"]').closest('.card');
 
@@ -171,6 +171,6 @@ humhub.module('marketplace', function (module, require, $) {
         updateAll,
         registerLicenceKey,
         install,
-        activate
+        enable
     });
 });

--- a/protected/humhub/modules/marketplace/services/MarketplaceService.php
+++ b/protected/humhub/modules/marketplace/services/MarketplaceService.php
@@ -62,7 +62,7 @@ class MarketplaceService
 
     public function refreshPendingModuleUpdateCount(int $count = null)
     {
-        if (MarketplaceModule::isEnabled()) {
+        if (MarketplaceModule::isMarketplaceEnabled()) {
             if ($count === null) {
                 $count = count($this->getMarketplaceModule()->onlineModuleManager->getModuleUpdates());
             }
@@ -73,7 +73,7 @@ class MarketplaceService
 
     public function getPendingModuleUpdateCount(): int
     {
-        return MarketplaceModule::isEnabled()
+        return MarketplaceModule::isMarketplaceEnabled()
             ? (int) $this->getSettings()->get('pendingModuleUpdateCount')
             : 0;
     }

--- a/protected/humhub/modules/marketplace/services/ModuleService.php
+++ b/protected/humhub/modules/marketplace/services/ModuleService.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @link https://www.humhub.org/
  * @copyright Copyright (c) HumHub GmbH & Co. KG
@@ -76,7 +77,17 @@ class ModuleService
         return true;
     }
 
+    /**
+     * @return bool
+     * @deprecated since v1.16; use static::enable()
+     * @see static::enable()
+     */
     public function activate(): bool
+    {
+        return $this->enable();
+    }
+
+    public function enable(): bool
     {
         return $this->module instanceof CoreModule && $this->module->enable();
     }
@@ -111,8 +122,8 @@ class ModuleService
             'success' => true,
             'status' => Yii::t('MarketplaceModule.base', 'Update successful'),
             'message' => Yii::t('MarketplaceModule.base', 'Module "{moduleName}" has been updated to version {newVersion} successfully.', [
-                'moduleName' => $moduleInfo['latestCompatibleVersion']['name'],
-                'newVersion' => $moduleInfo['latestCompatibleVersion']['version'],
+                    'moduleName' => $moduleInfo['latestCompatibleVersion']['name'],
+                    'newVersion' => $moduleInfo['latestCompatibleVersion']['version'],
             ])
         ];
     }

--- a/protected/humhub/modules/marketplace/views/browse/enabled.php
+++ b/protected/humhub/modules/marketplace/views/browse/enabled.php
@@ -12,7 +12,7 @@ use humhub\widgets\ModalDialog;
 /* @var string $moduleConfigUrl */
 ?>
 <?php ModalDialog::begin([
-    'header' => Yii::t('MarketplaceModule.base', 'Module <strong>activated</strong>')
+    'header' => Yii::t('MarketplaceModule.base', 'Module <strong>enabled</strong>')
 ]) ?>
 
     <div class="modal-body">
@@ -21,13 +21,13 @@ use humhub\widgets\ModalDialog;
             <br><br>
             <?= Yii::t('MarketplaceModule.base', 'Would you like to jump straight to it?') ?>
         <?php else : ?>
-            <?= Yii::t('MarketplaceModule.base', 'Well done! You have successful installed an activated the module!') ?>
+            <?= Yii::t('MarketplaceModule.base', 'Well done! You have successfully installed and enabled the module!') ?>
         <?php endif; ?>
     </div>
 
     <div class="modal-footer">
         <?php if ($moduleConfigUrl) : ?>
-            <?= ModalButton::cancel() ?>
+            <?= ModalButton::cancel(Yii::t('MarketplaceModule.base', 'No, thank you!')) ?>
             <?= Button::primary(Yii::t('MarketplaceModule.base', 'Module configuration'))
                 ->link($moduleConfigUrl) ?>
         <?php else : ?>

--- a/protected/humhub/modules/marketplace/views/browse/installed.php
+++ b/protected/humhub/modules/marketplace/views/browse/installed.php
@@ -15,13 +15,13 @@ use humhub\widgets\ModalDialog;
 ]) ?>
 
     <div class="modal-body">
-        <?= Yii::t('MarketplaceModule.base', 'Well done! To make the module available within your network, you will also need to activate it. Do you want to activate it now?') ?>
+        <?= Yii::t('MarketplaceModule.base', 'Well done! To make the module available within your network, you will also need to enable it. Do you want to enable it now?') ?>
     </div>
 
     <div class="modal-footer">
-        <?= ModalButton::cancel() ?>
-        <?= ModalButton::primary(Yii::t('MarketplaceModule.base', 'Activate now'))
-            ->action('marketplace.activate', ['/marketplace/browse/activate'])
+        <?= ModalButton::cancel(Yii::t('MarketplaceModule.base', 'No, thank you!')) ?>
+        <?= ModalButton::primary(Yii::t('MarketplaceModule.base', 'Enable now'))
+            ->action('marketplace.enable', ['/marketplace/browse/enable'])
             ->options(['data-module-id' => $moduleId]) ?>
     </div>
 

--- a/protected/humhub/modules/marketplace/widgets/MarketplaceLink.php
+++ b/protected/humhub/modules/marketplace/widgets/MarketplaceLink.php
@@ -29,7 +29,7 @@ class MarketplaceLink extends Button
      */
     public function beforeRun()
     {
-        if (!Module::isEnabled() || !Yii::$app->user->can(ManageModules::class)) {
+        if (!Module::isMarketplaceEnabled() || !Yii::$app->user->can(ManageModules::class)) {
             return false;
         }
 

--- a/protected/humhub/modules/marketplace/widgets/ModuleGroups.php
+++ b/protected/humhub/modules/marketplace/widgets/ModuleGroups.php
@@ -81,7 +81,7 @@ class ModuleGroups extends Widget
         $installedModules = $marketplaceModule->onlineModuleManager->getInstalledModules();
         if (count($installedModules) > 0) {
             $installedModules = Yii::$app->moduleManager->filterModules($installedModules);
-            ArrayHelper::multisort($installedModules, 'isActivated', SORT_DESC);
+            ArrayHelper::multisort($installedModules, 'isEnabled', SORT_DESC);
             $this->addGroup('installed', [
                 'title' => Yii::t('MarketplaceModule.base', 'Installed'),
                 'modules' => $installedModules,

--- a/protected/humhub/modules/marketplace/widgets/ModuleInstalledActionButtons.php
+++ b/protected/humhub/modules/marketplace/widgets/ModuleInstalledActionButtons.php
@@ -38,18 +38,18 @@ class ModuleInstalledActionButtons extends Widget
     {
         $html = '';
 
-        if ($this->module->isActivated) {
+        if ($this->module->getIsEnabled()) {
             if ($this->module->getConfigUrl() != '') {
                 $html .= Button::asLink(Yii::t('MarketplaceModule.base', 'Configure'), $this->module->getConfigUrl())
                     ->cssClass('btn btn-sm btn-info');
             }
-            $html .= Button::info(Yii::t('MarketplaceModule.base', 'Activated'))
+            $html .= Button::info(Yii::t('MarketplaceModule.base', 'Enabled'))
                 ->link(['/admin/module/list'])
                 ->icon('check')
                 ->cssClass('active')
                 ->sm();
         } else {
-            $html .= Button::info(Yii::t('MarketplaceModule.base', 'Activate'))
+            $html .= Button::info(Yii::t('MarketplaceModule.base', 'Enable'))
                 ->link(['/admin/module/list'])
                 ->sm();
         }

--- a/protected/humhub/modules/user/Module.php
+++ b/protected/humhub/modules/user/Module.php
@@ -197,7 +197,7 @@ class Module extends \humhub\components\Module
                 new permissions\ViewAboutPage(),
             ];
 
-            if(Yii::$app->getModule('friendship')->getIsEnabled()) {
+            if(Yii::$app->getModule('friendship')->isFriendshipEnabled()) {
                 $permissions[] = new permissions\CanMention();
             }
 

--- a/protected/humhub/modules/user/controllers/AccountController.php
+++ b/protected/humhub/modules/user/controllers/AccountController.php
@@ -187,7 +187,7 @@ class AccountController extends BaseAccountController
         $groups = [];
         $groupAccessEnabled = AuthHelper::isGuestAccessEnabled();
 
-        if (Yii::$app->getModule('friendship')->getIsEnabled()) {
+        if (Yii::$app->getModule('friendship')->isFriendshipEnabled()) {
             $groups[User::USERGROUP_FRIEND] = Yii::t('UserModule.account', 'Your friends');
             $groups[User::USERGROUP_USER] = Yii::t('UserModule.account', 'Other users');
         } else {

--- a/protected/humhub/modules/user/models/User.php
+++ b/protected/humhub/modules/user/models/User.php
@@ -440,7 +440,7 @@ class User extends ContentContainerActiveRecord implements IdentityInterface, Se
      */
     public function getFriends()
     {
-        if (Yii::$app->getModule('friendship')->getIsEnabled()) {
+        if (Yii::$app->getModule('friendship')->isFriendshipEnabled()) {
             return Friendship::getFriendsQuery($this);
         }
 
@@ -754,7 +754,7 @@ class User extends ContentContainerActiveRecord implements IdentityInterface, Se
         }
 
         // Friend
-        if (Yii::$app->getModule('friendship')->getIsEnabled()) {
+        if (Yii::$app->getModule('friendship')->isFriendshipEnabled()) {
             return (Friendship::getStateForUser($this, $user) == Friendship::STATE_FRIENDS);
         }
 
@@ -929,7 +929,7 @@ class User extends ContentContainerActiveRecord implements IdentityInterface, Se
     {
         $groups = [];
 
-        if (Yii::$app->getModule('friendship')->getIsEnabled()) {
+        if (Yii::$app->getModule('friendship')->isFriendshipEnabled()) {
             $groups[self::USERGROUP_FRIEND] = Yii::t('UserModule.account', 'Your friends');
             $groups[self::USERGROUP_USER] = Yii::t('UserModule.account', 'Other users');
         } else {
@@ -958,7 +958,7 @@ class User extends ContentContainerActiveRecord implements IdentityInterface, Se
             return self::USERGROUP_SELF;
         }
 
-        if (Yii::$app->getModule('friendship')->getIsEnabled()) {
+        if (Yii::$app->getModule('friendship')->isFriendshipEnabled()) {
             if (Friendship::getStateForUser($this, $user) === Friendship::STATE_FRIENDS) {
                 return self::USERGROUP_FRIEND;
             }

--- a/protected/humhub/modules/user/models/UserFilter.php
+++ b/protected/humhub/modules/user/models/UserFilter.php
@@ -22,7 +22,7 @@ class UserFilter extends User
     /**
      * Returns a UserFilter instance for the given $user or the current user identity
      * if $user is not provided.
-     * 
+     *
      * @param type $user
      * @return type
      */
@@ -38,17 +38,17 @@ class UserFilter extends User
 
     /**
      * Default implementation for user picker filter.
-     * 
+     *
      * @param type $keywords
      * @param type $maxResults
      * @param type $friendsOnly
      * @param type $permission
-     * @deprecated since 1.2 use 
+     * @deprecated since 1.2 use
      * @return type
      */
     public function getUserPickerResult($keywords = null, $maxResults = null, $friendsOnly = false, $permission = null)
     {
-        if (!Yii::$app->getModule('friendship')->getIsEnabled()) {
+        if (!Yii::$app->getModule('friendship')->isFriendshipEnabled()) {
             //We don't use the permission here for filtering since we include user with no permission as disabled in the result.
             //The problem here is we do not prefer users with permission in the query.
             $users = $this->getUserByFilter($keywords, $maxResults);
@@ -56,10 +56,10 @@ class UserFilter extends User
         }
 
         $friends = $this->getFriendsByFilter($keywords, $maxResults);
-        
+
         //Create userinfo json with with set 'disabled' field if the user is not permitted
         $jsonResult = UserPicker::asJSON($friends, $permission);
-        
+
         //Fill the remaining space with member users with the given permission
         if (!$friendsOnly && count($friends) < $maxResults) {
             $additionalUser = [];
@@ -74,7 +74,7 @@ class UserFilter extends User
 
         return $jsonResult;
     }
-    
+
     private function containsUser($userArr, $user)
     {
         foreach($userArr as $currentUser) {
@@ -87,7 +87,7 @@ class UserFilter extends User
 
     /**
      * Searches for all active users by the given keyword and permission.
-     * 
+     *
      * @param type $keywords
      * @param type $maxResults
      * @param type $permission
@@ -100,7 +100,7 @@ class UserFilter extends User
 
     /**
      * Search for all active friends by the given keyword and permission
-     * 
+     *
      * @param type $keywords search keyword
      * @param type $maxResults
      * @param type $permission
@@ -110,13 +110,13 @@ class UserFilter extends User
     {
         return self::filter($this->getFriends(), $keywords, $maxResults, $permission);
     }
-    
+
     /**
      * Returns an array of user models filtered by a $keyword and $permission. These filters
      * are added to the provided $query. The $keyword filter can be used to filter the users
      * by email, username, firstname, lastname and title. By default this functions does not
      * consider inactive user.
-     * 
+     *
      * @param type $query
      * @param type $keywords
      * @param type $maxResults
@@ -133,16 +133,16 @@ class UserFilter extends User
     public static function addQueryFilter($query, $keywords = null, $maxResults = null, $active = null)
     {
         self::addKeywordFilter($query, $keywords);
-        
+
         if ($maxResults != null) {
             $query->limit($maxResults);
         }
-        
+
         //We filter active user by default
         if(($active != null && $active) || $active == null) {
             $query->active();
         }
-        
+
         return $query;
     }
 
@@ -161,7 +161,7 @@ class UserFilter extends User
     /**
      * Returns a subset of the given array containing all users of the given set
      * which are permitted. If the permission is null this method returns the
-     * 
+     *
      * @param $users
      * @param $permission
      * @return array

--- a/protected/humhub/modules/user/permissions/ViewAboutPage.php
+++ b/protected/humhub/modules/user/permissions/ViewAboutPage.php
@@ -48,7 +48,7 @@ class ViewAboutPage extends \humhub\libs\BasePermission
     public function getDefaultState($groupId)
     {
         // When friendship is disabled, also allow normal members to see about page
-        if ($groupId == User::USERGROUP_USER && !Yii::$app->getModule('friendship')->getIsEnabled()) {
+        if ($groupId == User::USERGROUP_USER && !Yii::$app->getModule('friendship')->isFriendshipEnabled()) {
             return self::STATE_ALLOW;
         }
 

--- a/protected/humhub/modules/user/stream/filters/IncludeAllContributionsFilter.php
+++ b/protected/humhub/modules/user/stream/filters/IncludeAllContributionsFilter.php
@@ -85,7 +85,7 @@ class IncludeAllContributionsFilter extends ContentContainerStreamFilter
         $conditionUser .= '   (content.visibility = 1) OR';             // public visible content
         $conditionUser .= '   (content.visibility = 0' . $conditionUserPrivateRestriction . ')';  // private content of user
 
-        if (Yii::$app->getModule('friendship')->getIsEnabled()) {
+        if (Yii::$app->getModule('friendship')->isFriendshipEnabled()) {
             $this->query->leftJoin('user_friendship cff', 'cuser.id=cff.user_id AND cff.friend_user_id=:fuid', [':fuid' => $queryUser->id]);
             $conditionUser .= ' OR (content.visibility = 0 AND cff.id IS NOT NULL)';  // users are friends
         }

--- a/protected/humhub/modules/user/widgets/ProfileHeader.php
+++ b/protected/humhub/modules/user/widgets/ProfileHeader.php
@@ -65,7 +65,7 @@ class ProfileHeader extends \yii\base\Widget
             // Deprecated variables below (will removed in future versions)
             'allowModifyProfileImage' => $canEditProfileImage, // @deprecated since 1.4 only in use for legacy themes
             'allowModifyProfileBanner' => $canEditProfileImage, // @deprecated since 1.4 only in use for legacy themes
-            'friendshipsEnabled' => Yii::$app->getModule('friendship')->getIsEnabled(),
+            'friendshipsEnabled' => Yii::$app->getModule('friendship')->isFriendshipEnabled(),
             'followingEnabled' => !Yii::$app->getModule('user')->disableFollow,
             'countFriends' => -1,
             'countFollowers' => -1,

--- a/protected/humhub/modules/user/widgets/ProfileHeaderCounterSet.php
+++ b/protected/humhub/modules/user/widgets/ProfileHeaderCounterSet.php
@@ -36,7 +36,7 @@ class ProfileHeaderCounterSet extends CounterSet
      */
     public function init()
     {
-        if (Yii::$app->getModule('friendship')->getIsEnabled()) {
+        if (Yii::$app->getModule('friendship')->isFriendshipEnabled()) {
             $this->counters[] = new CounterSetItem([
                 'label' => Yii::t('UserModule.profile', 'Friends'),
                 'value' => Friendship::getFriendsQuery($this->user)->count(),


### PR DESCRIPTION


Renaming thought the code (of core) the terms that relate to Module's enabled state:
- `active` => `enabled`
- `activate` => `enable`
- `deactivate` => `disable`


## PR Admin
### What kind of change does this PR introduce?

- Code style update
- Refactor

### Does this PR introduce a breaking change?

- Yes

If yes, please describe the impact and migration path for existing applications:

documented in MIGRATE-DEV.md

### The PR fulfills these requirements

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [x] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [x] All tests are passing
- [ ] New/updated tests are included
- [x] Changelog was modified

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

See
- https://github.com/humhub/humhub/pull/6550#issuecomment-1829335643 (@luke-)
  > > > * I like the idea to remove the term `active` and always work with `enabled`. If you like feel free to create a PR and mark `activate*` as deprecated for now. @yurabakhtin ok from your side?
  > > 
  > > 
  > > Turns out, `\humhub\modules\friendship\Module::getIsEnabled()` is used for a different purpose. Shall we rename this or does that cause too much ripple?
  > 
  > Hmm, I think we can rename it. Any idea? isActivated? :-)
- https://github.com/humhub/humhub/pull/6550#issuecomment-1831571901 (@luke-)
  > > Otherwise, I'd use a more specific term, e.g. `isFriendshipEnabled()` (I'd not use "active" as the functionality may be "active" and still no one uses them, so there is no "active" friendship. "enabled" or "available" would reflect the potentiality.
  > 
  > For now I would prefer `isFriendshipEnabled()`. The `friendship` module is quite special. It's a core module, always activated, but can be disabled via Admin Settings.
- https://github.com/humhub/humhub/pull/6550#issuecomment-1832191248
  > > @luke-
  > > There are also a few places, where the term `enabled` or `isEnabled` is used
  > > 
  > > * `\humhub\modules\file\models\FileHistory::isEnabled()` refers to the functionality, not the module (should be fine)
  > >   👍
  > 
  > > * `\humhub\modules\marketplace\Module::isEnabled()` connected to
  > > * `\humhub\modules\marketplace\Module::$enabled` which is set to false if `Yii::$app->params['humhub']['apiEnabled']` is not `true`, and could also be disable through configuration
  > 
  > TBD
  > 
  > > * `\humhub\modules\content\components\ContentContainerModuleManager::isEnabled($id)` checks if module `$id` is enabled on the container
  > 
  > Is ok or?
  > 
  > > So the there is some potential for confusion between
  > > 
  > > * `\humhub\modules\marketplace\Module::isEnabled()`, which refers to a configured state, and it's inherited
  > > * `\humhub\components\Module::getIsEnabled()`, which refers to the module enabled state (but which is always true for a core module like the marketplace.
  > > 
  > > Would it make sense to also rename `\humhub\modules\marketplace\Module::isEnabled()` into `\humhub\modules\marketplace\Module::getIsEnabled()`, overriding the `\humhub\components\Module::getIsEnabled()`? In a way it seems to have a similar meaning. Or does that increase the confusion?
  > > Alternatively, we could obviously leave it, as it is, or rename it to `\humhub\components\Module::isMarketplaceEnabled()`, analogous to the friendship module.
  > 
  > Hmm, I would prefer to introduce `\humhub\modules\marketplace\Module::isMarketplaceEnabled()` analgour to the new `\humhub\modules\friendship\Module::isFriendshipEnabled()`. What do you think @yurabakhtin ?
  > 
  > For `Module::isFriendshipEnabled()` we need to do some refactorings in the `calendar`, `cfiles`, `content-bookmarks`, `mail` , `task`.


