### PR TITLE
Fix wording of button to enable space/user module

### DIFF
--- a/protected/humhub/modules/content/widgets/ContainerModuleActionButtons.php
+++ b/protected/humhub/modules/content/widgets/ContainerModuleActionButtons.php
@@ -34,23 +34,19 @@ class ContainerModuleActionButtons extends Widget
      */
     public function init()
     {
-        if ($this->module->getContentContainerConfigUrl($this->contentContainer)
-            && $this->contentContainer->moduleManager->isEnabled($this->module->id)) {
+        $isEnabled = $this->contentContainer->moduleManager->isEnabled($this->module->id);
+
+        if ($this->module->getContentContainerConfigUrl($this->contentContainer) && $isEnabled) {
             $this->buttons[] = Button::asLink(Yii::t('ContentModule.base', 'Configure'), $this->module->getContentContainerConfigUrl($this->contentContainer))
                 ->cssClass('btn btn-sm btn-accent configure-module-' . $this->module->id);
         }
 
         if ($this->contentContainer->moduleManager->canDisable($this->module->id)) {
             $this->buttons[] = Button::accent(Yii::t('ContentModule.base', 'Enabled'))
-                ->link('#')
                 ->sm()
                 ->icon('check')
-                ->cssClass('active disable disable-module-' . $this->module->id)
-                ->style($this->contentContainer->moduleManager->isEnabled($this->module->id) ? '' : 'display:none')
-                ->action(
-                    'content.container.disableModule',
-                    $this->getDisableUrl(),
-                )
+                ->cssClass('active disable disable-module-' . $this->module->id . ($isEnabled ? '' : ' d-none'))
+                ->action('content.container.disableModule', $this->getDisableUrl())
                 ->options(['data-reload' => '1'])
                 ->confirm(
                     Yii::t('AdminModule.modules', 'Disable Module'),
@@ -59,15 +55,10 @@ class ContainerModuleActionButtons extends Widget
                 );
         }
 
-        $this->buttons[] = Button::accent(Yii::t('ContentModule.base', 'Enabled'))
-            ->link('#')
+        $this->buttons[] = Button::accent(Yii::t('ContentModule.base', 'Enable'))
             ->sm()
-            ->cssClass('enable enable-module-' . $this->module->id)
-            ->style($this->contentContainer->moduleManager->isEnabled($this->module->id) ? 'display:none' : '')
-            ->action(
-                'content.container.enableModule',
-                $this->getEnableUrl(),
-            )
+            ->cssClass('enable enable-module-' . $this->module->id . ($isEnabled ? ' d-none' : ''))
+            ->action('content.container.enableModule', $this->getEnableUrl())
             ->options(['data-reload' => '1']);
 
         parent::init();


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] All tests are passing
- [ ] Changelog was modified

**Other information:**
[Here](https://github.com/humhub/humhub/pull/7653/commits/be7554778fda7db40817510c30287ce11b2a6f0b#diff-18119da3e09f6c9a15c33ef3749fd6786f52d79dee611765459f0a390794b36bR62) the button "Enable" was changed to "Enabled" by mistake:
<img width="792" height="276" alt="space-module-enable" src="https://github.com/user-attachments/assets/0eb70df0-e1de-4cfd-99f3-9965787869c1" />