### PR TITLE
Disable link in `TopicLabel` when contentContainer is not present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ HumHub Changelog
 - Fix #7281: SelfTest for DynamicConfig broken when not exist yet
 - Fix #7284: Content tag visibility
 - Enh #7287: Add `Template` virtual field
+- Enh #7291: Disable link in `TopicLabel` when contentContainer is not present
 
 1.17.0-beta.1 (October 28, 2024)
 --------------------------------

--- a/protected/humhub/modules/topic/widgets/TopicLabel.php
+++ b/protected/humhub/modules/topic/widgets/TopicLabel.php
@@ -23,12 +23,19 @@ class TopicLabel extends Label
      */
     public static function forTopic(Topic $topic, ?ContentContainerActiveRecord $contentContainer = null)
     {
-        $link = Link::withAction('', 'topic.addTopic')->options([
-            'data-topic-id' => $topic->id,
-            'data-topic-url' => $topic->getUrl($contentContainer ?: ContentContainerHelper::getCurrent()),
-        ]);
+        $label = static::light($topic->name)
+            ->sortOrder(20)
+            ->color($topic->color)
+            ->icon('fa-star');
 
-        return static::light($topic->name)->sortOrder(20)->color($topic->color)->withLink($link)->icon('fa-star');
+        if ($contentContainer = $contentContainer ?: ContentContainerHelper::getCurrent()) {
+            $label->withLink(Link::withAction('', 'topic.addTopic')->options([
+                'data-topic-id' => $topic->id,
+                'data-topic-url' => $topic->getUrl($contentContainer),
+            ]));
+        }
+
+        return $label;
     }
 
 }


### PR DESCRIPTION
https://github.com/humhub/humhub-internal/issues/433