### PR TITLE
Fix button link with icon only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ HumHub Changelog
 - Fix #8031: Border Radius for Color Picker under Theme Customisation
 - Fix #8006: Web Installer Nginx Example
 - Fix #8041: Update `Button::asLink` to `Link::to`
+- Fix #8071: Fix button link with icon only
 
 1.18.1 (Unreleased)
 -------------------------

--- a/protected/humhub/widgets/bootstrap/Link.php
+++ b/protected/humhub/widgets/bootstrap/Link.php
@@ -94,4 +94,16 @@ class Link extends Button
     {
         return $this->target('_blank');
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function run(): string
+    {
+        if ($this->label === null && $this->icon !== null) {
+            $this->cssClass('link-icon-only');
+        }
+
+        return parent::run();
+    }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] All tests are passing
- [x] Changelog was modified

**Other information:**
Before:
<img width="1736" height="429" alt="link-icon-right-space" src="https://github.com/user-attachments/assets/389c4a63-fc5c-4fb0-8bca-23cf2a1941fa" />
After:
<img width="726" height="194" alt="after-fix-link-icon" src="https://github.com/user-attachments/assets/61011d22-09ad-4923-9592-90b4acf859a3" />

@marc-farre I find the style class `link-icon-only` was added [here](https://github.com/humhub/humhub/commit/977ee05e92c3e07be6462e5025be73426995046b#diff-2928d8fb18b3e93a39bd9e4830f58d3b5473fa7f85808754ce92682157ea8c23R5) only in the scss file, but it is not applied.
Do you agree this change so now button link with only icon has styles as `btn link link-icon-only btn-icon-only`, or maybe we should remove the link styles from such button link and keep only `btn btn-icon-only`?