### PR TITLE
Fix: Always allow admins to edit/delete content in the other Profile stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ HumHub Changelog
 - Fix #7395: Fix profile stream for guests
 - Fix #7400: Fixed `Default user profile visibility` field visibility in the user settings
 - Fix #7404: Marketplace - Allow symlinked `@app/modules` directory
+- Fix: Always allow admins to edit/delete content in the other Profile stream
 
 1.17.0 (January 13, 2025)
 -------------------------

--- a/MIGRATE-DEV.md
+++ b/MIGRATE-DEV.md
@@ -9,6 +9,7 @@ Version 1.17 (Unreleased)
 
 - Forms in modal box no longer have focus automatically on the first field. [The `autofocus` attribute](https://developer.mozilla.org/docs/Web/HTML/Global_attributes/autofocus) is now required on the field. More info: [#7136](https://github.com/humhub/humhub/issues/7136)
 - The new "Manage All Content" Group Permission allows managing all content (view, edit, move, archive, pin, etc.) even if the user is not a super administrator. It is disabled by default. It can be enabled via the configuration file, using the `\humhub\modules\admin\Module::$enableManageAllContentPermission` option.
+- System admins are allowed, in all cases (even when `enableManageAllContentPermission` is disabled), to edit and delete content in other Profile streams.
 - Users allowed to "Manage Users" can no longer move all content: they need to be allowed to "Manage All Content".
 
 ### New

--- a/protected/humhub/modules/content/models/Content.php
+++ b/protected/humhub/modules/content/models/Content.php
@@ -915,8 +915,17 @@ class Content extends ActiveRecord implements Movable, ContentOwner, Archiveable
             $user = User::findOne(['id' => $user]);
         }
 
-        // Only owner can edit his content
+        // Owner can edit his content
         if ($user !== null && $this->created_by === $user->id) {
+            return true;
+        }
+
+        // System Admins can edit User content for moderation purposes
+        if (
+            $this->id // The content exists
+            && $this->container instanceof User
+            && $user->isSystemAdmin()
+        ) {
             return true;
         }
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [x] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [x] All tests are passing
- [ ] New/updated tests are included
- [x] Changelog was modified

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Issue https://github.com/humhub/humhub-internal/issues/523

This PR allows system admins, in all cases (even when `enableManageAllContentPermission` is disabled), to edit and delete content in other Profile streams (User container).
But the view behaviour remains identical (by default, if not a friend, admins don't see User's private content).