### PR TITLE
Support video and audio tags by RichText converters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ HumHub Changelog
 - Enh #8122: Update PHPspreadsheet
 - Enh #8112: Update Mobile-Detect library to 4.10.0
 - Fix #8125: Show oEmbed warning only for supported embed URLs
+- Enh #8131: Support video and audio tags by RichText converters
 
 1.18.2 (March 22, 2026)
 -----------------------

--- a/protected/humhub/modules/content/tests/codeception/unit/widgets/RichTextHtmlConverterTest.php
+++ b/protected/humhub/modules/content/tests/codeception/unit/widgets/RichTextHtmlConverterTest.php
@@ -250,6 +250,82 @@ class RichTextHtmlConverterTest extends HumHubDbTestCase
     }
 
     /*
+     * Videos
+     */
+
+    public function testConvertVideoToHtml()
+    {
+        $this->assertConversionResult(
+            'Test ![Video title](https://www.humhub.com/static/sample.mp4 video)',
+            '<p>Test <video src="https://www.humhub.com/static/sample.mp4" title="Video title"></video></p>',
+        );
+    }
+
+    public function testConvertVideoAsLink()
+    {
+        $this->assertConversionResult(
+            'Test ![Video title](https://www.humhub.com/static/sample.mp4 video)',
+            '<p>Test <a href="https://www.humhub.com/static/sample.mp4" target="_blank" rel="nofollow noreferrer noopener">Video title</a></p>',
+            [BaseRichTextConverter::OPTION_IMAGE_AS_LINK => true],
+        );
+    }
+
+    public function testConvertVideoAsText()
+    {
+        $this->assertConversionResult(
+            'Test ![Video title](https://www.humhub.com/static/sample.mp4 video)',
+            '<p>Test Video title</p>',
+            [BaseRichTextConverter::OPTION_IMAGE_AS_LINK => true, BaseRichTextConverter::OPTION_LINK_AS_TEXT => true],
+        );
+    }
+
+    public function testConvertVideoWithAllOptions()
+    {
+        $this->assertConversionResult(
+            'Test ![Video title><](http://localhost/static/sample.mp4 video controls autoplay muted loop =320x240)',
+            '<p>Test <video class="d-block mx-auto" src="http://localhost/static/sample.mp4" width="320" height="240" title="Video title" controls autoplay muted loop></video></p>',
+        );
+    }
+
+    /*
+     * Audios
+     */
+
+    public function testConvertAudioToHtml()
+    {
+        $this->assertConversionResult(
+            'Test ![Audio title](https://www.humhub.com/static/sample.mp3 audio)',
+            '<p>Test <audio src="https://www.humhub.com/static/sample.mp3" title="Audio title"></audio></p>',
+        );
+    }
+
+    public function testConvertAudioAsLink()
+    {
+        $this->assertConversionResult(
+            'Test ![Audio title](https://www.humhub.com/static/sample.mp3 audio)',
+            '<p>Test <a href="https://www.humhub.com/static/sample.mp3" target="_blank" rel="nofollow noreferrer noopener">Audio title</a></p>',
+            [BaseRichTextConverter::OPTION_IMAGE_AS_LINK => true],
+        );
+    }
+
+    public function testConvertAudioAsText()
+    {
+        $this->assertConversionResult(
+            'Test ![Audio title](https://www.humhub.com/static/sample.mp3 audio)',
+            '<p>Test Audio title</p>',
+            [BaseRichTextConverter::OPTION_IMAGE_AS_LINK => true, BaseRichTextConverter::OPTION_LINK_AS_TEXT => true],
+        );
+    }
+
+    public function testConvertAudioWithAllOptions()
+    {
+        $this->assertConversionResult(
+            'Test ![Audio title><](http://localhost/static/sample.mp3 audio controls autoplay muted loop)',
+            '<p>Test <audio class="d-block mx-auto" src="http://localhost/static/sample.mp3" title="Audio title" controls autoplay muted loop></audio></p>',
+        );
+    }
+
+    /*
      * Emoji
      */
 

--- a/protected/humhub/modules/content/tests/codeception/unit/widgets/RichTextShortTextConverterTest.php
+++ b/protected/humhub/modules/content/tests/codeception/unit/widgets/RichTextShortTextConverterTest.php
@@ -160,14 +160,6 @@ class RichTextShortTextConverterTest extends HumHubDbTestCase
      * Images
      */
 
-    public function testConvertImageAsLink()
-    {
-        $this->assertConversionResult(
-            'Test ![Alt Text](https://www.humhub.com/static/img/logo.png)',
-            'Test [Image]',
-        );
-    }
-
     /**
      * @throws InvalidConfigException
      */
@@ -275,6 +267,46 @@ class RichTextShortTextConverterTest extends HumHubDbTestCase
         $this->assertConversionResult(
             'Test ![Scaled Image><](http://localhost/static/img/logo.png =150x)',
             'Test [Image]',
+        );
+    }
+
+    /*
+     * Videos
+     */
+
+    public function testConvertVideoToShortText()
+    {
+        $this->assertConversionResult(
+            'Test ![Video Title](https://www.humhub.com/static/sample.mp4 video)',
+            'Test [Video]',
+        );
+    }
+
+    public function testConvertVideoWithAllOptionsToShortText()
+    {
+        $this->assertConversionResult(
+            'Test ![Video Title><](https://www.humhub.com/static/sample.mp4 video controls autoplay muted loop =300x200)',
+            'Test [Video]',
+        );
+    }
+
+    /*
+     * Audios
+     */
+
+    public function testConvertAudioToShortText()
+    {
+        $this->assertConversionResult(
+            'Test ![Audio Title](https://www.humhub.com/static/sample.mp3 audio)',
+            'Test [Audio]',
+        );
+    }
+
+    public function testConvertAudioWithAllOptionsToShortText()
+    {
+        $this->assertConversionResult(
+            'Test ![Audio Title><](https://www.humhub.com/static/sample.mp3 audio controls autoplay muted loop)',
+            'Test [Audio]',
         );
     }
 

--- a/protected/humhub/modules/content/widgets/richtext/converter/BaseRichTextConverter.php
+++ b/protected/humhub/modules/content/widgets/richtext/converter/BaseRichTextConverter.php
@@ -528,7 +528,11 @@ REGEXP;
             }
         }
 
-        return '<img' . $linkBlock->renderImageAttributes() . ($this->html5 ? '>' : ' />');
+        return match($linkBlock->getType()) {
+            'video' => Html::tag('video', '', $linkBlock->getVideoAttributes()),
+            'audio' => Html::tag('audio', '', $linkBlock->getAudioAttributes()),
+            default => Html::tag('img', '', $linkBlock->getImageAttributes()),
+        };
     }
 
     /**

--- a/protected/humhub/modules/content/widgets/richtext/converter/RichTextToHtmlConverter.php
+++ b/protected/humhub/modules/content/widgets/richtext/converter/RichTextToHtmlConverter.php
@@ -38,12 +38,17 @@ class RichTextToHtmlConverter extends BaseRichTextConverter
     /**
      * @var string HtmlPurifier HTML.Allowed configuration
      */
-    public $htmlAllowed = 'h1,h2,h3,h4,h5,h6,br,b,i,strong,em,a,pre,code,img,tt,div,ins,del,sup,sub,p,ol,ul,table,thead,tbody,tfoot,blockquote,dl,dt,dd,kbd,q,samp,var,hr,li,tr,td,th,s,strike';
+    public $htmlAllowed = 'h1,h2,h3,h4,h5,h6,br,b,i,strong,em,a,pre,code,img,video,audio,tt,div,ins,del,sup,sub,p,ol,ul,table,thead,tbody,tfoot,blockquote,dl,dt,dd,kbd,q,samp,var,hr,li,tr,td,th,s,strike';
 
     /**
      * @var string HtmlPurifier HTML.AllowedAttributes configuration
      */
-    public $htmlAllowedAttributes = 'img.src,img.alt,img.title,img.width,img.height,img.class,img.style,code.class,a.rel,a.target,a.href,a.title,th.align,td.align,ol.start';
+    public $htmlAllowedAttributes = 'img.src,img.alt,img.title,img.width,img.height,img.class,img.style,'
+        . 'video.src,video.title,video.width,video.height,video.class,video.style,video.controls,video.autoplay,video.muted,video.loop,'
+        . 'audio.src,audio.title,audio.class,audio.style,audio.controls,audio.autoplay,audio.muted,audio.loop,'
+        . 'code.class,'
+        . 'a.rel,a.target,a.href,a.title,'
+        . 'th.align,td.align,ol.start';
 
     /**
      * @var bool whether the output should be purified
@@ -88,6 +93,24 @@ class RichTextToHtmlConverter extends BaseRichTextConverter
 
             $htmlDefinition->addAttribute('a', 'target', 'Text');
             $htmlDefinition->addAttribute('img', 'style', 'Text');
+            $htmlDefinition->addElement('video', 'Block', 'Optional: (source, Flow) | Flow', 'Common', [
+                'src'      => 'URI',
+                'title'    => 'Text',
+                'width'    => 'Length',
+                'height'   => 'Length',
+                'controls' => 'Bool',
+                'autoplay' => 'Bool',
+                'muted'    => 'Bool',
+                'loop'     => 'Bool',
+            ]);
+            $htmlDefinition->addElement('audio', 'Block', 'Optional: (source, Flow) | Flow', 'Common', [
+                'src'      => 'URI',
+                'title'    => 'Text',
+                'controls' => 'Bool',
+                'autoplay' => 'Bool',
+                'muted'    => 'Bool',
+                'loop'     => 'Bool',
+            ]);
         });
     }
 

--- a/protected/humhub/modules/content/widgets/richtext/converter/RichTextToHtmlConverter.php
+++ b/protected/humhub/modules/content/widgets/richtext/converter/RichTextToHtmlConverter.php
@@ -93,7 +93,7 @@ class RichTextToHtmlConverter extends BaseRichTextConverter
 
             $htmlDefinition->addAttribute('a', 'target', 'Text');
             $htmlDefinition->addAttribute('img', 'style', 'Text');
-            $htmlDefinition->addElement('video', 'Block', 'Optional: (source, Flow) | Flow', 'Common', [
+            $htmlDefinition->addElement('video', 'Inline', 'Optional: (source, Flow) | Flow', 'Common', [
                 'src'      => 'URI',
                 'title'    => 'Text',
                 'width'    => 'Length',
@@ -103,7 +103,7 @@ class RichTextToHtmlConverter extends BaseRichTextConverter
                 'muted'    => 'Bool',
                 'loop'     => 'Bool',
             ]);
-            $htmlDefinition->addElement('audio', 'Block', 'Optional: (source, Flow) | Flow', 'Common', [
+            $htmlDefinition->addElement('audio', 'Inline', 'Optional: (source, Flow) | Flow', 'Common', [
                 'src'      => 'URI',
                 'title'    => 'Text',
                 'controls' => 'Bool',

--- a/protected/humhub/modules/content/widgets/richtext/converter/RichTextToShortTextConverter.php
+++ b/protected/humhub/modules/content/widgets/richtext/converter/RichTextToShortTextConverter.php
@@ -96,7 +96,9 @@ class RichTextToShortTextConverter extends RichTextToPlainTextConverter
      */
     protected function renderImage($block)
     {
-        return Yii::t('ContentModule.richtexteditor', '[Image]') . "\n\n";
+        $pattern = '/\([^)]+?\b(video|audio)\b[^)]*?\)/i';
+        $type = preg_match($pattern, $block['orig'], $type) ? ucfirst($type[1]) : 'Image';
+        return Yii::t('ContentModule.richtexteditor', '[' . $type . ']') . "\n\n";
     }
 
     /**

--- a/protected/humhub/modules/content/widgets/richtext/extensions/link/LinkParserBlock.php
+++ b/protected/humhub/modules/content/widgets/richtext/extensions/link/LinkParserBlock.php
@@ -2,13 +2,14 @@
 
 namespace humhub\modules\content\widgets\richtext\extensions\link;
 
-use humhub\helpers\Html;
 use yii\base\Model;
 use yii\helpers\Url;
 
 /**
  * Link: <orig> = [<text>](<url> "<title>")
  * Image: <orig> = ![<text><alignment>](<url> "<title>" =<width>x<height>)
+ * Video: <orig> = ![<text><alignment>](<url> video controls autoplay muted loop =<width>x<height>)
+ * Audio: <orig> = ![<text><alignment>](<url> audio controls autoplay muted loop)
  */
 class LinkParserBlock extends Model
 {
@@ -21,6 +22,11 @@ class LinkParserBlock extends Model
     public const BLOCK_KEY_HEIGHT = 'height';
     public const BLOCK_KEY_CLASS = 'class';
     public const BLOCK_KEY_STYLE = 'style';
+    public const BLOCK_KEY_TYPE = 'type';
+    public const BLOCK_KEY_CONTROLS = 'controls';
+    public const BLOCK_KEY_AUTOPLAY = 'autoplay';
+    public const BLOCK_KEY_MUTED = 'muted';
+    public const BLOCK_KEY_LOOP = 'loop';
 
     /**
      * @var array
@@ -77,9 +83,41 @@ class LinkParserBlock extends Model
             }
         }
 
-        if ($this->hasOption(static::BLOCK_KEY_MD) && preg_match('/=(\d+)?x(\d+)?\)$/', (string) $this->block[static::BLOCK_KEY_MD], $size)) {
-            $this->setWidth($size[1] ?? null);
-            $this->setHeight($size[2] ?? null);
+        if ($this->hasOption(static::BLOCK_KEY_MD)) {
+            $origTag = (string)$this->block[static::BLOCK_KEY_MD];
+
+            if (preg_match('/\((.*?)\)/', $origTag, $options)) {
+                $options = preg_split('/\s+/', $options[1], -1, PREG_SPLIT_NO_EMPTY);
+                foreach ($options as $option) {
+                    switch ($option) {
+                        case 'video':
+                        case 'audio':
+                            $this->setType($option);
+                            break;
+                        case 'controls':
+                            $this->setControls(true);
+                            break;
+                        case 'autoplay':
+                            $this->setAutoplay(true);
+                            break;
+                        case 'muted':
+                            $this->setMuted(true);
+                            break;
+                        case 'loop':
+                            $this->setLoop(true);
+                            break;
+                    }
+                }
+            }
+
+            if (preg_match('/\([^)]+?\b(video|audio)\b[^)]*?\)/i', $origTag, $type)) {
+                $this->setType($type[1]);
+            }
+
+            if (preg_match('/=(\d+)?x(\d+)?\)$/', $origTag, $size)) {
+                $this->setWidth($size[1] ?? null);
+                $this->setHeight($size[2] ?? null);
+            }
         }
     }
 
@@ -193,6 +231,56 @@ class LinkParserBlock extends Model
         $this->block[static::BLOCK_KEY_STYLE] = array_merge($this->block[static::BLOCK_KEY_STYLE], $style);
     }
 
+    public function setType(string $type): void
+    {
+        $this->block[static::BLOCK_KEY_TYPE] = $type;
+    }
+
+    public function getType(): string
+    {
+        return $this->block[static::BLOCK_KEY_TYPE] ?? 'image';
+    }
+
+    public function setControls(bool $enabled): void
+    {
+        $this->block[static::BLOCK_KEY_CONTROLS] = $enabled;
+    }
+
+    public function getControls(): bool
+    {
+        return $this->block[static::BLOCK_KEY_CONTROLS] ?? false;
+    }
+
+    public function setAutoplay(bool $enabled): void
+    {
+        $this->block[static::BLOCK_KEY_AUTOPLAY] = $enabled;
+    }
+
+    public function getAutoplay(): bool
+    {
+        return $this->block[static::BLOCK_KEY_AUTOPLAY] ?? false;
+    }
+
+    public function setMuted(bool $enabled): void
+    {
+        $this->block[static::BLOCK_KEY_MUTED] = $enabled;
+    }
+
+    public function getMuted(): bool
+    {
+        return $this->block[static::BLOCK_KEY_MUTED] ?? false;
+    }
+
+    public function setLoop(bool $enabled): void
+    {
+        $this->block[static::BLOCK_KEY_LOOP] = $enabled;
+    }
+
+    public function getLoop(): bool
+    {
+        return $this->block[static::BLOCK_KEY_LOOP] ?? false;
+    }
+
     public function setBlock(string $text, string $url, ?string $title = null, $fileId = null)
     {
         $this->setUrl($url);
@@ -244,7 +332,7 @@ class LinkParserBlock extends Model
         return isset($this->block[$key]) && $this->block[$key] !== '' && $this->block[$key] !== [];
     }
 
-    public function renderImageAttributes(): string
+    public function getImageAttributes(): array
     {
         $attrs = [
             'src' => $this->getUrl(),
@@ -266,7 +354,42 @@ class LinkParserBlock extends Model
             $attrs['style'] = $this->getStyle();
         }
 
-        return Html::renderTagAttributes($attrs);
+        return $attrs;
+    }
+
+    public function getVideoAttributes(): array
+    {
+        $attrs = $this->getImageAttributes();
+        unset($attrs['alt']);
+
+        if ($this->hasOption(static::BLOCK_KEY_CONTROLS)) {
+            $attrs['controls'] = 'controls';
+        }
+        if ($this->hasOption(static::BLOCK_KEY_AUTOPLAY)) {
+            $attrs['autoplay'] = 'autoplay';
+        }
+        if ($this->hasOption(static::BLOCK_KEY_MUTED)) {
+            $attrs['muted'] = 'muted';
+        }
+        if ($this->hasOption(static::BLOCK_KEY_LOOP)) {
+            $attrs['loop'] = 'loop';
+        }
+
+        return $attrs;
+    }
+
+    public function getAudioAttributes(): array
+    {
+        $attrs = $this->getVideoAttributes();
+
+        if (isset($attrs['width'])) {
+            unset($attrs['width']);
+        }
+        if (isset($attrs['height'])) {
+            unset($attrs['height']);
+        }
+
+        return $attrs;
     }
 
 }

--- a/protected/humhub/modules/content/widgets/richtext/extensions/link/LinkParserBlock.php
+++ b/protected/humhub/modules/content/widgets/richtext/extensions/link/LinkParserBlock.php
@@ -360,6 +360,7 @@ class LinkParserBlock extends Model
     public function getVideoAttributes(): array
     {
         $attrs = $this->getImageAttributes();
+        $attrs['title'] = $this->getText();
         unset($attrs['alt']);
 
         if ($this->hasOption(static::BLOCK_KEY_CONTROLS)) {

--- a/static/scss/_media.scss
+++ b/static/scss/_media.scss
@@ -22,6 +22,9 @@
         max-width: 100%;
         height: auto;
     }
+    audio {
+        min-height: 30px;
+    }
 
     img {
         image-orientation: from-image;

--- a/static/scss/_stream.scss
+++ b/static/scss/_stream.scss
@@ -206,10 +206,6 @@
                     }
                 }
             }
-
-            audio, video {
-                width: 100%;
-            }
         }
 
         .wall-stream-footer {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

**The PR fulfills these requirements:**

- [ ] All tests are passing
- [ ] Changelog was modified

**Other information:**
Related to https://github.com/humhub/humhub-internal/issues/1155 to make `<audio>` tag visible and don't force a width of the `<video>` and `<audio>` tag to 100%.