### PR TITLE
Revert deleted Link::userPickerSelfSelect

### DIFF
--- a/MIGRATE-DEV.md
+++ b/MIGRATE-DEV.md
@@ -80,6 +80,7 @@ Replaced methods:
   - `humhub\widgets\bootstrap\Button::asLink()` => `humhub\widgets\bootstrap\Link::to()`
   - `humhub\widgets\bootstrap\ModalButton::asLink()` => `humhub\widgets\bootstrap\Link::modal()`(new since v1.19)
   - `humhub\modules\ui\menu\widgets\Menu->addItem([...])` => `humhub\modules\ui\menu\widgets\Menu->addEntry(new MenuLink([...]))`(used in module files `Events.php` as `$event->sender->addItem([...])`)
+  - `humhub\widgets\bootstrap\Link::userPickerSelfSelect()` => `humhub\modules\user\widgets\UserPickerField::selfSelect()` or use new option `UserPickerField->selfSelect`
 - Refactored `Activities`
   - Make sure Content related Activities are now extended from `BaseContentActivity`
   - `getTitle` and `getDescription` are now `static`.

--- a/protected/humhub/modules/user/widgets/UserPickerField.php
+++ b/protected/humhub/modules/user/widgets/UserPickerField.php
@@ -4,6 +4,7 @@ namespace humhub\modules\user\widgets;
 
 use humhub\modules\content\widgets\ContentContainerPickerField;
 use humhub\modules\user\models\User;
+use humhub\widgets\bootstrap\Link;
 use Yii;
 use yii\helpers\Url;
 
@@ -26,6 +27,12 @@ class UserPickerField extends ContentContainerPickerField
      * @inheritdoc
      */
     public $jsWidget = 'user.picker.UserPicker';
+
+    /**
+     * @var string|bool|null True to show a link to select the current user, String to use a custom link text
+     * @since 1.19
+     */
+    public string|bool|null $selfSelect = null;
 
     /**
      * @inheritdoc
@@ -75,5 +82,42 @@ class UserPickerField extends ContentContainerPickerField
             );
         }
         return $result;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function run()
+    {
+        return parent::run() . $this->renderSelfSelect();
+    }
+
+    /**
+     * Renders self-selector for this user picker
+     *
+     * @return string
+     * @since 1.19
+     */
+    protected function renderSelfSelect(): string
+    {
+        return $this->selfSelect === true || is_string($this->selfSelect)
+            ? static::selfSelect('#' . $this->getId(), is_string($this->selfSelect) ? $this->selfSelect : null)
+            : '';
+    }
+
+    /**
+     * Renders self-selector for a user picker
+     *
+     * @param string $selector
+     * @param string|null $label
+     * @return Link
+     * @since 1.19
+     */
+    public static function selfSelect(string $selector, ?string $label = null): Link
+    {
+        return Link::to($label ?? Yii::t('base', 'Select Me'))
+            ->action('selectSelf', null, $selector)
+            ->icon('check-circle-o')
+            ->right();
     }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [x] Feature

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] All tests are passing
- [ ] Changelog was modified

**Other information:**
Related to https://github.com/humhub/humhub-internal/issues/1042.
Here https://github.com/humhub/humhub/pull/7980/changes#diff-a0403356c9c62020087b1815a4504396d20d8ff78943c9eaffee3ac56ab324ceL118-L126 I deleted the method `Link::userPickerSelfSelect()` by mistake, but it is used by modules Tasks and Meeting.
Tasks module is fixed here https://github.com/humhub/tasks/pull/308 by using of the new option `UserPickerField->selfSelect`.