### PR TITLE
Fix encoded HTML entities in notification mail subjects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ HumHub Changelog
 
 1.19 (TBD)
 ----------
-- Fix humhub-internal#1188: Decode HTML entities in notification mail subjects; split `RichTextToShortTextConverter` into a plain text variant and a new `RichTextToShortHtmlConverter` (HTML encoded)
+- Fix #8181: Encoded HTML entities in notification mail subjects
 - Enh #8179: Do not override meta tags set by modules with proper key
 - Enh #8179: Use property instead of name for `og:image`
 - Fix #8179: Allow to set image URL strings in `ViewMeta::setImages()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ HumHub Changelog
 
 1.19 (TBD)
 ----------
+- Fix humhub-internal#1188: Decode HTML entities in notification mail subjects; split `RichTextToShortTextConverter` into a plain text variant and a new `RichTextToShortHtmlConverter` (HTML encoded)
 - Enh #8011: Added `AssetImage` as replacement for `ProfileImage`, `SiteIcon`, `LogoImage`, `LoginBackground`, `MailHeader`
 - Enh #8011: Added `AssetManager` FlySystem support
 - Enh #7980: Remove deprecations

--- a/docs/develop/module-migrate.md
+++ b/docs/develop/module-migrate.md
@@ -6,6 +6,27 @@ Each minor release line has its own file with the breaking changes, new APIs and
 
 ## Unreleased
 
+- Split rich text short converters by output safety
+  - Added `humhub\modules\content\widgets\richtext\converter\RichTextToShortHtmlConverter`
+    producing HTML encoded short previews (with the `nl2br` option). Use this whenever
+    the result will be rendered inside an HTML view.
+  - `humhub\modules\content\widgets\richtext\converter\RichTextToShortTextConverter`
+    now returns **unencoded** plain text and no longer supports the `nl2br` option.
+    Use this for plain text contexts such as mail subjects.
+    **Modules rendering its result in HTML views must switch to
+    `RichTextToShortHtmlConverter` or wrap the output with `Html::encode()`** to
+    avoid XSS. Direct callers of `convertToShortText()` are affected in the same
+    way — use the new `convertToShortHtml()` for HTML rendering.
+  - Added `convertToShortHtml()` on `AbstractRichTextConverter` and corresponding
+    `RichText::FORMAT_SHORT_HTML` / `RichText::FORMAT_SHORT_TEXT` format constants.
+    `RichText::FORMAT_SHORTTEXT` is deprecated and aliased to `FORMAT_SHORT_HTML`
+    for backward compatibility. `RichText::preview()` internally uses `FORMAT_SHORT_HTML`.
+  - `SocialActivity::getContentPreview()` / `ContentHelper::getContentPreview()` now
+    use `RichTextToShortHtmlConverter` to keep their previous (HTML encoded) output.
+  - Mail subjects are now decoded centrally in
+    `humhub\modules\notification\targets\MailTarget::handle()` and in
+    `BaseNotification::asArray()`. Per-notification `Html::decode()` workarounds in
+    `getMailSubject()` overrides should be removed.
 - Refactored `ContentAddons`
   - Improved `humhub\modules\content\components\ContentAddonActiveRecord`, now required `content_id` attribute
     - Removed `user` relation, use `createdBy` instead.

--- a/protected/humhub/components/SocialActivity.php
+++ b/protected/humhub/components/SocialActivity.php
@@ -15,7 +15,7 @@ use humhub\modules\comment\models\Comment;
 use humhub\modules\content\components\ContentContainerActiveRecord;
 use humhub\modules\content\interfaces\ContentOwner;
 use humhub\modules\content\models\Content;
-use humhub\modules\content\widgets\richtext\converter\RichTextToShortTextConverter;
+use humhub\modules\content\widgets\richtext\converter\RichTextToShortHtmlConverter;
 use humhub\modules\space\models\Space;
 use humhub\modules\user\models\User;
 use Yii;
@@ -368,9 +368,9 @@ abstract class SocialActivity extends BaseObject implements rendering\Viewable
             $content = $this->source;
         }
 
-        return RichTextToShortTextConverter::process($content->getContentDescription(), [
-            RichTextToShortTextConverter::OPTION_MAX_LENGTH => $maxLength,
-            RichTextToShortTextConverter::OPTION_CACHE_KEY => RichTextToShortTextConverter::buildCacheKeyForContent($content),
+        return RichTextToShortHtmlConverter::process($content->getContentDescription(), [
+            RichTextToShortHtmlConverter::OPTION_MAX_LENGTH => $maxLength,
+            RichTextToShortHtmlConverter::OPTION_CACHE_KEY => RichTextToShortHtmlConverter::buildCacheKeyForContent($content),
         ]);
     }
 

--- a/protected/humhub/modules/content/helpers/ContentHelper.php
+++ b/protected/humhub/modules/content/helpers/ContentHelper.php
@@ -5,7 +5,7 @@ namespace humhub\modules\content\helpers;
 use humhub\helpers\Html;
 use humhub\modules\content\interfaces\ContentOwner;
 use humhub\modules\content\widgets\richtext\converter\RichTextToPlainTextConverter;
-use humhub\modules\content\widgets\richtext\converter\RichTextToShortTextConverter;
+use humhub\modules\content\widgets\richtext\converter\RichTextToShortHtmlConverter;
 use Yii;
 
 final class ContentHelper
@@ -42,9 +42,9 @@ final class ContentHelper
      */
     public static function getContentPreview(ContentOwner $content, int $maxLength = 60): string
     {
-        return RichTextToShortTextConverter::process($content->getContentDescription(), [
-            RichTextToShortTextConverter::OPTION_MAX_LENGTH => $maxLength,
-            RichTextToShortTextConverter::OPTION_CACHE_KEY => RichTextToShortTextConverter::buildCacheKeyForContent($content),
+        return RichTextToShortHtmlConverter::process($content->getContentDescription(), [
+            RichTextToShortHtmlConverter::OPTION_MAX_LENGTH => $maxLength,
+            RichTextToShortHtmlConverter::OPTION_CACHE_KEY => RichTextToShortHtmlConverter::buildCacheKeyForContent($content),
         ]);
     }
 

--- a/protected/humhub/modules/content/tests/codeception/unit/widgets/RichTextShortHtmlConverterTest.php
+++ b/protected/humhub/modules/content/tests/codeception/unit/widgets/RichTextShortHtmlConverterTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * @link https://www.humhub.org/
+ * @copyright Copyright (c) 2017 HumHub GmbH & Co. KG
+ * @license https://www.humhub.com/licences
+ *
+ */
+
+namespace tests\codeception\unit\modules\content\widgets;
+
+use humhub\modules\content\widgets\richtext\converter\RichTextToShortHtmlConverter;
+use humhub\modules\content\widgets\richtext\converter\RichTextToShortTextConverter;
+use humhub\modules\content\widgets\richtext\RichText;
+use tests\codeception\_support\HumHubDbTestCase;
+
+/**
+ * Tests that the dedicated short HTML converter and the deprecated
+ * FORMAT_SHORTTEXT alias both yield HTML encoded results.
+ */
+class RichTextShortHtmlConverterTest extends HumHubDbTestCase
+{
+    public function testEncodesSpecialChars()
+    {
+        $this->assertEquals(
+            'test &amp; test',
+            RichText::convert('test & test', RichText::FORMAT_SHORT_HTML),
+        );
+    }
+
+    public function testEncodesAngleBrackets()
+    {
+        $this->assertEquals(
+            'This is &lt;em&gt;bold text&lt;/em&gt;',
+            RichText::convert('This is <em>bold text</em>', RichText::FORMAT_SHORT_HTML),
+        );
+    }
+
+    public function testNl2BrOption()
+    {
+        $this->assertEquals(
+            "Test<br>\nBreak",
+            RichText::convert("Test\\\nBreak", RichText::FORMAT_SHORT_HTML, [
+                RichTextToShortTextConverter::OPTION_PRESERVE_SPACES => true,
+                RichTextToShortHtmlConverter::OPTION_NL2BR => true,
+            ]),
+        );
+    }
+
+    public function testDeprecatedFormatStillEncodes()
+    {
+        // FORMAT_SHORTTEXT is deprecated but must still produce encoded HTML for BC.
+        $this->assertEquals(
+            'test &amp; test',
+            RichText::convert('test & test', RichText::FORMAT_SHORTTEXT),
+        );
+    }
+}

--- a/protected/humhub/modules/content/tests/codeception/unit/widgets/RichTextShortPlainConverterTest.php
+++ b/protected/humhub/modules/content/tests/codeception/unit/widgets/RichTextShortPlainConverterTest.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * @link https://www.humhub.org/
+ * @copyright Copyright (c) 2017 HumHub GmbH & Co. KG
+ * @license https://www.humhub.com/licences
+ *
+ */
+
+namespace tests\codeception\unit\modules\content\widgets;
+
+use humhub\modules\content\widgets\richtext\RichText;
+use tests\codeception\_support\HumHubDbTestCase;
+
+/**
+ * Tests for the plain text variant of the short text converter
+ * ([[RichTextToShortTextConverter]] / FORMAT_SHORT_TEXT).
+ *
+ * Plain text output must not be HTML encoded.
+ */
+class RichTextShortPlainConverterTest extends HumHubDbTestCase
+{
+    public function testKeepsAmpersand()
+    {
+        $this->assertEquals(
+            'test & test',
+            RichText::convert('test & test', RichText::FORMAT_SHORT_TEXT),
+        );
+    }
+
+    public function testKeepsAngleBrackets()
+    {
+        $this->assertEquals(
+            'This is <em>bold text</em>',
+            RichText::convert('This is <em>bold text</em>', RichText::FORMAT_SHORT_TEXT),
+        );
+    }
+
+    public function testKeepsSingleQuote()
+    {
+        $this->assertEquals(
+            "test ' test",
+            RichText::convert("test ' test", RichText::FORMAT_SHORT_TEXT),
+        );
+    }
+
+    public function testConvertsImage()
+    {
+        $this->assertEquals(
+            '[Image]',
+            RichText::convert('![Alt](file-guid-image.png)', RichText::FORMAT_SHORT_TEXT),
+        );
+    }
+}

--- a/protected/humhub/modules/content/tests/codeception/unit/widgets/RichTextShortTextConverterTest.php
+++ b/protected/humhub/modules/content/tests/codeception/unit/widgets/RichTextShortTextConverterTest.php
@@ -11,6 +11,7 @@ namespace tests\codeception\unit\modules\content\widgets;
 
 use humhub\libs\EmojiMap;
 use humhub\modules\content\widgets\richtext\converter\RichTextToHtmlConverter;
+use humhub\modules\content\widgets\richtext\converter\RichTextToShortHtmlConverter;
 use humhub\modules\content\widgets\richtext\converter\RichTextToShortTextConverter;
 use humhub\modules\content\widgets\richtext\extensions\mentioning\MentioningExtension;
 use humhub\modules\content\widgets\richtext\RichText;
@@ -802,7 +803,7 @@ class RichTextShortTextConverterTest extends HumHubDbTestCase
             "Test<br>\nBreak",
             [
                 RichTextToShortTextConverter::OPTION_PRESERVE_SPACES => true,
-                RichTextToShortTextConverter::OPTION_NL2BR => true,
+                RichTextToShortHtmlConverter::OPTION_NL2BR => true,
             ],
         );
     }

--- a/protected/humhub/modules/content/widgets/richtext/AbstractRichText.php
+++ b/protected/humhub/modules/content/widgets/richtext/AbstractRichText.php
@@ -80,8 +80,23 @@ abstract class AbstractRichText extends JsWidget
     public const FORMAT_PLAINTEXT = 'plaintext';
 
     /**
+     * Short, unencoded plain text format used for example in mail subjects.
+     * @since 1.19
+     */
+    public const FORMAT_SHORT_TEXT = 'short_text';
+
+    /**
+     * Short, HTML encoded format used in previews as notifications and activities.
+     * @since 1.19
+     */
+    public const FORMAT_SHORT_HTML = 'short_html';
+
+    /**
      * Short text format used in previews as notifications and activities.
      * @since 1.8
+     * @deprecated since 1.19, use [[FORMAT_SHORT_HTML]] for encoded HTML previews or
+     *     [[FORMAT_SHORT_TEXT]] for unencoded plain text. This constant currently maps
+     *     to [[FORMAT_SHORT_HTML]] for backward compatibility.
      */
     public const FORMAT_SHORTTEXT = 'shorttext';
 
@@ -330,7 +345,8 @@ abstract class AbstractRichText extends JsWidget
             static::FORMAT_HTML => $converter->convertToHtml($content, $options),
             static::FORMAT_MARKDOWN => $converter->convertToMarkdown($content, $options),
             static::FORMAT_PLAINTEXT => $converter->convertToPlaintext($content, $options),
-            static::FORMAT_SHORTTEXT => $converter->convertToShortText($content, $options),
+            static::FORMAT_SHORT_TEXT => $converter->convertToShortText($content, $options),
+            static::FORMAT_SHORT_HTML, static::FORMAT_SHORTTEXT => $converter->convertToShortHtml($content, $options),
             default => Html::encode($converter->convertToPlaintext($content, $options)),
         };
     }
@@ -351,6 +367,6 @@ abstract class AbstractRichText extends JsWidget
         if (!empty($maxLength)) {
             $config['maxLength'] = $maxLength;
         }
-        return static::convert($text, static::FORMAT_SHORTTEXT, $config);
+        return static::convert($text, static::FORMAT_SHORT_HTML, $config);
     }
 }

--- a/protected/humhub/modules/content/widgets/richtext/AbstractRichTextConverter.php
+++ b/protected/humhub/modules/content/widgets/richtext/AbstractRichTextConverter.php
@@ -66,10 +66,11 @@ abstract class AbstractRichTextConverter extends BaseObject
     abstract public function convertToPlaintext(string $content, array $options = []): string;
 
     /**
-     * Converts the given rich-text content to html encoded short text preview. The short text should not contain any
-     * html elements.
+     * Converts the given rich-text content to an unencoded short plain text preview.
      *
-     * A proper implementation of this function is mandatory.
+     * The result is **not** HTML encoded and must not be rendered directly in HTML
+     * views without further escaping. Typical use cases are mail subjects and other
+     * plain text contexts.
      *
      * The $options array may be used to manipulate the result. This converter should support a `maxLength` option
      * in order to cut the result. This is used for example in previews of a rich text.
@@ -79,4 +80,21 @@ abstract class AbstractRichTextConverter extends BaseObject
      * @return mixed
      */
     abstract public function convertToShortText(string $content, array $options = []): string;
+
+    /**
+     * Converts the given rich-text content to an HTML encoded short preview. The short
+     * text should not contain any html elements other than `<br>` (when the `nl2br`
+     * option is enabled).
+     *
+     * A proper implementation of this function is mandatory.
+     *
+     * The $options array may be used to manipulate the result. This converter should support a `maxLength` option
+     * in order to cut the result. This is used for example in previews of a rich text.
+     *
+     * @param string $content
+     * @param array $options
+     * @return mixed
+     * @since 1.19
+     */
+    abstract public function convertToShortHtml(string $content, array $options = []): string;
 }

--- a/protected/humhub/modules/content/widgets/richtext/ProsemirrorRichTextConverter.php
+++ b/protected/humhub/modules/content/widgets/richtext/ProsemirrorRichTextConverter.php
@@ -5,6 +5,7 @@ namespace humhub\modules\content\widgets\richtext;
 use humhub\modules\content\widgets\richtext\converter\RichTextToHtmlConverter;
 use humhub\modules\content\widgets\richtext\converter\RichTextToMarkdownConverter;
 use humhub\modules\content\widgets\richtext\converter\RichTextToPlainTextConverter;
+use humhub\modules\content\widgets\richtext\converter\RichTextToShortHtmlConverter;
 use humhub\modules\content\widgets\richtext\converter\RichTextToShortTextConverter;
 
 /**
@@ -45,5 +46,13 @@ class ProsemirrorRichTextConverter extends AbstractRichTextConverter
     public function convertToShortText(string $content, array $options = []): string
     {
         return RichTextToShortTextConverter::process($content, $options);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function convertToShortHtml(string $content, array $options = []): string
+    {
+        return RichTextToShortHtmlConverter::process($content, $options);
     }
 }

--- a/protected/humhub/modules/content/widgets/richtext/converter/RichTextToShortHtmlConverter.php
+++ b/protected/humhub/modules/content/widgets/richtext/converter/RichTextToShortHtmlConverter.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace humhub\modules\content\widgets\richtext\converter;
+
+use humhub\helpers\Html;
+use humhub\modules\content\widgets\richtext\ProsemirrorRichText;
+
+/**
+ * Converts richtext content to a short, HTML encoded preview suitable for rendering
+ * inside HTML views (e.g. content previews, notification HTML).
+ *
+ * Output is always HTML encoded. With [[OPTION_NL2BR]] preserved newlines are
+ * converted to `<br>` tags.
+ *
+ * Use [[RichTextToShortTextConverter]] when an unencoded plain text result is needed
+ * (e.g. for mail subjects or other non-HTML contexts).
+ *
+ * @since 1.19
+ */
+class RichTextToShortHtmlConverter extends RichTextToShortTextConverter
+{
+    /**
+     * Option can be used in combination with [[OPTION_PRESERVE_SPACES]] in order to
+     * convert preserved newlines into `<br>` tags.
+     */
+    public const OPTION_NL2BR = 'nl2br';
+
+    /**
+     * @inheritdoc
+     */
+    public $format = ProsemirrorRichText::FORMAT_SHORT_HTML;
+
+    /**
+     * @var array
+     */
+    public static $cache = [];
+
+    /**
+     * @inheritDoc
+     */
+    protected function onAfterParse($text): string
+    {
+        $result = parent::onAfterParse($text);
+        $result = Html::encode($result);
+
+        if ($this->getOption(static::OPTION_NL2BR, false)) {
+            $result = nl2br($result, false);
+        }
+
+        return $result;
+    }
+}

--- a/protected/humhub/modules/content/widgets/richtext/converter/RichTextToShortTextConverter.php
+++ b/protected/humhub/modules/content/widgets/richtext/converter/RichTextToShortTextConverter.php
@@ -2,12 +2,20 @@
 
 namespace humhub\modules\content\widgets\richtext\converter;
 
-use humhub\helpers\Html;
 use humhub\modules\content\widgets\richtext\extensions\link\LinkParserBlock;
 use humhub\modules\content\widgets\richtext\extensions\link\RichTextLinkExtension;
 use humhub\modules\content\widgets\richtext\ProsemirrorRichText;
 use Yii;
 
+/**
+ * Converts richtext content to a short, unencoded plain text preview.
+ *
+ * The result is **not** HTML encoded and must not be rendered directly in HTML
+ * views without further escaping. Suitable for plain text contexts like mail
+ * subjects.
+ *
+ * For an HTML encoded short preview use [[RichTextToShortHtmlConverter]].
+ */
 class RichTextToShortTextConverter extends RichTextToPlainTextConverter
 {
     /**
@@ -17,14 +25,9 @@ class RichTextToShortTextConverter extends RichTextToPlainTextConverter
     public const OPTION_PRESERVE_SPACES = 'preserveNewlines';
 
     /**
-     * Option can be used in combination with OPTIONS_PRESERVE_SPACES in order to allow breaks inside the short text
-     */
-    public const OPTION_NL2BR = 'nl2br';
-
-    /**
      * @inheritdoc
      */
-    public $format = ProsemirrorRichText::FORMAT_SHORTTEXT;
+    public $format = ProsemirrorRichText::FORMAT_SHORT_TEXT;
 
     /**
      * @inheritdoc
@@ -121,13 +124,6 @@ class RichTextToShortTextConverter extends RichTextToPlainTextConverter
             $result = trim((string) preg_replace('/\s+/', ' ', $result));
         }
 
-        $result = parent::onAfterParse($result);
-        $result = Html::encode($result);
-
-        if ($this->getOption(static::OPTION_NL2BR, false)) {
-            $result = nl2br($result, false);
-        }
-
-        return $result;
+        return parent::onAfterParse($result);
     }
 }

--- a/protected/humhub/modules/notification/components/BaseNotification.php
+++ b/protected/humhub/modules/notification/components/BaseNotification.php
@@ -555,7 +555,7 @@ abstract class BaseNotification extends SocialActivity
     public function asArray(User $user)
     {
         $result = parent::asArray($user);
-        $result['mailSubject'] = $this->getMailSubject();
+        $result['mailSubject'] = Html::decode($this->getMailSubject());
         return $result;
     }
 

--- a/protected/humhub/modules/notification/targets/MailTarget.php
+++ b/protected/humhub/modules/notification/targets/MailTarget.php
@@ -9,6 +9,7 @@
 namespace humhub\modules\notification\targets;
 
 use humhub\components\InstallationState;
+use humhub\helpers\Html;
 use humhub\modules\notification\components\BaseNotification;
 use humhub\modules\user\models\User;
 use Yii;
@@ -71,7 +72,7 @@ class MailTarget extends BaseTarget
 
         $mail = Yii::$app->mailer->compose($this->view, $viewParams)
             ->setTo($recipient->email)
-            ->setSubject(str_replace("\n", " ", trim($notification->getMailSubject())));
+            ->setSubject(str_replace("\n", " ", trim(Html::decode($notification->getMailSubject()))));
         if ($replyTo = Yii::$app->settings->get('mailerSystemEmailReplyTo')) {
             $mail->setReplyTo($replyTo);
         }

--- a/protected/humhub/tests/codeception/_support/HumHubHelperTrait.php
+++ b/protected/humhub/tests/codeception/_support/HumHubHelperTrait.php
@@ -22,6 +22,7 @@ use humhub\modules\activity\models\Activity;
 use humhub\modules\content\widgets\richtext\converter\RichTextToHtmlConverter;
 use humhub\modules\content\widgets\richtext\converter\RichTextToMarkdownConverter;
 use humhub\modules\content\widgets\richtext\converter\RichTextToPlainTextConverter;
+use humhub\modules\content\widgets\richtext\converter\RichTextToShortHtmlConverter;
 use humhub\modules\content\widgets\richtext\converter\RichTextToShortTextConverter;
 use humhub\modules\notification\models\Notification;
 use PHPUnit\Framework\Constraint\LogicalNot;
@@ -67,6 +68,7 @@ trait HumHubHelperTrait
         Yii::$app->cache->flush();
         Yii::$app->runtimeCache->flush();
         RichTextToShortTextConverter::flushCache();
+        RichTextToShortHtmlConverter::flushCache();
         RichTextToHtmlConverter::flushCache();
         RichTextToPlainTextConverter::flushCache();
         RichTextToMarkdownConverter::flushCache();


### PR DESCRIPTION
## Summary

Fixes humhub/humhub-internal#1188 — notification mail subjects no longer leak HTML-encoded entities (e.g. `&amp;` instead of `&`) into the actual email subject line.

The root cause is that `getContentInfo()` (used by many `getMailSubject()` overrides) produces HTML-encoded output via `RichTextToShortTextConverter`, which was then sent verbatim to the mail subject (a plain-text field).

Rather than decoding per notification — which requires PRs against every module that overrides `getMailSubject()` — this decodes centrally in `MailTarget::handle()` and `BaseNotification::asArray()` (the latter is consumed by the mobile target).

While in there, the short text converter is split along the documented naming convention:

- `RichTextToShortTextConverter` — **unencoded plain text** (e.g. mail subjects)
- `RichTextToShortHtmlConverter` *(new)* — **HTML encoded** preview with the `nl2br` option

A new abstract method `convertToShortHtml()` and the constants `RichText::FORMAT_SHORT_HTML` / `FORMAT_SHORT_TEXT` accompany the split. `RichText::FORMAT_SHORTTEXT` is kept as a `@deprecated` alias mapped to `FORMAT_SHORT_HTML` for backward compatibility, and `RichText::preview()` now uses `FORMAT_SHORT_HTML` internally so existing callers (`NewCommentActivity`, external modules) keep their HTML-safe output.

Internal callers that need HTML-safe output (`SocialActivity::getContentPreview`, `ContentHelper::getContentPreview`) were switched to `RichTextToShortHtmlConverter` so behavior is unchanged.

### External module impact

- `humhub/custom-pages` uses the deprecated `FORMAT_SHORTTEXT` — still works via the BC alias.
- `humhub/reportcontent` uses `RichTextToShortTextConverter` directly in an HTML admin grid (`format: 'raw'`) and **must** be updated to `RichTextToShortHtmlConverter` (or `Html::encode()` the result) to avoid an admin XSS once core 1.19 ships. Companion PR will follow.

All affected behavior is documented under the `Unreleased` section of `docs/develop/module-migrate.md`.

## Test plan

- [x] Existing `RichTextShortTextConverterTest` (81 tests) still passes via the `FORMAT_SHORTTEXT` BC alias
- [x] New `RichTextShortHtmlConverterTest` covers `FORMAT_SHORT_HTML` (encoded output, `nl2br`, deprecated alias)
- [x] New `RichTextShortPlainConverterTest` covers `FORMAT_SHORT_TEXT` (unencoded output)
- [x] `RichtextPreviewTest` (8 tests) still passes — confirms `RichText::preview()` keeps HTML-safe output after switching to `FORMAT_SHORT_HTML`
- [x] Full core content-module unit suite green (526 tests)
- [ ] Manual: trigger a notification on content whose title contains `&`, `<`, `'` and confirm the email subject shows the decoded characters