### PR TITLE
Fix env-based config overrides for web/console contexts

### DIFF
--- a/protected/humhub/services/BootstrapService.php
+++ b/protected/humhub/services/BootstrapService.php
@@ -45,6 +45,10 @@ final class BootstrapService
 
     public function getConfig($mode = 'web'): array
     {
+        $appClass = $mode === 'console'
+            ? \humhub\components\console\Application::class
+            : \humhub\components\Application::class;
+
         $humhubConfig = [
             require($this->humhubPath . '/config/common.php'),
             require($this->humhubPath . '/config/' . $mode . '.php'),
@@ -52,7 +56,6 @@ final class BootstrapService
 
         $commonConfig = [
             require($this->configPath . '/common.php'),
-            require($this->configPath . '/' . $mode . '.php'),
             require($this->configPath . '/' . $mode . '.php'),
         ];
 
@@ -63,7 +66,7 @@ final class BootstrapService
             ->setHumhub(...$humhubConfig)
             ->setDynamic($dynamicConfig)
             ->setCommon(...$commonConfig)
-            ->setEnv(EnvHelper::toConfig($_ENV, \humhub\components\console\Application::class))
+            ->setEnv(EnvHelper::toConfig($_ENV, $appClass))
             ->toArray();
     }
 


### PR DESCRIPTION
## Summary

`BootstrapService::getConfig()` is called by both `runWeb()` and `runConsole()`, but the call to `EnvHelper::toConfig()` hardcoded `console\Application::class` regardless of the `\$mode` argument.

Looking at `EnvHelper::toConfig()`, that mapping decides which env-var prefixes are honoured:

| Application class | Honoured prefixes |
|---|---|
| `humhub\components\Application` (web) | `HUMHUB_CONFIG`, `HUMHUB_WEB_CONFIG` |
| `humhub\components\console\Application` (CLI) | `HUMHUB_CONFIG`, `HUMHUB_CLI_CONFIG` |

So the hardcoded console class produced two symmetrical bugs:
- **`HUMHUB_WEB_CONFIG__*` env vars were never applied** — neither in web nor CLI.
- **`HUMHUB_CLI_CONFIG__*` env vars were applied to the web application** as well as the CLI.

This was visible in the wild: setting e.g. `HUMHUB_WEB_CONFIG__COMPONENTS__REQUEST__TRUSTED_HOSTS__...` had no effect, while moving the same value to `HUMHUB_CONFIG__...` worked but also broke `./yii` (because the console Request component does not accept all web-only properties like `trustedHosts`).

Fix: map `\$mode` (`'web'`/`'console'`) to the matching Application class and pass it through.

Also removes a duplicated `require($this->configPath . '/' . \$mode . '.php')` line in `commonConfig` — harmless (same array merged twice) but clearly a copy-paste.

## Test plan

- [ ] Set `HUMHUB_WEB_CONFIG__COMPONENTS__REQUEST__TRUSTED_HOSTS__...` and confirm `Yii::\$app->request->getHostInfo()` honours `X-Forwarded-Host` on web requests.
- [ ] Confirm the same env var has no effect when invoked via `./yii`.
- [ ] Confirm `HUMHUB_CLI_CONFIG__*` continues to work in CLI and no longer leaks into web.
- [ ] Existing test suite remains green.