### PR TITLE
Fix #6774: When enableMailSummaries is false in the configuration fil…

### DIFF
--- a/CHANGELOG-DEV.md
+++ b/CHANGELOG-DEV.md
@@ -40,3 +40,4 @@ HumHub Changelog
 - Fix #6725: Allow theme without second topbar menu
 - Fix #6752: Allow sending a notification to originator when sending to a single user and suppressSendToOriginator is false
 - Enh #131: Online Indicator- People Cards, Members Snippet, My Profile
+- Fix #6774: When enableMailSummaries is false in the configuration file, prevent accessing the "E-Mail Summaries" page in the account settings

--- a/protected/humhub/modules/activity/controllers/UserController.php
+++ b/protected/humhub/modules/activity/controllers/UserController.php
@@ -8,9 +8,11 @@
 
 namespace humhub\modules\activity\controllers;
 
-use Yii;
-use humhub\modules\user\components\BaseAccountController;
 use humhub\modules\activity\models\MailSummaryForm;
+use humhub\modules\activity\Module;
+use humhub\modules\user\components\BaseAccountController;
+use Yii;
+use yii\web\NotFoundHttpException;
 
 /**
  * UserController allows users to modify the E-Mail summary settings.
@@ -21,8 +23,18 @@ use humhub\modules\activity\models\MailSummaryForm;
 class UserController extends BaseAccountController
 {
 
+    /**
+     * @return string
+     * @throws NotFoundHttpException
+     */
     public function actionIndex()
     {
+        /** @var Module $module */
+        $module = Yii::$app->getModule('activity');
+        if (!$module->enableMailSummaries) {
+            throw new NotFoundHttpException('Mail summaries are not enabled.');
+        }
+
         $model = new MailSummaryForm();
         $model->user = $this->getUser();
         $model->loadCurrent();


### PR DESCRIPTION
Fix #6774: When enableMailSummaries is false in the configuration file, prevent accessing the "E-Mail Summaries" page in the account settings

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [x] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included
- [x] Changelog was modified

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Issue https://github.com/humhub/humhub/issues/6774