### PR TITLE
Fix for PHP 8.4

### DIFF
--- a/protected/humhub/widgets/bootstrap/BootstrapVariationsTrait.php
+++ b/protected/humhub/widgets/bootstrap/BootstrapVariationsTrait.php
@@ -50,52 +50,52 @@ trait BootstrapVariationsTrait
         return self::light($text);
     }
 
-    public static function primary(string $label = null): static
+    public static function primary(?string $label = null): static
     {
         return static::instance($label, 'primary');
     }
 
-    public static function secondary(string $label = null): static
+    public static function secondary(?string $label = null): static
     {
         return static::instance($label, 'secondary');
     }
 
-    public static function info(string $label = null): static
+    public static function info(?string $label = null): static
     {
         return static::instance($label, 'info');
     }
 
-    public static function accent(string $label = null): static
+    public static function accent(?string $label = null): static
     {
         return static::instance($label, 'accent');
     }
 
-    public static function success(string $label = null): static
+    public static function success(?string $label = null): static
     {
         return static::instance($label, 'success');
     }
 
-    public static function warning(string $label = null): static
+    public static function warning(?string $label = null): static
     {
         return static::instance($label, 'warning');
     }
 
-    public static function danger(string $label = null): static
+    public static function danger(?string $label = null): static
     {
         return static::instance($label, 'danger');
     }
 
-    public static function light(string $label = null): static
+    public static function light(?string $label = null): static
     {
         return static::instance($label, 'light');
     }
 
-    public static function dark(string $label = null): static
+    public static function dark(?string $label = null): static
     {
         return static::instance($label, 'dark');
     }
 
-    public static function none(string $label = null): static
+    public static function none(?string $label = null): static
     {
         return static::instance($label);
     }

--- a/protected/humhub/widgets/bootstrap/Button.php
+++ b/protected/humhub/widgets/bootstrap/Button.php
@@ -79,7 +79,7 @@ class Button extends \yii\bootstrap5\Button
     /**
      * @deprecated since 1.18 use [[\humhub\widgets\bootstrap\Link::to()]] instead
      */
-    public static function asLink(string $label = null, $href = '#'): static
+    public static function asLink(?string $label = null, $href = '#'): static
     {
         $button = self::instance($label)
             ->loader(false)
@@ -89,7 +89,7 @@ class Button extends \yii\bootstrap5\Button
         return $button;
     }
 
-    public static function none(string $label = null): static
+    public static function none(?string $label = null): static
     {
         $button = self::instance($label)
             ->loader(false);
@@ -100,7 +100,7 @@ class Button extends \yii\bootstrap5\Button
     /**
      * @since 1.18
      */
-    public static function asBadge(string $label = null, ?string $color = null): static
+    public static function asBadge(?string $label = null, ?string $color = null): static
     {
         return self::none($label)
             ->cssClass(['badge', 'text-bg-' . $color]);


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] All tests are passing
- [ ] Changelog was modified

**Other information:**
I see errors on PHP 8.4.1 like:

`During class fetch: Uncaught yii\base\ErrorException: humhub\widgets\bootstrap\BootstrapVariationsTrait::light(): Implicitly marking parameter $label as nullable is deprecated`

`humhub\widgets\bootstrap\Button::asLink(): Implicitly marking parameter $label as nullable is deprecated, the explicit nullable type must be used instead`

I'd like to merge these fixes, also later I will do similar fixes for other modules which has min version 1.18.