### PR TITLE
Remove obsolete property `AbstractRichText::$record`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ HumHub Changelog
 - Fix #7197: Increased version of `PHPOffice/PHPSpreadsheet` to v2.2+
 - Enh #7167: Disable DEBUG mode automatically after successful humhub installation. Add `.env` support
 - Enh #7202: Increased minimum PHP version to 8.1
+- Enh #7211: Remove obsolete property `AbstractRichText::$record`
 
 1.16.2 (September 5, 2024)
 --------------------------

--- a/protected/humhub/modules/comment/widgets/views/comment.php
+++ b/protected/humhub/modules/comment/widgets/views/comment.php
@@ -50,7 +50,7 @@ $module = Yii::$app->getModule('comment');
         <div class="content comment_edit_content" id="comment_editarea_<?= $comment->id; ?>">
             <div id="comment-message-<?= $comment->id; ?>" class="comment-message" data-ui-markdown data-ui-show-more
                  data-read-more-text="<?= Yii::t('CommentModule.base', 'Read full comment...') ?>">
-                <?= RichText::output($comment->message, ['record' => $comment]); ?>
+                <?= RichText::output($comment->message) ?>
             </div>
             <?= ShowFiles::widget(['object' => $comment]); ?>
         </div>

--- a/protected/humhub/modules/content/widgets/richtext/AbstractRichText.php
+++ b/protected/humhub/modules/content/widgets/richtext/AbstractRichText.php
@@ -145,11 +145,6 @@ abstract class AbstractRichText extends JsWidget
     protected static $converterClass;
 
     /**
-     * @var mixed can be used to identify the related record
-     */
-    public $record;
-
-    /**
      * @var array of richtext extension classes used for preparing and post processing output and converter result
      * @since 1.8
      */

--- a/protected/humhub/modules/post/widgets/views/wallEntry.php
+++ b/protected/humhub/modules/post/widgets/views/wallEntry.php
@@ -23,6 +23,6 @@ $isDetailView = $renderOptions->isViewContext(WallStreamEntryOptions::VIEW_CONTE
             data-collapse-at="<?= $collapsedPostHeight ?>"
         <?php endif; ?>
     >
-        <?= RichText::output($post->message, ['record' => $post]) ?>
+        <?= RichText::output($post->message) ?>
     </div>
 </div>


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Refactor

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] All tests are passing
- [x] Changelog was modified

**Other information:**
https://github.com/humhub/translator/issues/52#issuecomment-2334600960