### PR TITLE
Allow access to pending registrations to non system admins

### DIFF
--- a/CHANGELOG-DEV.md
+++ b/CHANGELOG-DEV.md
@@ -41,3 +41,4 @@ HumHub Changelog
 - Fix #6752: Allow sending a notification to originator when sending to a single user and suppressSendToOriginator is false
 - Enh #131: Online Indicator- People Cards, Members Snippet, My Profile
 - Fix #6774: When enableMailSummaries is false in the configuration file, prevent accessing the "E-Mail Summaries" page in the account settings
+- Fix #6777: Allow access to pending registrations to non-system admins

--- a/protected/humhub/modules/admin/controllers/PendingRegistrationsController.php
+++ b/protected/humhub/modules/admin/controllers/PendingRegistrationsController.php
@@ -19,6 +19,10 @@ use yii\web\HttpException;
 
 class PendingRegistrationsController extends Controller
 {
+    /**
+     * @inheritdoc
+     */
+    public $adminOnly = false;
 
     /**
      * @inheritDoc


### PR DESCRIPTION
- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included
- [x] Changelog was modified

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Users admin and pending approvals already are allowed for non sys admins.
And access rules are defined for ManageUsers or ManageGroups, so no need to restrict to only sys admins.