### PR TITLE
Enable option for non-member users of a space to create posts

### DIFF
--- a/protected/humhub/modules/post/permissions/CreatePost.php
+++ b/protected/humhub/modules/post/permissions/CreatePost.php
@@ -34,7 +34,6 @@ class CreatePost extends BasePermission
      * @inheritdoc
      */
     protected $fixedGroups = [
-        Space::USERGROUP_USER,
         Space::USERGROUP_GUEST,
         User::USERGROUP_SELF,
         User::USERGROUP_GUEST,


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included
- [ ] Changelog was modified

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

I was trying to configure my HumHub instance so that non-members could post in into Spaces without first joining the space. This is vital for the way my instance is used. As it stood, it was only possible for instance Admins to create posts in Spaces they were not members of.

The change from this PR will make it so that in a Space's permission settings the option "Create Posts" will become available to configure, and setting it to "Allow" will result in letting non-members create posts in the space. This solution was proposed by @marc-farre . Thanks, Marc!

I tested this on my development instance and it works nicely.

This shouldn't create any unexpected behaviour because the setting is by default set to "Deny".

Please see this HumHub Community post for more info: https://community.humhub.com/content/perma?id=279216

