### PR TITLE
Fix notification switcher in wall stream entry context menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ HumHub Changelog
 - Fix #6813: Fix for displaying whether I follow a user
 - Fix #6126: `Session::$timeout` takes effect before configured `User::$authTimeout`
 - Fix #6795: Fix searching of disabled users in Administration
+- Fix #6834: Fix notification switcher in wall stream entry context menu
 
 1.15.2 (December 19, 2023)
 --------------------------

--- a/protected/humhub/modules/content/resources/js/humhub.content.container.js
+++ b/protected/humhub/modules/content/resources/js/humhub.content.container.js
@@ -102,8 +102,8 @@ humhub.module('content.container', function (module, require, $) {
             if (response.success) {
                 const contentId = event.$trigger.data('content-id');
 
-                $('#notification_off_' + contentId).hide();
-                $('#notification_on_' + contentId).show();
+                $('#notification_on_' + contentId).hide();
+                $('#notification_off_' + contentId).show();
             }
         });
     }
@@ -113,8 +113,8 @@ humhub.module('content.container', function (module, require, $) {
             if (response.success) {
                 const contentId = event.$trigger.data('content-id');
 
-                $('#notification_on_' + contentId).hide();
-                $('#notification_off_' + contentId).show();
+                $('#notification_off_' + contentId).hide();
+                $('#notification_on_' + contentId).show();
             }
         });
     };

--- a/protected/humhub/modules/content/widgets/views/notificationSwitchLink.php
+++ b/protected/humhub/modules/content/widgets/views/notificationSwitchLink.php
@@ -43,6 +43,7 @@ ContentContainerAsset::register($this);
             'data' => [
                 'action-click' => 'content.container.turnOnNotifications',
                 'action-url' => Url::to(['/content/content/notification-switch', 'id' => $content->id, 'switch' => 1]),
+                'content-id' => $content->id,
             ]
         ]
     ); ?>


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

**The PR fulfills these requirements:**

- [ ] All tests are passing
- [x] Changelog was modified

**Other information:**
This switcher doesn't work correctly:
![notification switcher](https://github.com/humhub/humhub/assets/6995524/889ac065-ce4c-4ba4-9ab0-001b1cff4f96)