### PR TITLE
Allow sending a notification to originator when sending to a single u…

### DIFF
--- a/CHANGELOG-DEV.md
+++ b/CHANGELOG-DEV.md
@@ -37,3 +37,4 @@ HumHub Changelog
 - Enh #6609: Monthly email summary
 - Fix #6721: Top menu entries for spaces are not highlighted when clicked
 - Fix #6725: Allow theme without second topbar menu
+- Fix #6752: Allow sending a notification to originator when sending to a single user and suppressSendToOriginator is false

--- a/protected/humhub/modules/notification/components/BaseNotification.php
+++ b/protected/humhub/modules/notification/components/BaseNotification.php
@@ -156,11 +156,11 @@ abstract class BaseNotification extends SocialActivity
             $date = null;
         }
 
-        if(!empty($this->record->payload)) {
+        if (!empty($this->record->payload)) {
             $this->payload = Json::decode($this->record->payload);
         }
 
-        if($this->hasContent()) {
+        if ($this->hasContent()) {
             $url = Url::to(['/notification/entry', 'id' => $this->record->id, 'cId' => $this->getContent()->id], true);
             $relativeUrl = Url::to(['/notification/entry', 'id' => $this->record->id, 'cId' => $this->getContent()->id], false);
         } else {
@@ -223,7 +223,7 @@ abstract class BaseNotification extends SocialActivity
             throw new InvalidConfigException('No moduleId given for "' . get_class($this) . '"');
         }
 
-        if ($this->isOriginator($user)) {
+        if ($this->suppressSendToOriginator && $this->isOriginator($user)) {
             return;
         }
 
@@ -241,8 +241,8 @@ abstract class BaseNotification extends SocialActivity
     /**
      * Returns a non html encoded mail subject which will be used in the notification e-mail
      *
-     * @see \humhub\modules\notification\targets\MailTarget
      * @return string the subject
+     * @see \humhub\modules\notification\targets\MailTarget
      */
     public function getMailSubject()
     {
@@ -383,9 +383,9 @@ abstract class BaseNotification extends SocialActivity
     /**
      * Set additional data
      *
-     * @since 1.11
      * @param $payload
      * @return $this
+     * @since 1.11
      */
     public function payload($payload)
     {
@@ -583,9 +583,9 @@ abstract class BaseNotification extends SocialActivity
     /**
      * This method is invoked right before a mail will be send for this notificatoin
      *
-     * @see \humhub\modules\notification\targets\MailTarget
      * @param \yii\mail\MessageInterface $message
      * @return boolean when true the mail will be send
+     * @see \humhub\modules\notification\targets\MailTarget
      */
     public function beforeMailSend(MessageInterface $message)
     {


### PR DESCRIPTION
Allow sending a notification to originator when sending to a single user and suppressSendToOriginator is false

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included
- [x] Changelog was modified

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
