### PR TITLE
Refresh the updated_at timestamp of invitation after resend it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ HumHub Changelog
 - Fix #7222: Fix rendering of checkbox on MacOS and iOS
 - Fix #7225: Fix module JS config initialisation on AJAX request
 - Fix #7227: Fix search reindexing after create new content
+- Fix #7232: Refresh the updated_at timestamp of invitation after resend it
 
 1.16.2 (September 5, 2024)
 --------------------------

--- a/protected/humhub/modules/user/models/Invite.php
+++ b/protected/humhub/modules/user/models/Invite.php
@@ -227,6 +227,11 @@ class Invite extends ActiveRecord
             Yii::$app->setLanguage(Yii::$app->user->language);
         }
 
+        if ($result) {
+            // Refresh the updated_at timestamp
+            $this->save();
+        }
+
         return $result;
     }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

**The PR fulfills these requirements:**

- [ ] All tests are passing
- [ ] Changelog was modified

**Other information:**
https://github.com/humhub/humhub-internal/issues/390