### PR TITLE
Enh meta tags logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ HumHub Changelog
 
 1.19 (TBD)
 ----------
+- Enh: Do not override meta tags set by modules with proper key
+- Enh: Use property instead of name for `og:image`
 - Enh #8011: Added `AssetImage` as replacement for `ProfileImage`, `SiteIcon`, `LogoImage`, `LoginBackground`, `MailHeader`
 - Enh #8011: Added `AssetManager` FlySystem support
 - Enh #7980: Remove deprecations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@ HumHub Changelog
 
 1.19 (TBD)
 ----------
-- Enh: Do not override meta tags set by modules with proper key
-- Enh: Use property instead of name for `og:image`
+- Enh #8179: Do not override meta tags set by modules with proper key
+- Enh #8179: Use property instead of name for `og:image`
+- Fix #8179: Allow to set image URL strings in `ViewMeta::setImages()`
 - Enh #8011: Added `AssetImage` as replacement for `ProfileImage`, `SiteIcon`, `LogoImage`, `LoginBackground`, `MailHeader`
 - Enh #8011: Added `AssetManager` FlySystem support
 - Enh #7980: Remove deprecations

--- a/protected/humhub/components/ViewMeta.php
+++ b/protected/humhub/components/ViewMeta.php
@@ -218,7 +218,9 @@ class ViewMeta extends BaseObject
         }
 
         if (count($this->images) > 0) {
-            $this->view->registerMetaTag(['name' => 'og:image', 'content' => $this->images[0]]);
+            if (!isset($this->view->metaTags['og:image'])) {
+                $this->view->registerMetaTag(['property' => 'og:image', 'content' => $this->images[0]], "og:image");
+            }
         }
     }
 

--- a/protected/humhub/components/ViewMeta.php
+++ b/protected/humhub/components/ViewMeta.php
@@ -228,7 +228,7 @@ class ViewMeta extends BaseObject
         }
 
         if (count($this->images) > 0 && !isset($this->view->metaTags['og:image'])) {
-            $this->view->registerMetaTag(['property' => 'og:image', 'content' => $this->images[0]], "og:image");
+            $this->view->registerMetaTag(['property' => 'og:image', 'content' => $this->images[0]]);
         }
     }
 

--- a/protected/humhub/components/ViewMeta.php
+++ b/protected/humhub/components/ViewMeta.php
@@ -127,8 +127,12 @@ class ViewMeta extends BaseObject
     {
         $previewImage = new PreviewImage();
         foreach ($images as $image) {
-            if ($previewImage->applyFile($image)) {
-                $this->images[] = $image->getUrl();
+            if ($image instanceof File) {
+                if ($previewImage->applyFile($image)) {
+                    $this->images[] = $image->getUrl();
+                }
+            } else if (is_string($image)) {
+                $this->images[] = $image;
             }
         }
     }
@@ -191,7 +195,7 @@ class ViewMeta extends BaseObject
     {
         $this->view->registerLinkTag(['rel' => 'canonical', 'href' => $this->url]);
 
-        if (!empty($this->description)) {
+        if (!empty($this->description) && !isset($this->view->metaTags['description'])) {
             $this->view->registerMetaTag([
                 'name' => 'description',
                 'content' => str_replace("\n", '', StringHelper::truncate($this->description, 255)),
@@ -206,21 +210,25 @@ class ViewMeta extends BaseObject
      */
     private function registerOpenGraphMetaTags()
     {
-        $this->view->registerMetaTag(['property' => 'og:url', 'content' => $this->url]);
-        $this->view->registerMetaTag(['property' => 'og:site_name', 'content' => Yii::$app->name]);
-        $this->view->registerMetaTag(['property' => 'og:type', 'content' => $this->contentType]);
+        if (!isset($this->view->metaTags['og:url'])) {
+            $this->view->registerMetaTag(['property' => 'og:url', 'content' => $this->url]);
+        }
+        if (!isset($this->view->metaTags['og:site_name'])) {
+            $this->view->registerMetaTag(['property' => 'og:site_name', 'content' => Yii::$app->name]);
+        }
+        if (!isset($this->view->metaTags['og:type'])) {
+            $this->view->registerMetaTag(['property' => 'og:type', 'content' => $this->contentType]);
+        }
 
-        if (!empty($this->title)) {
+        if (!empty($this->title) && !isset($this->view->metaTags['og:title'])) {
             $this->view->registerMetaTag(['property' => 'og:title', 'content' => StringHelper::truncate($this->title, 70)]);
         }
-        if (!empty($this->description)) {
+        if (!empty($this->description) && !isset($this->view->metaTags['og:description'])) {
             $this->view->registerMetaTag(['property' => 'og:description', 'content' => StringHelper::truncate($this->description, 200)]);
         }
 
-        if (count($this->images) > 0) {
-            if (!isset($this->view->metaTags['og:image'])) {
-                $this->view->registerMetaTag(['property' => 'og:image', 'content' => $this->images[0]], "og:image");
-            }
+        if (count($this->images) > 0 && !isset($this->view->metaTags['og:image'])) {
+            $this->view->registerMetaTag(['property' => 'og:image', 'content' => $this->images[0]], "og:image");
         }
     }
 
@@ -231,19 +239,25 @@ class ViewMeta extends BaseObject
      */
     private function registerTwitterMetaTags()
     {
-        $this->view->registerMetaTag(['property' => 'twitter:url', 'content' => $this->url]);
-        $this->view->registerMetaTag(['property' => 'twitter:site', 'content' => Yii::$app->name]);
-        $this->view->registerMetaTag(['property' => 'twitter:type', 'content' => $this->contentType]);
+        if (!isset($this->view->metaTags['twitter:url'])) {
+            $this->view->registerMetaTag(['property' => 'twitter:url', 'content' => $this->url]);
+        }
+        if (!isset($this->view->metaTags['twitter:site'])) {
+            $this->view->registerMetaTag(['property' => 'twitter:site', 'content' => Yii::$app->name]);
+        }
+        if (!isset($this->view->metaTags['twitter:type'])) {
+            $this->view->registerMetaTag(['property' => 'twitter:type', 'content' => $this->contentType]);
+        }
 
-        if (!empty($this->title)) {
+        if (!empty($this->title) && !isset($this->view->metaTags['twitter:title'])) {
             $this->view->registerMetaTag(['property' => 'twitter:title', 'content' => StringHelper::truncate($this->title, 70)]);
         }
-        if (!empty($this->description)) {
+        if (!empty($this->description) && !isset($this->view->metaTags['twitter:description'])) {
             $this->view->registerMetaTag([
                 'property' => 'twitter:description',
                 'content' => StringHelper::truncate($this->description, 200)]);
         }
-        if (count($this->images) > 0) {
+        if (count($this->images) > 0 && !isset($this->view->metaTags['twitter:image'])) {
             $this->view->registerMetaTag(['name' => 'twitter:image', 'content' => $this->images[0]]);
         }
     }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included
- [x] Changelog was modified

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
This PR makes 3 changes:
## 1) og:image uses "property" instead of name
see the Open Graph Protocol at https://ogp.me/
The first example shows `<meta property="og:image" content="https://ia.media-imdb.com/images/rock.jpg" />`

So this is the official way. Before, Humhub was rendering like this: `<meta name="og:image" content="https://ia.media-imdb.com/images/rock.jpg" />`

## 2) only set meta tags if they are not already set (by a module)
`humhub\components\View` first triggers the `EVENT_END_PAGE` event, then registers meta tags. So modules have no proper way to alter the meta tags.
In this PR, I implemented the most simple solution: just check if a tag with this key has already been set.

An alternative implementation would be:
- set meta tags with a key
- set them earlier so modules can still alter them

## 3) allow modules to set image URLs
The public function `humhub\components\ViewMeta::setImages()` stated "Sets an array of File or Image URLs" but setting a string failed because the value was passed to `FilePreview::applyFile()` without checking.

The error was:
```
humhub\modules\file\converter\BaseConverter::applyFile(): Argument #1 ($file) must be of type humhub\modules\file\models\File, string given, called in /home/felix/public_html/humhub/humhub/protected/humhub/components/ViewMeta.php on line 131
```