### PR TITLE
Fix #6919: Migration to revert user profile country names to Iso 3166 codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ HumHub Changelog
 - Enh #6899: Fix a missed module config file
 - Fix #6913: Fix API tests
 - Fix #6919: Fix saving of user profile country field value and enable a searching by country title
+- Fix #6919: Migration to revert user profile country names to Iso 3166 codes
 
 1.15.4 (March 20, 2024)
 -----------------------

--- a/protected/humhub/modules/user/migrations/m240419_095931_fix_user_profile_country_code.php
+++ b/protected/humhub/modules/user/migrations/m240419_095931_fix_user_profile_country_code.php
@@ -2,6 +2,7 @@
 
 use humhub\libs\Iso3166Codes;
 use humhub\modules\user\models\Profile;
+use humhub\modules\user\models\ProfileField;
 use yii\db\Expression;
 use yii\db\Migration;
 
@@ -19,6 +20,10 @@ class m240419_095931_fix_user_profile_country_code extends Migration
      */
     public function safeUp(): void
     {
+        if (!ProfileField::find()->where(['internal_name' => 'country'])->exists()) {
+            return; // don't run the migration
+        }
+
         $profiles = Profile::find()
             ->select('country')
             ->distinct('country')

--- a/protected/humhub/modules/user/migrations/m240419_095931_fix_user_profile_country_code.php
+++ b/protected/humhub/modules/user/migrations/m240419_095931_fix_user_profile_country_code.php
@@ -1,0 +1,65 @@
+<?php
+
+use humhub\libs\Iso3166Codes;
+use humhub\modules\user\models\Profile;
+use yii\db\Expression;
+use yii\db\Migration;
+
+/**
+ * Fix for https://github.com/humhub/humhub/issues/6919
+ *
+ * Class m240419_095931_fix_user_profile_country_code
+ */
+class m240419_095931_fix_user_profile_country_code extends Migration
+{
+    private ?array $translatedCountries = null;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function safeUp(): void
+    {
+        $profiles = Profile::find()
+            ->select('country')
+            ->distinct('country')
+            ->where(['NOT IN', 'country', array_keys(Iso3166Codes::$countries)])
+            ->andWhere(['IS NOT', 'country', new Expression('NULL')]);
+
+        foreach ($profiles->column() as $wrongCountryCode) {
+            Profile::updateAll(
+                ['country' => $this->getCodeByCountry($wrongCountryCode)],
+                ['country' => $wrongCountryCode]);
+        }
+    }
+
+    private function getCodeByCountry($wrongCountryCode): ?string
+    {
+        if ($this->translatedCountries === null) {
+            $this->translatedCountries = [];
+            foreach (Iso3166Codes::$countries as $code => $title) {
+                $this->translatedCountries[$code] = [];
+                foreach (Yii::$app->params['availableLanguages'] as $language => $name) {
+                    $this->translatedCountries[$code][] = Locale::getDisplayRegion('_' . $code, $language);
+                }
+            }
+        }
+
+        foreach ($this->translatedCountries as $code => $titles) {
+            if (in_array($wrongCountryCode, $titles, true)) {
+                return $code;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function safeDown()
+    {
+        echo "m240419_095931_fix_user_profile_country_code cannot be reverted.\n";
+
+        return false;
+    }
+}


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [x] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included
- [x] Changelog was modified

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

https://github.com/humhub/humhub/issues/6919