### PR TITLE
Add dropdown-toggle-no-caret class

### DIFF
--- a/MIGRATE-BS5.md
+++ b/MIGRATE-BS5.md
@@ -299,6 +299,8 @@ Now:
 </li>
 ```
 
+To remove the right caret, add the `dropdown-toggle-no-caret` class to the button: `dropdown-toggle dropdown-toggle-no-caret`.
+
 #### Javascript
 
 The jQuery `.dropdown()` method is removed. Use BS5 vanilla JS API instead. Example for a close button:

--- a/static/scss/_nav.scss
+++ b/static/scss/_nav.scss
@@ -193,6 +193,12 @@ ul.tab-menu-settings {
     }
 }
 
+.dropdown-toggle.dropdown-toggle-no-caret {
+    &::after {
+        display: none;
+    }
+}
+
 // Nav-Tabs
 .nav-tabs {
     margin-bottom: 10px;


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included
- [ ] Changelog was modified

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Before this PR:
<img width="1669" height="107" alt="image" src="https://github.com/user-attachments/assets/f777553e-32d4-4e76-b5f2-06cab4761d63" />

Thanks to this PR, we can remove the dropdown right caret using the `dropdown-toggle-no-caret` class:
<img width="1644" height="119" alt="image" src="https://github.com/user-attachments/assets/ef67c793-2fde-404a-bd06-72f9b5bbf9b2" />

Without this PR, the only way to remove the caret is by using CSS, which is quite painful, because there are many locations where we want to hide it.