### PR TITLE
Fix: Bootstrap 3 compatible SCSS overwrites unwanted values such as M…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ HumHub Changelog
 ----------------------------------
 - Enh #7719: Make Add/Remove Group Member optional for group managers
 - Fix #7720: Saving the new Mobile App admin form when no whitelisted domain
+- Fix: Bootstrap 3 compatible SCSS overwrites unwanted values such as Markdown h1 font size
 
 1.18.0-beta.4 (September 19, 2025)
 ----------------------------------

--- a/static/scss/build.scss
+++ b/static/scss/build.scss
@@ -2,6 +2,12 @@
 @import "mixins";
 @import "root";
 
+// TODO: Remove this when Bootstrap 3 is no longer supported
+$prev-bootstrap3: false !default;
+@if not $prev-bootstrap3 {
+    @import "bootstrap3";
+}
+
 // Import base components. Components can be deactivated by $prev-* variables.
 $prev-base: false !default;
 @if not $prev-base {
@@ -216,11 +222,4 @@ $prev-search: false !default;
 $prev-select2: false !default;
 @if not $prev-select2 {
     @import "select2";
-}
-
-// TODO: Remove this when Bootstrap 3 is no longer supported
-// TODO: When converted to SCSS, move it to `mixins/deprecate` and wrap it in `$include deprecate("The `old-mixin()` mixin") { ... }`
-$prev-bootstrap3: false !default;
-@if not $prev-bootstrap3 {
-    @import "bootstrap3";
 }


### PR DESCRIPTION
…arkdown h1 font size

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included
- [ ] Changelog was modified

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Now, BS3 compatible SCSS is loaded before other SCSS files, instead of after.

Before this PR in a wiki page:

<img width="148" height="219" alt="image" src="https://github.com/user-attachments/assets/9421dd95-7460-465b-81bf-d06811564fa7" />

After this PR:

<img width="116" height="217" alt="image" src="https://github.com/user-attachments/assets/ac6ebbb9-0983-4510-a7b6-b28960fd0803" />