### PR TITLE
HumHub ArrayHelper::flatten() not compatible Yii base ArrayHelper #51…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ HumHub Changelog
 1.17.0-beta.5 (Unreleased)
 ---------------------------------
 - Fix #7365: `DeviceDetectorHelper::isMobile()` and `DeviceDetectorHelper::isTablet()` when no user agent
+- Fix: `humhub\helpers\ArrayHelper::flatten()` not compatible Yii base ArrayHelper
 
 1.17.0-beta.4 (December 24, 2024)
 ---------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ HumHub Changelog
 1.17.0-beta.5 (Unreleased)
 ---------------------------------
 - Fix #7365: `DeviceDetectorHelper::isMobile()` and `DeviceDetectorHelper::isTablet()` when no user agent
-- Fix: `humhub\helpers\ArrayHelper::flatten()` not compatible Yii base ArrayHelper
+- Fix #7376: `humhub\helpers\ArrayHelper::flatten()` not compatible Yii base ArrayHelper
 
 1.17.0-beta.4 (December 24, 2024)
 ---------------------------------

--- a/protected/humhub/helpers/ArrayHelper.php
+++ b/protected/humhub/helpers/ArrayHelper.php
@@ -2,11 +2,9 @@
 
 namespace humhub\helpers;
 
-use function humhub\libs\array_flatten;
-
 class ArrayHelper extends \yii\helpers\ArrayHelper
 {
-    public static function flatten(array $array, string $separator = '.', string $path = ''): array
+    public static function flatten($array, $separator = '.', string $path = ''): array
     {
         $result = [];
         foreach ($array as $key => $value) {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [x] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [x] All tests are passing
- [ ] New/updated tests are included
- [x] Changelog was modified

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Issue https://github.com/humhub/humhub-internal/issues/512