### PR TITLE
Register `ContentHighlightAsset` only when app is installed

### DIFF
--- a/protected/humhub/modules/content/Events.php
+++ b/protected/humhub/modules/content/Events.php
@@ -145,7 +145,9 @@ class Events extends BaseObject
 
     public static function onViewBeginBody($event)
     {
-        ContentHighlightAsset::register($event->sender);
+        if (Yii::$app->isInstalled()) {
+            ContentHighlightAsset::register($event->sender);
+        }
     }
 
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] All tests are passing
- [ ] Changelog was modified

**Other information:**
Bug produced from https://github.com/humhub/humhub/pull/6971 on run install new site:

![install-error](https://github.com/humhub/humhub/assets/6995524/e0601482-3325-4419-97fb-d1339be0631d)