### PR TITLE
Implement new method `getCommentUrl` for permanent comment URL

### DIFF
--- a/CHANGELOG-DEV.md
+++ b/CHANGELOG-DEV.md
@@ -70,3 +70,4 @@ HumHub Changelog
 - Enh #6707: Uninstalling modules should be done in a background job
 - Enh #25: Improve contrast of @default button color
 - Fix #6889: Issue with modal boxes when positioning an element at the bottom of the screen
+- Enh #6892: Implement new method `getCommentUrl` for comment permanent URL

--- a/protected/humhub/modules/comment/controllers/PermaController.php
+++ b/protected/humhub/modules/comment/controllers/PermaController.php
@@ -9,6 +9,7 @@ namespace humhub\modules\comment\controllers;
 
 use humhub\components\Controller;
 use humhub\modules\comment\models\Comment;
+use yii\web\BadRequestHttpException;
 use yii\web\NotFoundHttpException;
 use yii\web\Response;
 
@@ -36,15 +37,24 @@ class PermaController extends Controller
         }
 
         $content = $comment->content;
+        $record = $content->getPolymorphicRelation();
+
+        if ($record !== null && method_exists($record, 'getCommentUrl')) {
+            return $this->redirect($record->getCommentUrl($comment->id));
+        }
+
         if ($content->container !== null) {
             return $this->redirect($content->container->createUrl(null, [
                 'contentId' => $comment->content->id,
                 'commentId' => $comment->id,
             ]));
         }
-        if (method_exists($content->getPolymorphicRelation(), 'getUrl')) {
-            return $this->redirect($content->getPolymorphicRelation()->getUrl());
+
+        if ($record !== null && method_exists($record, 'getUrl')) {
+            return $this->redirect($record->getUrl());
         }
+
+        throw new BadRequestHttpException('Content has no URL for comments');
     }
 
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Feature

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] All tests are passing
- [x] Changelog was modified

**Other information:**
Issue: https://github.com/humhub/humhub-internal/issues/174