### PR TITLE
Fix MultiSelect when empty selection is given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 HumHub Changelog
 ================
 
-1.15.2 (December 19, 2023)
+1.15.3 (unreleased)
+--------------------------
+- Fix #6768 MultiSelect when empty selection is given
+
+- 1.15.2 (December 19, 2023)
 --------------------------
 - Fix #6753: Non-unique key used for permission caching
 - Fix #6741: Fix no pretty url of password recovery link

--- a/MIGRATE-DEV.md
+++ b/MIGRATE-DEV.md
@@ -4,6 +4,12 @@ Module Migration Guide
 See [humhub/documentation::docs/develop/modules-migrate.md](https://github.com/humhub/documentation/blob/master/docs/develop/modules-migrate.md)
 for full version.
 
+Version 1.15.3
+-------------------------
+
+### Bugfix with potential side-effect
+- `\humhub\modules\ui\form\widgets\BasePicker` and `\humhub\modules\ui\form\widgets\MultiSelect` do now treat and empty array for the field `BasePicker::$selection` as a valid selection list and will not attempt to get the list from the model in that case.
+
 Version 1.15
 -------------------------
 

--- a/protected/humhub/modules/ui/form/widgets/BasePicker.php
+++ b/protected/humhub/modules/ui/form/widgets/BasePicker.php
@@ -238,7 +238,7 @@ abstract class BasePicker extends JsInputWidget
      */
     public function run()
     {
-        if ($this->selection != null && !is_array($this->selection)) {
+        if ($this->selection !== null && !is_array($this->selection)) {
             $this->selection = [$this->selection];
         }
 
@@ -280,7 +280,7 @@ abstract class BasePicker extends JsInputWidget
      */
     protected function getSelectedOptions()
     {
-        if (!$this->selection && $this->model != null) {
+        if ($this->selection === null && $this->model !== null) {
             $attribute = $this->attribute;
             if (strrpos($attribute, '[') !== false) {
                 $this->selection = $this->loadItems(Html::getAttributeValue($this->model, $attribute));
@@ -288,7 +288,6 @@ abstract class BasePicker extends JsInputWidget
                 $this->selection = $this->loadItems($this->model->$attribute);
             }
         }
-
 
         if (!$this->selection) {
             $this->selection = [];

--- a/protected/humhub/modules/ui/form/widgets/MultiSelect.php
+++ b/protected/humhub/modules/ui/form/widgets/MultiSelect.php
@@ -8,6 +8,8 @@
 
 namespace humhub\modules\ui\form\widgets;
 
+use yii\helpers\ArrayHelper;
+
 /**
  * Multiselect
  *
@@ -51,7 +53,7 @@ class MultiSelect extends BasePicker
 
     protected function getSelectedOptions()
     {
-        if (empty($this->selection)) {
+        if ($this->selection === null) {
             $attribute = $this->attribute;
             $this->selection = ($this->model) ? $this->model->$attribute : [];
         }
@@ -66,7 +68,7 @@ class MultiSelect extends BasePicker
                 continue;
             }
 
-            $result[$key] = $this->buildItemOption([$key => $value], in_array($key, $this->selection));
+            $result[$key] = $this->buildItemOption([$key => $value], ArrayHelper::keyExists($key, $this->selection));
         }
         return $result;
     }


### PR DESCRIPTION

Currently, the `BasePicker` and the `MultiSelect` widgets try to get the value from the module, if `$config['selection']` is `empty` (which includes an empty array!).

To avoid such a lookup by the widget, one would expect to provide an empty array (which may actually constitute the current selection). However, this will be ignored due to the above.

This PR does treat an empty array as a valid selection list. Thus, avoiding looking up the value.

Additionally, if the field value is an `ArrayAccess` instance, rather than an `array`, the current code fails with a fatal error. Using `ArrayHelper::keyExists()` rather than `in_array()` solves this issue.

## PR Admin
### What kind of change does this PR introduce?

- Bugfix

### Does this PR introduce a breaking change?

- Maybe Yes
- Probably No

If yes, please describe the impact and migration path for existing applications:

Not sure if there are use cases, where and empty array has been provided as `selection` and was expected to be replaced by the attribute value of the model or some other source. To me this would not make sense. Because if you expect the `selection` to be filled by the field/widget, then why would you provide an empty array, rather then just leaving the config alone?

That's why I currently filed the PR against `master`.

### The PR fulfills these requirements

- [ ] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] All tests [tests](#issuecomment-new) are passing
- [ ] New/updated tests are included
- [x] Changelog was modified

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
