### PR TITLE
Revert removed property `AbstractRichText::$record` from PR #7211

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,6 @@ HumHub Changelog
 - Enh #7167: Disable DEBUG mode automatically after successful humhub installation. Add `.env` support
 - Enh #7202: Increased minimum PHP version to 8.1
 - Enh #7208: Improvements in dotenv parsing
-- Enh #7211: Remove obsolete property `AbstractRichText::$record`
 - Enh #7213: By default, enabled "Mobile" notification types for those enabled for "Web"
 - Fix #7215: Wording: replace British "licence" with American "license"
 - Fix #6987: Added LatAm Spanish

--- a/protected/humhub/modules/comment/widgets/views/comment.php
+++ b/protected/humhub/modules/comment/widgets/views/comment.php
@@ -50,7 +50,7 @@ $module = Yii::$app->getModule('comment');
         <div class="content comment_edit_content" id="comment_editarea_<?= $comment->id; ?>">
             <div id="comment-message-<?= $comment->id; ?>" class="comment-message" data-ui-markdown data-ui-show-more
                  data-read-more-text="<?= Yii::t('CommentModule.base', 'Read full comment...') ?>">
-                <?= RichText::output($comment->message) ?>
+                <?= RichText::output($comment->message, ['record' => $comment]) ?>
             </div>
             <?= ShowFiles::widget(['object' => $comment]); ?>
         </div>

--- a/protected/humhub/modules/content/widgets/richtext/AbstractRichText.php
+++ b/protected/humhub/modules/content/widgets/richtext/AbstractRichText.php
@@ -145,6 +145,14 @@ abstract class AbstractRichText extends JsWidget
     protected static $converterClass;
 
     /**
+     * @var mixed can be used to identify the related record
+     * Note: This property is used by external modules:
+     *   - Legal Tools: https://github.com/humhub/legal/blob/master/Events.php#L263
+     *   - Link Preview: https://github.com/humhub/linkpreview/blob/master/widgets/Viewer.php#L44
+     */
+    public $record;
+
+    /**
      * @var array of richtext extension classes used for preparing and post processing output and converter result
      * @since 1.8
      */

--- a/protected/humhub/modules/post/widgets/views/wallEntry.php
+++ b/protected/humhub/modules/post/widgets/views/wallEntry.php
@@ -23,6 +23,6 @@ $isDetailView = $renderOptions->isViewContext(WallStreamEntryOptions::VIEW_CONTE
             data-collapse-at="<?= $collapsedPostHeight ?>"
         <?php endif; ?>
     >
-        <?= RichText::output($post->message) ?>
+        <?= RichText::output($post->message, ['record' => $post]) ?>
     </div>
 </div>


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] All tests are passing
- [ ] Changelog was modified


**Other information:**
https://github.com/humhub/humhub-internal/issues/424#issuecomment-2428754154
Revert PR https://github.com/humhub/humhub/pull/7211