### PR TITLE
Fix linked badge icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ HumHub Changelog
 - Enh #8051: Add `AltchaCaptchaInput::$showOnFocusElement` and `YiiCaptchaInput::$showOnFocusElement` (see [migration guide](https://github.com/humhub/humhub/blob/master/MIGRATE-DEV.md#version-1181) for details)
 - Fix #8054: Login layout widths (Default: Bootstrap width, Registration: 500px, Login & Password: 300px, Login with multiple SSO buttons: 500px)
 - Enh #8044: Update package `firebase/php-jwt` to v7
+- Fix #8056: Fix linked badge icon
 
 1.18.1 (March 2, 2026)
 ----------------------

--- a/protected/humhub/widgets/bootstrap/Badge.php
+++ b/protected/humhub/widgets/bootstrap/Badge.php
@@ -123,8 +123,7 @@ class Badge extends Widget
     public function action($handler, $url = null, $target = null)
     {
         $this->link = Link::withAction($this->label, $handler, $url, $target)
-            ->encodeLabel($this->encodeLabel)
-            ->icon($this->icon);
+            ->encodeLabel($this->encodeLabel);
         return $this;
     }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

**The PR fulfills these requirements:**
- [ ] All tests are passing
- [x] Changelog was modified

**Other information:**
I removed the `->icon($this->icon)` because the module Question has the error on render the badge "BEST ANSWER" [here](https://github.com/humhub/questions/blob/master/widgets/BestAnswerButton.php#L44): `humhub\widgets\bootstrap\Button::icon(): Argument #1 ($icon) must be of type humhub\modules\ui\icon\widgets\Icon|string, null given, called in /Users/yb/Sites/hh/humhub/protected/humhub/widgets/bootstrap/Badge.php on line 127`

It is related to [this change](https://github.com/humhub/humhub/commit/bd06ab4c75f6c65295ee3e1ce3643437e8f9d10a#diff-d3881698349664a6332f7d1d9864fc0cfb6e76aa7017c4a3d7f455281a0c1949L125-L129). But I don't think we need to prepend icon to the link label because the icon is already rendered in the method `run()` [here](https://github.com/humhub/humhub/blob/master/protected/humhub/widgets/bootstrap/Badge.php#L57-L59).

Currently the "BEST ANSWER" badge doesn't have any icon, it is why we have the error there, but if I try to add some icon to the badge with this new PR change it looks correctly:
<img width="720" height="253" alt="best-icon" src="https://github.com/user-attachments/assets/8c23a60a-62a9-4432-8d1c-f1ca2ae144b0" />

but if we keep previous code(before the PR https://github.com/humhub/humhub/pull/8039) like:

```php
public function action($handler, $url = null, $target = null)
{
    $this->link = Link::withAction($this->label, $handler, $url, $target)
        ->encodeLabel($this->encodeLabel);
    if ($this->icon) {
        $this->link->icon($this->icon);
    }
    return $this;
}
```

then the icon is rendered twice:
<img width="1279" height="347" alt="best-icon-twice" src="https://github.com/user-attachments/assets/232144ae-64cd-40a6-8283-ba27eda84fbd" />
it is why I decided to remove the line completely.