### PR TITLE
Resolve user_source badge title via UserSourceCollection

### DIFF
--- a/protected/humhub/modules/user/grid/DisplayNameColumn.php
+++ b/protected/humhub/modules/user/grid/DisplayNameColumn.php
@@ -9,7 +9,7 @@
 namespace humhub\modules\user\grid;
 
 use humhub\helpers\Html;
-use humhub\modules\user\authclient\Collection;
+use humhub\modules\user\source\UserSourceCollection;
 use Yii;
 
 /**
@@ -44,10 +44,10 @@ class DisplayNameColumn extends BaseColumn
 
         $badge = '';
         if ($user->user_source !== 'local' && Yii::$app->user->isAdmin()) {
-            /** @var Collection $collection */
-            $collection = Yii::$app->authClientCollection;
-            $title = $collection->hasClient($user->user_source)
-                ? $collection->getClient($user->user_source)->getTitle()
+            /** @var UserSourceCollection $collection */
+            $collection = Yii::$app->userSourceCollection;
+            $title = $collection->hasUserSource($user->user_source)
+                ? $collection->getUserSource($user->user_source)->getTitle()
                 : $user->user_source;
             $badge = '&nbsp;<span class="badge">' . Html::encode($title) . '</span>';
         }


### PR DESCRIPTION
## Summary

`DisplayNameColumn` in the admin user grid resolves the source badge label via `authClientCollection` — which only knows OAuth/SAML login providers. Pure provisioning sources (LDAP, SCIM) are registered in `userSourceCollection` and have no auth client entry, so `hasClient()` returns false and the raw `scim_<tenant>` / `ldap` source id is rendered as the badge.

`UserSourceCollection` is the post-1.19 abstraction that covers every source — login-providing or not — so the badge now picks up `ScimUserSource` / `LdapUserSource` titles too.

## Test plan

- [ ] Admin → Users with a SCIM-provisioned user shows the tenant title (e.g. *Authentik*) on the badge instead of `scim_authentik`
- [ ] Existing OAuth/SAML-provisioned users still show their authClient title
- [ ] Local users still render without a badge