### PR TITLE
SpaceModelMembership::removeMember() should return bool

### DIFF
--- a/CHANGELOG-DEV.md
+++ b/CHANGELOG-DEV.md
@@ -50,4 +50,4 @@ HumHub Changelog
 - Enh #6788: Allow to disable login/registration form via configuration file
 - Enh #6788: Allow new user registration of specified SSO providers via configuration file
 - Fix #6790: Fix marketplace searching
-- Fix: `SpaceModelMembership::removeMember()` should always return a boolean value (returns void if success)
+- Fix #6811: `SpaceModelMembership::removeMember()` should always return a boolean value (returns void if success)

--- a/CHANGELOG-DEV.md
+++ b/CHANGELOG-DEV.md
@@ -48,5 +48,6 @@ HumHub Changelog
 - Enh #6783: Lowercase user email before save
 - Enh #6786: Improve password hashing
 - Enh #6788: Allow to disable login/registration form via configuration file
-- Enh #6788: Allow new user registration of specified SSO providers via configuration file 
+- Enh #6788: Allow new user registration of specified SSO providers via configuration file
 - Fix #6790: Fix marketplace searching
+- Fix: `SpaceModelMembership::removeMember()` should always return a boolean value (returns void if success)

--- a/protected/humhub/modules/space/behaviors/SpaceModelMembership.php
+++ b/protected/humhub/modules/space/behaviors/SpaceModelMembership.php
@@ -396,12 +396,13 @@ class SpaceModelMembership extends Behavior
      * @throws \yii\base\InvalidConfigException
      */
     public function addMember(
-        int $userId,
-        int $canLeave = 1,
-        bool $silent = false,
+        int    $userId,
+        int    $canLeave = 1,
+        bool   $silent = false,
         string $groupId = Space::USERGROUP_MEMBER,
-        bool $showAtDashboard = true
-    ): bool {
+        bool   $showAtDashboard = true
+    ): bool
+    {
         $user = User::findOne(['id' => $userId]);
         if (!$user) {
             return false;
@@ -481,14 +482,14 @@ class SpaceModelMembership extends Behavior
     /**
      * Remove Membership
      *
-     * @param integer $userId of User to Remove
+     * @param integer|null $userId of User to Remove
      * @return bool
      * @throws \yii\base\InvalidConfigException
      * @throws \Throwable
      */
-    public function removeMember($userId = '')
+    public function removeMember($userId = null)
     {
-        if ($userId == '') {
+        if (!$userId) {
             $userId = Yii::$app->user->id;
         }
 
@@ -510,6 +511,8 @@ class SpaceModelMembership extends Behavior
 
             $this->handleRemoveMembershipEvent($membership, $user);
         });
+
+        return true;
     }
 
     /**


### PR DESCRIPTION
`SpaceModelMembership::removeMember()` should always return a boolean value (returns void if success)

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included
- [x] Changelog was modified

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
