### PR TITLE
Use same order for meta searching that is used for content page searching by default

### DIFF
--- a/CHANGELOG-DEV.md
+++ b/CHANGELOG-DEV.md
@@ -12,6 +12,7 @@ HumHub Changelog
 - Fix #6954: Search out of viewport on mobile 
 - Fix #6962: People filter - Hide follower options if Following is disabled in the User module
 - Fix #6961: Fix people dropdown filter without defined keys
+- Fix #6967: Use same order for meta searching that is used for content page searching by default
 
 1.16.0-beta.2 (April 9, 2024)
 -----------------------------

--- a/protected/humhub/modules/content/search/ContentSearchProvider.php
+++ b/protected/humhub/modules/content/search/ContentSearchProvider.php
@@ -77,6 +77,7 @@ class ContentSearchProvider implements MetaSearchProviderInterface
         $resultSet = $module->getSearchDriver()->search(new SearchRequest([
             'keyword' => $this->getKeyword(),
             'pageSize' => $maxResults,
+            'orderBy' => SearchRequest::ORDER_BY_SCORE,
         ]));
 
         $results = [];

--- a/protected/humhub/modules/content/search/SearchRequest.php
+++ b/protected/humhub/modules/content/search/SearchRequest.php
@@ -42,7 +42,7 @@ class SearchRequest extends Model
 
     public $contentContainer = [];
 
-    public $orderBy = 'content.created_at';
+    public $orderBy = self::ORDER_BY_CREATION_DATE;
 
     public ?SearchQuery $searchQuery = null;
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] All tests are passing
- [x] Changelog was modified

**Other information:**
https://github.com/humhub/humhub-internal/issues/228