### PR TITLE
When a JS file has module.initOnAjaxLoad = true, if the initOnAjaxUrl…

### DIFF
--- a/CHANGELOG-DEV.md
+++ b/CHANGELOG-DEV.md
@@ -22,6 +22,7 @@ HumHub Changelog
 - Enh #6984: In forms, change checkbox style to match other input types
 - Enh #6986: When moving a content from a container to another, prevent updating the content dates to keep the stream sort as it was
 - Enh #6992: Improve handle database connection errors
+- Fix: When a JS file has `module.initOnAjaxLoad = true;`, if the `initOnAjaxUrls` contains multiple params in the URL, the `init` function is not triggered
 
 1.16.0-beta.2 (April 9, 2024)
 -----------------------------

--- a/CHANGELOG-DEV.md
+++ b/CHANGELOG-DEV.md
@@ -22,7 +22,7 @@ HumHub Changelog
 - Enh #6984: In forms, change checkbox style to match other input types
 - Enh #6986: When moving a content from a container to another, prevent updating the content dates to keep the stream sort as it was
 - Enh #6992: Improve handle database connection errors
-- Fix: When a JS file has `module.initOnAjaxLoad = true;`, if the `initOnAjaxUrls` contains multiple params in the URL, the `init` function is not triggered
+- Fix #6552: When a JS file has `module.initOnAjaxLoad = true;`, if the `initOnAjaxUrls` contains multiple params in the URL, the `init` function is not triggered
 
 1.16.0-beta.2 (April 9, 2024)
 -----------------------------

--- a/static/js/humhub/humhub.core.js
+++ b/static/js/humhub/humhub.core.js
@@ -175,7 +175,8 @@ var humhub = humhub || (function ($) {
                         if (typeof initOnAjaxUrls === 'object') {
                             var ajaxUrl = new URL('https://domain.tld' + ajaxOptions.url);
                             // Remove all params except `r` param (in case pretty URLs are disabled)
-                            ajaxUrl.searchParams.forEach(function (value, name) {
+                            var searchParamNames = Array.from(ajaxUrl.searchParams.keys());
+                            searchParamNames.forEach(function (name) {
                                 if (name !== 'r') {
                                     ajaxUrl.searchParams.delete(name);
                                 }


### PR DESCRIPTION
…s contains multiple params in the URL, the init function is not triggered

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [x] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included
- [x] Changelog was modified

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Fix for https://github.com/humhub/humhub/pull/6563/files#diff-e58e8662213684a9f6b13971c8a8560d61b19ff2fe72fbe0b4a2abb5d82c2c08R178
Issue: https://github.com/humhub/humhub/issues/6552