### PR TITLE
Fix #7281: SelfTest for DynamicConfig broken when not exist yet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ HumHub Changelog
 1.17.0-beta.2 (Unreleased)
 --------------------------------
 - Enh #7280: Allow to add a space as default for new users from "Invite members" modal window
+- Fix #7281: SelfTest for DynamicConfig broken when not exist yet
 
 1.17.0-beta.1 (October 28, 2024)
 --------------------------------

--- a/protected/humhub/libs/SelfTest.php
+++ b/protected/humhub/libs/SelfTest.php
@@ -585,12 +585,12 @@ class SelfTest
         }
         // Check Dynamic Config is Writable
         $title = Yii::t('AdminModule.information', 'Permissions') . ' - ' . Yii::t('AdminModule.information', 'Dynamic Config');
-        $path = realpath(Yii::getAlias(Yii::$app->params['dynamicConfigFile']));
+        $path = Yii::getAlias(Yii::$app->params['dynamicConfigFile']);
         if (!is_file($path)) {
             $path = dirname($path);
         }
 
-        if (is_writeable($path)) {
+        if (is_writeable(realpath($path))) {
             $checks[] = [
                 'title' => $title,
                 'state' => 'OK',

--- a/protected/humhub/libs/SelfTest.php
+++ b/protected/humhub/libs/SelfTest.php
@@ -590,7 +590,11 @@ class SelfTest
             $path = dirname($path);
         }
 
-        if (is_writeable(realpath($path))) {
+        // Use realpath on the path alone to get the canonical path
+        // Applying realpath to a boolean (from is_writable) would cause errors, so keep them separate
+        $realPath = realpath($path);
+
+        if ($realPath !== false && is_writable($realPath)) {
             $checks[] = [
                 'title' => $title,
                 'state' => 'OK',


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included
- [ ] Changelog was modified

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
