### PR TITLE
Fix #6766: Since Humhub 1.15.1, getting content polymorphic relation …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ HumHub Changelog
 - Enh #6734: Trim Base URL on save
 - Fix #6708: Fix displaying of alert when RichText is changed on refresh a page
 - Fix #6747: Fix loading of default container permissions from cache
+- Fix #6766: Since Humhub 1.15.1, getting content polymorphic relation changes the content object_model to the wrong class
 
 1.15.1 (December 13, 2023)
 -------------------------

--- a/protected/humhub/components/behaviors/PolymorphicRelation.php
+++ b/protected/humhub/components/behaviors/PolymorphicRelation.php
@@ -101,8 +101,8 @@ class PolymorphicRelation extends Behavior
             $this->cached = $object;
 
             if ($object instanceof ActiveRecord) {
-                $class = get_class($object);
-                if ($cached === null || get_class($cached) !== $class) {
+                $class = self::getObjectModel($object);
+                if ($cached === null || self::getObjectModel($cached) !== $class) {
                     $this->owner->setAttribute($this->classAttribute, $class);
                 }
 

--- a/protected/humhub/modules/comment/widgets/Comments.php
+++ b/protected/humhub/modules/comment/widgets/Comments.php
@@ -2,10 +2,11 @@
 
 namespace humhub\modules\comment\widgets;
 
+use humhub\components\behaviors\PolymorphicRelation;
+use humhub\components\Widget;
 use humhub\modules\comment\models\Comment as CommentModel;
 use humhub\modules\comment\Module;
 use humhub\modules\content\components\ContentActiveRecord;
-use humhub\components\Widget;
 use humhub\modules\content\widgets\stream\StreamEntryOptions;
 use humhub\modules\content\widgets\stream\WallStreamEntryOptions;
 use Yii;
@@ -62,7 +63,7 @@ class Comments extends Widget
      */
     public function run()
     {
-        $objectModel = get_class($this->object);
+        $objectModel = PolymorphicRelation::getObjectModel($this->object);
         $objectId = $this->object->getPrimaryKey();
 
         $streamQuery = Yii::$app->request->getQueryParam('StreamQuery');

--- a/protected/humhub/modules/comment/widgets/Form.php
+++ b/protected/humhub/modules/comment/widgets/Form.php
@@ -8,9 +8,10 @@
 
 namespace humhub\modules\comment\widgets;
 
+use humhub\components\behaviors\PolymorphicRelation;
 use humhub\components\Widget;
-use humhub\modules\comment\Module;
 use humhub\modules\comment\models\Comment as CommentModel;
+use humhub\modules\comment\Module;
 use humhub\modules\content\components\ContentActiveRecord;
 use humhub\modules\file\handler\FileHandlerCollection;
 use Yii;
@@ -81,7 +82,7 @@ class Form extends Widget
         }
 
         return $this->render('form', [
-            'objectModel' => get_class($this->object),
+            'objectModel' => PolymorphicRelation::getObjectModel($this->object),
             'objectId' => $this->object->getPrimaryKey(),
             'id' => $this->object->getUniqueId(),
             'model' => $this->model,

--- a/protected/humhub/modules/comment/widgets/ShowMore.php
+++ b/protected/humhub/modules/comment/widgets/ShowMore.php
@@ -2,6 +2,7 @@
 
 namespace humhub\modules\comment\widgets;
 
+use humhub\components\behaviors\PolymorphicRelation;
 use humhub\modules\comment\models\Comment;
 use Yii;
 use yii\base\Widget;
@@ -57,7 +58,7 @@ class ShowMore extends Widget
         return $this->render('showMore', [
             'text' => $this->getText(),
             'showMoreUrl' => Url::to(['/comment/comment/show',
-                'objectModel' => get_class($this->object),
+                'objectModel' => PolymorphicRelation::getObjectModel($this->object),
                 'objectId' => $this->object->getPrimaryKey(),
                 'pageSize' => $this->pageSize,
                 'commentId' => $this->commentId,

--- a/protected/humhub/modules/content/components/ContentAddonController.php
+++ b/protected/humhub/modules/content/components/ContentAddonController.php
@@ -8,11 +8,12 @@
 
 namespace humhub\modules\content\components;
 
-use Yii;
+use humhub\components\behaviors\PolymorphicRelation;
 use humhub\components\Controller;
-use yii\web\HttpException;
-use yii\base\Exception;
 use humhub\libs\Helpers;
+use Yii;
+use yii\base\Exception;
+use yii\web\HttpException;
 
 
 /**
@@ -73,12 +74,12 @@ class ContentAddonController extends Controller
     {
 
         $modelClass = Yii::$app->request->get('contentModel');
-        $pk = (int) Yii::$app->request->get('contentId');
+        $pk = (int)Yii::$app->request->get('contentId');
 
         // Fixme
         if ($modelClass == '') {
             $modelClass = Yii::$app->request->post('contentModel');
-            $pk = (int) Yii::$app->request->post('contentId');
+            $pk = (int)Yii::$app->request->post('contentId');
         }
 
 
@@ -105,7 +106,7 @@ class ContentAddonController extends Controller
             throw new HttpException(403, 'Access denied!');
         }
 
-        $this->contentModel = get_class($target);
+        $this->contentModel = PolymorphicRelation::getObjectModel($target);
         $this->contentId = $target->getPrimaryKey();
 
         return parent::beforeAction($action);
@@ -132,7 +133,7 @@ class ContentAddonController extends Controller
             throw new HttpException(500, 'Could not find content addon record!');
         }
 
-        if ($target->object_model != get_class($this->parentContent) && $target->object_id != $this->parentContent->getPrimaryKey()) {
+        if ($target->object_model !== PolymorphicRelation::getObjectModel($this->parentContent) && $target->object_id !== $this->parentContent->getPrimaryKey()) {
             throw new HttpException(500, 'Content addon not belongs to given content record!');
         }
 

--- a/protected/humhub/modules/content/models/Content.php
+++ b/protected/humhub/modules/content/models/Content.php
@@ -12,7 +12,6 @@ use humhub\components\ActiveRecord;
 use humhub\components\behaviors\GUID;
 use humhub\components\behaviors\PolymorphicRelation;
 use humhub\components\Module;
-use humhub\modules\activity\models\Activity;
 use humhub\modules\admin\permissions\ManageUsers;
 use humhub\modules\content\components\ContentActiveRecord;
 use humhub\modules\content\components\ContentContainerActiveRecord;
@@ -28,7 +27,6 @@ use humhub\modules\content\permissions\ManageContent;
 use humhub\modules\content\services\ContentStateService;
 use humhub\modules\content\services\ContentTagService;
 use humhub\modules\notification\models\Notification;
-use humhub\modules\post\models\Post;
 use humhub\modules\search\libs\SearchHelper;
 use humhub\modules\space\models\Space;
 use humhub\modules\user\components\PermissionManager;
@@ -36,7 +34,6 @@ use humhub\modules\user\helpers\AuthHelper;
 use humhub\modules\user\models\User;
 use Yii;
 use yii\base\Exception;
-use yii\base\InvalidArgumentException;
 use yii\db\IntegrityException;
 use yii\helpers\Url;
 
@@ -261,7 +258,7 @@ class Content extends ActiveRecord implements Movable, ContentOwner, SoftDeletab
                 $model->afterStateChange($this->state, $previousState);
             }
 
-            if (!$this->getStateService()->wasPublished() && (int) $previousState === self::STATE_PUBLISHED) {
+            if (!$this->getStateService()->wasPublished() && (int)$previousState === self::STATE_PUBLISHED) {
                 $this->updateAttributes(['was_published' => 1]);
             }
         }
@@ -308,7 +305,7 @@ class Content extends ActiveRecord implements Movable, ContentOwner, SoftDeletab
                 'originator' => $this->createdBy->guid,
                 'contentContainerId' => $this->container->contentContainerRecord->id,
                 'visibility' => $this->visibility,
-                'sourceClass' => get_class($record),
+                'sourceClass' => PolymorphicRelation::getObjectModel($record),
                 'sourceId' => $record->getPrimaryKey(),
                 'silent' => $this->isMuted(),
                 'streamChannel' => $this->stream_channel,
@@ -406,7 +403,7 @@ class Content extends ActiveRecord implements Movable, ContentOwner, SoftDeletab
         }
 
         Notification::deleteAll([
-            'source_class' => get_class($this),
+            'source_class' => PolymorphicRelation::getObjectModel($this),
             'source_pk' => $this->getPrimaryKey(),
         ]);
 
@@ -984,7 +981,7 @@ class Content extends ActiveRecord implements Movable, ContentOwner, SoftDeletab
         }
 
         // Check system admin can see all content module configuration
-        if ($user->canViewAllContent(get_class($this->container))) {
+        if ($user->canViewAllContent(PolymorphicRelation::getObjectModel($this->container))) {
             return true;
         }
 

--- a/protected/humhub/modules/content/models/Content.php
+++ b/protected/humhub/modules/content/models/Content.php
@@ -981,7 +981,7 @@ class Content extends ActiveRecord implements Movable, ContentOwner, SoftDeletab
         }
 
         // Check system admin can see all content module configuration
-        if ($user->canViewAllContent(PolymorphicRelation::getObjectModel($this->container))) {
+        if ($user->canViewAllContent(get_class($this->container))) {
             return true;
         }
 

--- a/protected/humhub/modules/content/tests/codeception/functional/RichTextToEmailHtmlConverterCest.php
+++ b/protected/humhub/modules/content/tests/codeception/functional/RichTextToEmailHtmlConverterCest.php
@@ -8,6 +8,7 @@
 namespace content\functional;
 
 use content\FunctionalTester;
+use humhub\components\behaviors\PolymorphicRelation;
 use humhub\modules\comment\models\forms\CommentForm;
 use humhub\modules\file\models\File;
 use humhub\modules\post\models\Post;
@@ -78,7 +79,7 @@ class RichTextToEmailHtmlConverterCest
         $post = Post::findOne(['id' => 2]);
         $commentForm = new CommentForm($post);
         $commentForm->load([
-            'objectModel' => get_class($post),
+            'objectModel' => PolymorphicRelation::getObjectModel($post),
             'objectId' => $post->id,
             'Comment' => ['message' =>
                 'Test comment with image ![' . $file->file_name . '](file-guid:' . $file->guid . ' "' . $file->title . '") ' .

--- a/protected/humhub/modules/content/widgets/WallEntry.php
+++ b/protected/humhub/modules/content/widgets/WallEntry.php
@@ -8,7 +8,6 @@
 
 namespace humhub\modules\content\widgets;
 
-use humhub\components\behaviors\PolymorphicRelation;
 use humhub\components\Widget;
 use humhub\modules\content\components\ContentContainerController;
 use humhub\modules\content\widgets\stream\StreamEntryOptions;
@@ -217,7 +216,7 @@ class WallEntry extends Widget
     {
         $entryClass = null;
         if ($entry instanceof MenuEntry) {
-            $entryClass = PolymorphicRelation::getObjectModel($entry);
+            $entryClass = get_class($entry);
         } elseif (is_array($entry) && isset($entry[0])) {
             $entryClass = $entry[0];
         }

--- a/protected/humhub/modules/content/widgets/WallEntry.php
+++ b/protected/humhub/modules/content/widgets/WallEntry.php
@@ -8,18 +8,17 @@
 
 namespace humhub\modules\content\widgets;
 
-use humhub\modules\content\widgets\stream\StreamEntryWidget;
+use humhub\components\behaviors\PolymorphicRelation;
+use humhub\components\Widget;
+use humhub\modules\content\components\ContentContainerController;
 use humhub\modules\content\widgets\stream\StreamEntryOptions;
 use humhub\modules\dashboard\controllers\DashboardController;
-use humhub\modules\stream\actions\Stream;
+use humhub\modules\space\models\Space;
 use humhub\modules\ui\menu\DropdownDivider;
 use humhub\modules\ui\menu\MenuEntry;
-use Yii;
 use humhub\modules\user\controllers\ProfileController;
-use humhub\components\Widget;
-use humhub\modules\space\models\Space;
 use humhub\modules\user\models\User;
-use humhub\modules\content\components\ContentContainerController;
+use Yii;
 
 /**
  * WallEntry is responsible to show a content inside a stream/wall.
@@ -218,7 +217,7 @@ class WallEntry extends Widget
     {
         $entryClass = null;
         if ($entry instanceof MenuEntry) {
-            $entryClass = get_class($entry);
+            $entryClass = PolymorphicRelation::getObjectModel($entry);
         } elseif (is_array($entry) && isset($entry[0])) {
             $entryClass = $entry[0];
         }

--- a/protected/humhub/modules/file/components/FileManager.php
+++ b/protected/humhub/modules/file/components/FileManager.php
@@ -8,12 +8,13 @@
 
 namespace humhub\modules\file\components;
 
+use humhub\components\behaviors\PolymorphicRelation;
 use humhub\modules\comment\models\Comment;
 use humhub\modules\content\components\ContentActiveRecord;
+use humhub\modules\file\models\File;
 use humhub\modules\search\libs\SearchHelper;
 use Yii;
 use yii\base\Component;
-use humhub\modules\file\models\File;
 use yii\helpers\ArrayHelper;
 
 /**
@@ -69,7 +70,7 @@ class FileManager extends Component
             }
 
             $attributes = [
-                'object_model' => get_class($this->record),
+                'object_model' => PolymorphicRelation::getObjectModel($this->record),
                 'object_id' => $this->record->getPrimaryKey(),
             ];
 
@@ -90,7 +91,7 @@ class FileManager extends Component
      */
     public function find()
     {
-        return File::find()->andWhere(['object_id' => $this->record->getPrimaryKey(), 'object_model' => get_class($this->record)]);
+        return File::find()->andWhere(['object_id' => $this->record->getPrimaryKey(), 'object_model' => PolymorphicRelation::getObjectModel($this->record)]);
     }
 
     /**

--- a/protected/humhub/modules/file/models/File.php
+++ b/protected/humhub/modules/file/models/File.php
@@ -350,7 +350,7 @@ class File extends FileCompat
      */
     public function isAssignedTo(ActiveRecord $record)
     {
-        return $this->object_model === get_class($record) && $this->object_id == $record->getPrimaryKey();
+        return $this->object_model === PolymorphicRelation::getObjectModel($record) && $this->object_id == $record->getPrimaryKey();
     }
 
     /**

--- a/protected/humhub/modules/like/widgets/LikeLink.php
+++ b/protected/humhub/modules/like/widgets/LikeLink.php
@@ -2,6 +2,7 @@
 
 namespace humhub\modules\like\widgets;
 
+use humhub\components\behaviors\PolymorphicRelation;
 use humhub\modules\content\components\ContentActiveRecord;
 use humhub\modules\like\models\Like as LikeModel;
 use humhub\modules\like\Module;
@@ -50,7 +51,7 @@ class LikeLink extends \yii\base\Widget
         $module = Yii::$app->getModule('like');
         $canLike = $module->canLike($this->object);
 
-        $likes = LikeModel::GetLikes(get_class($this->object), $this->object->id);
+        $likes = LikeModel::GetLikes(PolymorphicRelation::getObjectModel($this->object), $this->object->id);
         foreach ($likes as $like) {
             if ($like->user->id == Yii::$app->user->id) {
                 $currentUserLiked = true;
@@ -58,15 +59,15 @@ class LikeLink extends \yii\base\Widget
         }
 
         return $this->render('likeLink', [
-                    'canLike' => $canLike,
-                    'object' => $this->object,
-                    'likes' => $likes,
-                    'currentUserLiked' => $currentUserLiked,
-                    'id' => $this->object->getUniqueId(),
-                    'likeUrl' => Url::to(['/like/like/like', 'contentModel' => get_class($this->object), 'contentId' => $this->object->id]),
-                    'unlikeUrl' => Url::to(['/like/like/unlike', 'contentModel' => get_class($this->object), 'contentId' => $this->object->id]),
-                    'userListUrl' => Url::to(['/like/like/user-list', 'contentModel' => get_class($this->object), 'contentId' => $this->object->getPrimaryKey()]),
-                    'title' => $this->generateLikeTitleText($currentUserLiked, $likes)
+            'canLike' => $canLike,
+            'object' => $this->object,
+            'likes' => $likes,
+            'currentUserLiked' => $currentUserLiked,
+            'id' => $this->object->getUniqueId(),
+            'likeUrl' => Url::to(['/like/like/like', 'contentModel' => PolymorphicRelation::getObjectModel($this->object), 'contentId' => $this->object->id]),
+            'unlikeUrl' => Url::to(['/like/like/unlike', 'contentModel' => PolymorphicRelation::getObjectModel($this->object), 'contentId' => $this->object->id]),
+            'userListUrl' => Url::to(['/like/like/user-list', 'contentModel' => PolymorphicRelation::getObjectModel($this->object), 'contentId' => $this->object->getPrimaryKey()]),
+            'title' => $this->generateLikeTitleText($currentUserLiked, $likes)
         ]);
     }
 
@@ -84,7 +85,7 @@ class LikeLink extends \yii\base\Widget
                 return Yii::t('LikeModule.base', 'You like this.');
             } else {
                 // output, if more users like this
-                $userlist .= Yii::t('LikeModule.base', 'You'). "\n";
+                $userlist .= Yii::t('LikeModule.base', 'You') . "\n";
                 $previewUserCount++;
             }
         }
@@ -102,7 +103,7 @@ class LikeLink extends \yii\base\Widget
                 // check, if you liked
                 if ($likes[$i]->user->guid != Yii::$app->user->guid) {
                     // output, if an other user liked
-                    $userlist .= Html::encode($likes[$i]->user->displayName). "\n";
+                    $userlist .= Html::encode($likes[$i]->user->displayName) . "\n";
                     $previewUserCount++;
                 }
 

--- a/protected/humhub/modules/search/libs/SearchHelper.php
+++ b/protected/humhub/modules/search/libs/SearchHelper.php
@@ -8,6 +8,7 @@
 
 namespace humhub\modules\search\libs;
 
+use humhub\components\behaviors\PolymorphicRelation;
 use humhub\modules\search\interfaces\Searchable;
 use humhub\modules\search\jobs\DeleteDocument;
 use humhub\modules\search\jobs\UpdateDocument;
@@ -54,7 +55,7 @@ class SearchHelper extends BaseObject
             $pk = $record->getPrimaryKey();
             if (!empty($pk) && !is_array($pk)) {
                 Yii::$app->queue->push(new UpdateDocument([
-                    'activeRecordClass' => get_class($record),
+                    'activeRecordClass' => PolymorphicRelation::getObjectModel($record),
                     'primaryKey' => $pk
                 ]));
                 return true;
@@ -75,7 +76,7 @@ class SearchHelper extends BaseObject
             $pk = $record->getPrimaryKey();
             if (!empty($pk) && !is_array($pk)) {
                 Yii::$app->queue->push(new DeleteDocument([
-                    'activeRecordClass' => get_class($record),
+                    'activeRecordClass' => PolymorphicRelation::getObjectModel($record),
                     'primaryKey' => $pk
                 ]));
                 return true;

--- a/protected/humhub/modules/user/behaviors/Followable.php
+++ b/protected/humhub/modules/user/behaviors/Followable.php
@@ -8,7 +8,6 @@
 
 namespace humhub\modules\user\behaviors;
 
-use humhub\components\behaviors\PolymorphicRelation;
 use humhub\modules\content\components\ContentContainerActiveRecord;
 use humhub\modules\space\models\Space;
 use humhub\modules\user\components\ActiveQueryUser;
@@ -47,7 +46,7 @@ class Followable extends Behavior
         return Yii::$app->runtimeCache->getOrSet(__METHOD__ . $userId, function () use ($userId) {
             return Follow::find()
                 ->where([
-                    'object_model' => PolymorphicRelation::getObjectModel($this->owner),
+                    'object_model' => get_class($this->owner),
                     'object_id' => $this->owner->getPrimaryKey(),
                     'user_id' => $userId
                 ])->one();
@@ -162,7 +161,7 @@ class Followable extends Behavior
     {
         return User::find()
             ->leftJoin('user_follow', 'user.id = user_follow.user_id AND user_follow.object_id=:object_id AND user_follow.object_model = :object_model', [
-                ':object_model' => PolymorphicRelation::getObjectModel($this->owner),
+                ':object_model' => get_class($this->owner),
                 ':object_id' => $this->owner->getPrimaryKey(),
             ])
             ->where('user_follow.user_id IS NOT null')
@@ -192,7 +191,7 @@ class Followable extends Behavior
     public function getFollowingQuery($query)
     {
         $query->leftJoin('user_follow', 'user.id=user_follow.object_id AND user_follow.object_model=:object_model',
-            ['object_model' => PolymorphicRelation::getObjectModel($this->owner)]);
+            ['object_model' => get_class($this->owner)]);
         $query->andWhere(['user_follow.user_id' => $this->owner->id]);
         return $query;
     }

--- a/protected/humhub/modules/user/behaviors/Followable.php
+++ b/protected/humhub/modules/user/behaviors/Followable.php
@@ -8,6 +8,7 @@
 
 namespace humhub\modules\user\behaviors;
 
+use humhub\components\behaviors\PolymorphicRelation;
 use humhub\modules\content\components\ContentContainerActiveRecord;
 use humhub\modules\space\models\Space;
 use humhub\modules\user\components\ActiveQueryUser;
@@ -43,10 +44,10 @@ class Followable extends Behavior
     public function getFollowRecord($userId)
     {
         $userId = ($userId instanceof User) ? $userId->id : $userId;
-        return Yii::$app->runtimeCache->getOrSet(__METHOD__ . $userId, function() use ($userId) {
+        return Yii::$app->runtimeCache->getOrSet(__METHOD__ . $userId, function () use ($userId) {
             return Follow::find()
                 ->where([
-                    'object_model' => get_class($this->owner),
+                    'object_model' => PolymorphicRelation::getObjectModel($this->owner),
                     'object_id' => $this->owner->getPrimaryKey(),
                     'user_id' => $userId
                 ])->one();
@@ -161,7 +162,7 @@ class Followable extends Behavior
     {
         return User::find()
             ->leftJoin('user_follow', 'user.id = user_follow.user_id AND user_follow.object_id=:object_id AND user_follow.object_model = :object_model', [
-                ':object_model' => get_class($this->owner),
+                ':object_model' => PolymorphicRelation::getObjectModel($this->owner),
                 ':object_id' => $this->owner->getPrimaryKey(),
             ])
             ->where('user_follow.user_id IS NOT null')
@@ -191,7 +192,7 @@ class Followable extends Behavior
     public function getFollowingQuery($query)
     {
         $query->leftJoin('user_follow', 'user.id=user_follow.object_id AND user_follow.object_model=:object_model',
-            ['object_model' => get_class($this->owner)]);
+            ['object_model' => PolymorphicRelation::getObjectModel($this->owner)]);
         $query->andWhere(['user_follow.user_id' => $this->owner->id]);
         return $query;
     }


### PR DESCRIPTION
Fix #6766: Since Humhub 1.15.1, getting content polymorphic relation changes the content object_model to the wrong class

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [x] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included
- [x] Changelog was modified

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Issue https://github.com/humhub/humhub/issues/6766