### PR TITLE
BS5 - Installer not working when `assets/` dir is empty

### DIFF
--- a/protected/humhub/modules/admin/models/forms/DesignSettingsForm.php
+++ b/protected/humhub/modules/admin/models/forms/DesignSettingsForm.php
@@ -8,6 +8,7 @@
 
 namespace humhub\modules\admin\models\forms;
 
+use humhub\components\InstallationState;
 use humhub\components\Theme;
 use humhub\helpers\ThemeHelper;
 use humhub\libs\LogoImage;
@@ -63,6 +64,11 @@ class DesignSettingsForm extends Model
     public function init()
     {
         parent::init();
+
+        // Do not try to load settings if the installation is not completed yet
+        if (!Yii::$app->installationState->hasState(InstallationState::STATE_INSTALLED)) {
+            return;
+        }
 
         $settingsManager = Yii::$app->settings;
         $themeVariables = Yii::$app->view->theme->variables;


### PR DESCRIPTION
@marc-farre If the Assets Directory is empty and the theme is compiled before installation (without Settings DB), the following error occurs.

Is my fix okay?

<img width="1379" height="1078" alt="image" src="https://github.com/user-attachments/assets/643023cd-11d3-4a52-9567-2486f4ecc59b" />
