### PR TITLE
Fix theme migration on install new site

### DIFF
--- a/protected/humhub/migrations/m250405_072758_1_18_switch_to_humhub_theme_and_disable_themes.php
+++ b/protected/humhub/migrations/m250405_072758_1_18_switch_to_humhub_theme_and_disable_themes.php
@@ -124,7 +124,7 @@ class m250405_072758_1_18_switch_to_humhub_theme_and_disable_themes extends Migr
     private function currentThemeIsVariantOf(string $theme): bool
     {
         $currentThemePath = Yii::$app->settings->get('theme');
-        if (str_ends_with($currentThemePath, $theme)) {
+        if ($currentThemePath && str_ends_with($currentThemePath, $theme)) {
             return true;
         }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] All tests are passing
- [ ] Changelog was modified

**Other information:**
Fix the error on install new site when no theme in system yet:
<img width="1330" height="414" alt="install-migration-theme" src="https://github.com/user-attachments/assets/e87a4f09-cd70-474a-9990-ab02345dbc7d" />