### PR TITLE
Fix content search order after restoring from cache

### DIFF
--- a/CHANGELOG-DEV.md
+++ b/CHANGELOG-DEV.md
@@ -28,6 +28,7 @@ HumHub Changelog
 - Fix #7011: Fixed performance issue in `Members::getPrivilegedUserIds`
 - Enh #7010: Rich text tables: Vertical align top instead of middle
 - Enh #5310: Mobile - Zooming into pictures
+- Fix #7017: Fix content search order after restoring from cache
 
 1.16.0-beta.2 (April 9, 2024)
 -----------------------------

--- a/protected/humhub/modules/content/search/ResultSet.php
+++ b/protected/humhub/modules/content/search/ResultSet.php
@@ -10,6 +10,7 @@ namespace humhub\modules\content\search;
 
 use humhub\modules\content\models\Content;
 use yii\data\Pagination;
+use yii\db\Expression;
 
 /**
  * SearchResultSet
@@ -41,6 +42,10 @@ class ResultSet
         $this->pagination = $data['pagination'];
         $this->results = empty($data['results'])
             ? []
-            : Content::find()->where(['IN', 'id', $data['results']])->all();
+            : Content::find()
+                ->where(['IN', 'id', $data['results']])
+                // Restore an original order what was before serializing
+                ->orderBy([new Expression('FIELD(id, ' . implode(',', $data['results']) . ')')])
+                ->all();
     }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] All tests are passing
- [ ] Changelog was modified

**Other information:**
https://github.com/humhub/humhub-internal/issues/259