### PR TITLE
Enh: Community modules Handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ HumHub Changelog
 
 1.19 (TBD)
 ----------
+- Enh: Improved community module handling in the marketplace — admins can opt in via a new "Include community modules" option to show modules contributed by the community
 - Fix #8181: Encoded HTML entities in notification mail subjects
 - Enh #8179: Do not override meta tags set by modules with proper key
 - Enh #8179: Use property instead of name for `og:image`

--- a/protected/humhub/modules/marketplace/components/OnlineModuleManager.php
+++ b/protected/humhub/modules/marketplace/components/OnlineModuleManager.php
@@ -272,6 +272,14 @@ class OnlineModuleManager extends Component
             Yii::$app->cache->set('onlineModuleManager_modules', $this->_modules, Yii::$app->settings->get('cacheExpireTime'));
         }
 
+        if (!(bool)$module->settings->get('includeCommunityModules', false)) {
+            foreach ($this->_modules as $id => $info) {
+                if (!empty($info['isCommunity']) && !Yii::$app->moduleManager->hasModule($id)) {
+                    unset($this->_modules[$id]);
+                }
+            }
+        }
+
         return $this->_modules;
     }
 

--- a/protected/humhub/modules/marketplace/controllers/BrowseController.php
+++ b/protected/humhub/modules/marketplace/controllers/BrowseController.php
@@ -112,6 +112,23 @@ class BrowseController extends Controller
         ]);
     }
 
+    /**
+     * Toggles the marketplace setting that controls whether unverified community
+     * modules are included in the marketplace listing.
+     *
+     * @since 1.19
+     */
+    public function actionToggleCommunity()
+    {
+        $this->forcePostRequest();
+
+        $value = (bool) Yii::$app->request->post('value');
+        $this->module->settings->set('includeCommunityModules', $value);
+        Yii::$app->cache->delete('marketplace-categories');
+
+        return $this->asJson(['success' => true, 'enabled' => $value]);
+    }
+
     private function getModuleService(): ModuleService
     {
         return new ModuleService(Yii::$app->request->post('moduleId'));

--- a/protected/humhub/modules/marketplace/models/forms/GeneralModuleSettingsForm.php
+++ b/protected/humhub/modules/marketplace/models/forms/GeneralModuleSettingsForm.php
@@ -30,12 +30,19 @@ class GeneralModuleSettingsForm extends Model
      */
     public $includeBetaUpdates;
 
+    /**
+     * @var bool
+     * @since 1.19
+     */
+    public $includeCommunityModules;
+
     public function init()
     {
         parent::init();
 
         $this->marketplaceModule = Yii::$app->getModule('marketplace');
         $this->includeBetaUpdates = (bool)$this->marketplaceModule->settings->get('includeBetaUpdates', false);
+        $this->includeCommunityModules = (bool)$this->marketplaceModule->settings->get('includeCommunityModules', false);
     }
 
     /**
@@ -44,7 +51,7 @@ class GeneralModuleSettingsForm extends Model
     public function rules()
     {
         return [
-            [['includeBetaUpdates'], 'boolean'],
+            [['includeBetaUpdates', 'includeCommunityModules'], 'boolean'],
         ];
     }
 
@@ -55,6 +62,7 @@ class GeneralModuleSettingsForm extends Model
     {
         return [
             'includeBetaUpdates' => Yii::t('MarketplaceModule.base', 'Allow module versions in beta status'),
+            'includeCommunityModules' => Yii::t('MarketplaceModule.base', 'Include community modules'),
         ];
     }
 
@@ -69,6 +77,8 @@ class GeneralModuleSettingsForm extends Model
 
         if ($this->marketplaceModule) {
             $this->marketplaceModule->settings->set('includeBetaUpdates', $this->includeBetaUpdates);
+            $this->marketplaceModule->settings->set('includeCommunityModules', $this->includeCommunityModules);
+            Yii::$app->cache->delete('marketplace-categories');
         }
 
         return true;

--- a/protected/humhub/modules/marketplace/resources/js/humhub.marketplace.js
+++ b/protected/humhub/modules/marketplace/resources/js/humhub.marketplace.js
@@ -137,6 +137,13 @@ humhub.module('marketplace', function (module, require, $) {
         });
     }
 
+    const buy = function (evt) {
+        const url = evt.$trigger.data('action-click-url');
+        if (url) {
+            window.open(url, '_blank', 'noopener,noreferrer');
+        }
+    }
+
     const install = function (evt) {
         const installButton = evt.$trigger;
         const moduleId = installButton.data('module-id');
@@ -173,11 +180,55 @@ humhub.module('marketplace', function (module, require, $) {
         });
     }
 
+    const toggleCommunity = function (evt) {
+        const checkbox = evt.$trigger;
+        const enabled = checkbox.is(':checked');
+        const url = checkbox.data('action-change-url');
+
+        const persistIfAjax = function () {
+            if (!url) {
+                return;
+            }
+            client.post(url, {data: {value: enabled ? 1 : 0}}).then(function () {
+                window.location.reload();
+            }).catch(function (e) {
+                module.log.error(e, true);
+                checkbox.prop('checked', !enabled);
+            });
+        };
+
+        if (!enabled) {
+            persistIfAjax();
+            return;
+        }
+
+        modal.confirm({
+            header: checkbox.data('confirm-header'),
+            body: checkbox.data('confirm-body'),
+            confirmText: checkbox.data('confirm-text'),
+            cancelText: checkbox.data('cancel-text'),
+        }).then(function (confirmed) {
+            if (confirmed) {
+                persistIfAjax();
+            } else {
+                checkbox.prop('checked', false);
+            }
+        });
+
+        const $confirmModal = $('#globalModalConfirm');
+        const $confirmBtn = $confirmModal.find('[data-modal-confirm]').prop('disabled', true).addClass('disabled');
+        $confirmModal.find('#community-risk-accepted').off('change.communityRisk').on('change.communityRisk', function () {
+            $confirmBtn.prop('disabled', !this.checked).toggleClass('disabled', !this.checked);
+        });
+    }
+
     module.export({
         update,
         updateAll,
         registerLicenceKey,
+        buy,
         install,
-        enable
+        enable,
+        toggleCommunity,
     });
 });

--- a/protected/humhub/modules/marketplace/views/browse/moduleSettings.php
+++ b/protected/humhub/modules/marketplace/views/browse/moduleSettings.php
@@ -5,11 +5,29 @@
  * @license https://www.humhub.com/licences
  */
 
+use humhub\helpers\Html;
 use humhub\modules\marketplace\models\forms\GeneralModuleSettingsForm;
 use humhub\widgets\modal\Modal;
 use humhub\widgets\modal\ModalButton;
 
 /* @var GeneralModuleSettingsForm $settings */
+
+$communityWarning = Yii::t('MarketplaceModule.base', 'Community modules are developed by third parties and are <strong>not tested or maintained by the HumHub team</strong>.<br><br>They may not be compatible with your HumHub version, can cause <strong>instability or unexpected behavior</strong>, and may stop working after future updates. Their long-term maintenance is not guaranteed.<br><br>Only enable this option if you understand the risks and trust the source of the module you intend to install.');
+$communityAck = Html::tag(
+    'div',
+    Html::checkbox('communityRiskAccepted', false, [
+        'id' => 'community-risk-accepted',
+        'class' => 'form-check-input',
+    ])
+    . ' '
+    . Html::label(
+        Yii::t('MarketplaceModule.base', 'I understand the risk and want to continue.'),
+        'community-risk-accepted',
+        ['class' => 'form-check-label'],
+    ),
+    ['class' => 'form-check mt-3'],
+);
+$communityConfirmBody = $communityWarning . $communityAck;
 ?>
 
 <?php $form = Modal::beginFormDialog([
@@ -18,5 +36,13 @@ use humhub\widgets\modal\ModalButton;
 ]) ?>
 
     <?= $form->field($settings, 'includeBetaUpdates')->checkbox() ?>
+
+    <?= $form->field($settings, 'includeCommunityModules')->checkbox([
+        'data-action-change' => 'marketplace.toggleCommunity',
+        'data-confirm-header' => Yii::t('MarketplaceModule.base', 'Include unverified community modules?'),
+        'data-confirm-body' => $communityConfirmBody,
+        'data-confirm-text' => Yii::t('MarketplaceModule.base', 'Yes, show community modules'),
+        'data-cancel-text' => Yii::t('MarketplaceModule.base', 'Cancel'),
+    ]) ?>
 
 <?php Modal::endFormDialog(); ?>

--- a/protected/humhub/modules/marketplace/views/browse/thirdpartyDisclaimer.php
+++ b/protected/humhub/modules/marketplace/views/browse/thirdpartyDisclaimer.php
@@ -20,7 +20,7 @@ use humhub\widgets\modal\ModalButton;
     </p>
 
     <p>
-        <?= Yii::t('MarketplaceModule.base', 'If this Module is additionally marked as <strong>"Community"</strong> it is neither tested nor monitored by the HumHub project team.') ?>
+        <?= Yii::t('MarketplaceModule.base', 'If this Module is additionally marked as <strong>"Unverified Community"</strong> it is neither tested nor maintained by the HumHub project team. It may cause instability or stop working after future updates.') ?>
     </p>
 
 <?php Modal::endDialog() ?>

--- a/protected/humhub/modules/marketplace/widgets/ModuleActionButtons.php
+++ b/protected/humhub/modules/marketplace/widgets/ModuleActionButtons.php
@@ -55,23 +55,51 @@ class ModuleActionButtons extends Widget
                 ->options(['target' => '_blank'])
                 ->sm()
                 ->loader(false);
-        } elseif (!empty($this->module->price_request_quote) && !$this->module->purchased) {
-            $html .= Button::primary(Yii::t('MarketplaceModule.base', 'Buy'))
-                ->link($this->module->checkoutUrl)
-                ->sm()
-                ->options(['target' => '_blank'])
-                ->loader(false);
-        } elseif (!empty($this->module->price_eur) && !$this->module->purchased) {
-            $html .= Button::primary(Yii::t('MarketplaceModule.base', 'Buy (%price%)', ['%price%' => $this->module->price_eur . '€']))
-                ->link($this->module->checkoutUrl)
-                ->sm()
-                ->options(['target' => '_blank'])
-                ->loader(false);
+        } elseif ((!empty($this->module->price_request_quote) || !empty($this->module->price_eur)) && !$this->module->purchased) {
+            $buyLabel = !empty($this->module->price_request_quote)
+                ? Yii::t('MarketplaceModule.base', 'Buy')
+                : Yii::t('MarketplaceModule.base', 'Buy (%price%)', ['%price%' => $this->module->price_eur . '€']);
+
+            if ($this->module->isCommunity) {
+                $html .= Button::primary($buyLabel)
+                    ->action('marketplace.buy', $this->module->checkoutUrl)
+                    ->confirm(
+                        Yii::t('MarketplaceModule.base', 'Buy unverified community module?'),
+                        Yii::t(
+                            'MarketplaceModule.base',
+                            'You are about to purchase <strong>{moduleName}</strong>, an unverified community module.<br><br>This module is provided by a third party and has not been reviewed or tested by the HumHub team. It may behave unexpectedly, conflict with other modules, or stop working with future HumHub releases.<br><br>Make sure you trust the source before continuing.',
+                            ['moduleName' => $this->module->name],
+                        ),
+                        Yii::t('MarketplaceModule.base', 'Continue to checkout'),
+                    )
+                    ->sm()
+                    ->loader(false);
+            } else {
+                $html .= Button::primary($buyLabel)
+                    ->link($this->module->checkoutUrl)
+                    ->sm()
+                    ->options(['target' => '_blank'])
+                    ->loader(false);
+            }
         } else {
-            $html .= Button::primary(Yii::t('MarketplaceModule.base', 'Install'))
+            $installButton = Button::primary(Yii::t('MarketplaceModule.base', 'Install'))
                 ->action('marketplace.install', ['/marketplace/browse/install'])
                 ->options(['data-module-id' => $this->module->id])
                 ->sm();
+
+            if ($this->module->isCommunity) {
+                $installButton->confirm(
+                    Yii::t('MarketplaceModule.base', 'Install unverified community module?'),
+                    Yii::t(
+                        'MarketplaceModule.base',
+                        'You are about to install <strong>{moduleName}</strong>, an unverified community module.<br><br>This module is provided by a third party and has not been reviewed or tested by the HumHub team. It may behave unexpectedly, conflict with other modules, or stop working with future HumHub releases.<br><br>Make sure you trust the source before continuing.',
+                        ['moduleName' => $this->module->name],
+                    ),
+                    Yii::t('MarketplaceModule.base', 'Install anyway'),
+                );
+            }
+
+            $html .= $installButton;
         }
 
         if (trim($html) === '') {

--- a/protected/humhub/modules/marketplace/widgets/ModuleControls.php
+++ b/protected/humhub/modules/marketplace/widgets/ModuleControls.php
@@ -55,7 +55,7 @@ class ModuleControls extends Menu
             $this->addEntry(new MenuLink([
                 'id' => 'marketplace-third-party',
                 'label' => Yii::t('MarketplaceModule.base', 'Third-party')
-                    . ($this->module->isCommunity ? ' - ' . Yii::t('MarketplaceModule.base', 'Community') : ''),
+                    . ($this->module->isCommunity ? ' - ' . Yii::t('MarketplaceModule.base', 'Unverified Community') : ''),
                 'url' => ['/marketplace/browse/thirdparty-disclaimer'],
                 'htmlOptions' => ['data-bs-target' => '#globalModal'],
                 'icon' => 'info-circle',

--- a/protected/humhub/modules/marketplace/widgets/ModuleFilters.php
+++ b/protected/humhub/modules/marketplace/widgets/ModuleFilters.php
@@ -59,6 +59,16 @@ class ModuleFilters extends DirectoryFilters
             ]);
         }
 
+        $this->addFilter('includeCommunityModules', [
+            'type' => 'info',
+            'wrapperClass' => 'w-100 form-search-filter-include-community',
+            'info' => '<div class="d-flex gap-2">'
+                . '<div style="flex: 1 1 0; min-width: 200px;"></div>'
+                . '<div style="flex: 1 1 0; min-width: 200px;">' . $this->renderIncludeCommunityCheckbox($marketplaceModule) . '</div>'
+                . '</div>',
+            'sortOrder' => 300,
+        ]);
+
         $this->addFilter('tags', [
             'title' => Yii::t('MarketplaceModule.base', 'Tags'),
             'type' => 'tags',
@@ -75,6 +85,49 @@ class ModuleFilters extends DirectoryFilters
             'wrapperClass' => 'w-100 form-search-filter-tags',
             'sortOrder' => 20000,
         ]);
+    }
+
+    private function renderIncludeCommunityCheckbox(Module $marketplaceModule): string
+    {
+        $checked = (bool) $marketplaceModule->settings->get('includeCommunityModules', false);
+
+        $warning = Yii::t('MarketplaceModule.base', 'Community modules are developed by third parties and are <strong>not tested or maintained by the HumHub team</strong>.<br><br>They may not be compatible with your HumHub version, can cause <strong>instability or unexpected behavior</strong>, and may stop working after future updates. Their long-term maintenance is not guaranteed.<br><br>Only enable this option if you understand the risks and trust the source of the module you intend to install.');
+
+        $ackCheckbox = Html::tag(
+            'div',
+            Html::checkbox('communityRiskAccepted', false, [
+                'id' => 'community-risk-accepted',
+                'class' => 'form-check-input',
+            ])
+            . ' '
+            . Html::label(
+                Yii::t('MarketplaceModule.base', 'I understand the risk and want to continue.'),
+                'community-risk-accepted',
+                ['class' => 'form-check-label'],
+            ),
+            ['class' => 'form-check mt-3'],
+        );
+
+        $confirmBody = $warning . $ackCheckbox;
+
+        $checkbox = Html::checkbox('includeCommunityModules', $checked, [
+            'id' => 'marketplace-include-community',
+            'class' => 'form-check-input',
+            'data-action-change' => 'marketplace.toggleCommunity',
+            'data-action-change-url' => Url::to(['/marketplace/browse/toggle-community']),
+            'data-confirm-header' => Yii::t('MarketplaceModule.base', 'Include unverified community modules?'),
+            'data-confirm-body' => $confirmBody,
+            'data-confirm-text' => Yii::t('MarketplaceModule.base', 'Yes, show community modules'),
+            'data-cancel-text' => Yii::t('MarketplaceModule.base', 'Cancel'),
+        ]);
+
+        $label = Html::label(
+            Yii::t('MarketplaceModule.base', 'Include community modules'),
+            'marketplace-include-community',
+            ['class' => 'form-check-label'],
+        );
+
+        return Html::tag('div', $checkbox . ' ' . $label, ['class' => 'form-check']);
     }
 
     public static function getDefaultValue(string $filter): string

--- a/protected/humhub/modules/marketplace/widgets/ModuleStatus.php
+++ b/protected/humhub/modules/marketplace/widgets/ModuleStatus.php
@@ -63,6 +63,8 @@ class ModuleStatus extends Widget
             $this->_status = 'partner';
         } elseif ($this->module->isDeprecated) {
             $this->_status = 'deprecated';
+        } elseif ($this->module->isCommunity) {
+            $this->_status = 'community';
         } else {
             $this->_status = 'none';
         }
@@ -79,6 +81,7 @@ class ModuleStatus extends Widget
             'official' => Yii::t('MarketplaceModule.base', 'Official'),
             'partner' => Yii::t('MarketplaceModule.base', 'Partner'),
             'deprecated' => Yii::t('MarketplaceModule.base', 'Deprecated'),
+            'community' => Yii::t('MarketplaceModule.base', 'Community'),
             'new' => Yii::t('MarketplaceModule.base', 'New'),
             default => '',
         };

--- a/protected/humhub/resources/scss/_cards.scss
+++ b/protected/humhub/resources/scss/_cards.scss
@@ -233,6 +233,13 @@
                 &.card-status-new {
                     background: #21A1B3;
                 }
+
+                &.card-status-community {
+                    background: transparent;
+                    color: var(--bs-secondary-color);
+                    border: 1px solid var(--bs-border-color);
+                    box-sizing: border-box;
+                }
             }
 
             .card-header {

--- a/protected/humhub/tests/codeception/unit/modules/marketplace/OnlineModuleManagerTest.php
+++ b/protected/humhub/tests/codeception/unit/modules/marketplace/OnlineModuleManagerTest.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+ * @link      https://www.humhub.org/
+ * @copyright Copyright (c) 2026 HumHub GmbH & Co. KG
+ * @license   https://www.humhub.com/licences
+ */
+
+namespace humhub\tests\codeception\unit\modules\marketplace;
+
+use humhub\modules\marketplace\components\OnlineModuleManager;
+use humhub\modules\marketplace\Module;
+use tests\codeception\_support\HumHubDbTestCase;
+use Yii;
+
+/**
+ * @since 1.19
+ */
+class OnlineModuleManagerTest extends HumHubDbTestCase
+{
+    private const CACHE_KEY = 'onlineModuleManager_modules';
+
+    private const COMMUNITY_INSTALLED_ID = 'content';   // core module, always installed in tests
+    private const COMMUNITY_NOT_INSTALLED_ID = 'fake_community_module_for_test';
+    private const REGULAR_NOT_INSTALLED_ID = 'fake_regular_module_for_test';
+
+    /**
+     * @var Module
+     */
+    private $marketplaceModule;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->marketplaceModule = Yii::$app->getModule('marketplace');
+
+        Yii::$app->cache->set(self::CACHE_KEY, [
+            self::COMMUNITY_INSTALLED_ID => [
+                'name' => 'Installed community module',
+                'isCommunity' => true,
+            ],
+            self::COMMUNITY_NOT_INSTALLED_ID => [
+                'name' => 'Uninstalled community module',
+                'isCommunity' => true,
+            ],
+            self::REGULAR_NOT_INSTALLED_ID => [
+                'name' => 'Uninstalled regular module',
+                'isCommunity' => false,
+            ],
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        Yii::$app->cache->delete(self::CACHE_KEY);
+        $this->marketplaceModule->settings->delete('includeCommunityModules');
+
+        parent::tearDown();
+    }
+
+    public function testCommunityModulesAreHiddenByDefault(): void
+    {
+        $this->marketplaceModule->settings->set('includeCommunityModules', false);
+
+        $modules = (new OnlineModuleManager())->getModules();
+
+        $this->assertArrayHasKey(self::REGULAR_NOT_INSTALLED_ID, $modules);
+        $this->assertArrayNotHasKey(self::COMMUNITY_NOT_INSTALLED_ID, $modules);
+    }
+
+    public function testCommunityModulesAreShownWhenSettingEnabled(): void
+    {
+        $this->marketplaceModule->settings->set('includeCommunityModules', true);
+
+        $modules = (new OnlineModuleManager())->getModules();
+
+        $this->assertArrayHasKey(self::REGULAR_NOT_INSTALLED_ID, $modules);
+        $this->assertArrayHasKey(self::COMMUNITY_NOT_INSTALLED_ID, $modules);
+    }
+
+    public function testInstalledCommunityModulesAreAlwaysVisible(): void
+    {
+        $this->marketplaceModule->settings->set('includeCommunityModules', false);
+
+        $this->assertTrue(
+            Yii::$app->moduleManager->hasModule(self::COMMUNITY_INSTALLED_ID),
+            'Precondition: ' . self::COMMUNITY_INSTALLED_ID . ' is expected to be installed in the test environment',
+        );
+
+        $modules = (new OnlineModuleManager())->getModules();
+
+        $this->assertArrayHasKey(self::COMMUNITY_INSTALLED_ID, $modules);
+    }
+}


### PR DESCRIPTION
## Summary

Improves community module handling in the marketplace by hiding unverified community modules behind an opt-in toggle.

Refs humhub/humhub-internal#1170

### Changes

- **New filter "Include community modules"** placed under the Categories dropdown on the marketplace browse page. Toggling it on shows a confirmation modal with a risk acknowledgement checkbox; the confirm button stays disabled until the user ticks it. The setting persists via the new `marketplace/browse/toggle-community` action.
- **Mirrored setting in Module Settings** (`GeneralModuleSettingsForm`) so admins can also enable it from the marketplace settings page.
- **Confirmation modals before install and buy** for community modules. The buy flow uses a custom JS handler (`marketplace.buy`) that opens the checkout URL in a new tab after the confirm is accepted.
- **Marketplace listing filter** in `OnlineModuleManager::getModules()` drops community modules when the flag is off — but always keeps modules already installed locally, so existing installations continue to receive updates regardless of the setting.
- **Subtle "Community" status badge** on marketplace cards (transparent background, light border) for visual differentiation. Lower priority than Professional / Featured / Official / Partner / Deprecated, so featured community modules still show "Featured".
- **Reworded disclaimer / control labels** from "Community" to "Unverified Community" where the wording previously suggested a quality signal.

### Tests

`OnlineModuleManagerTest` (new):
- Community modules are hidden by default.
- Community modules are shown when the setting is enabled.
- Installed community modules remain visible even with the setting off — ensures updates keep flowing for existing installs.

## Test plan

- [ ] Toggle the new filter on the marketplace browse page, verify confirm modal + risk acknowledgement gating works
- [ ] Verify the buy / install confirm modals appear for community modules and not for non-community ones
- [ ] Verify already-installed community modules still appear with the filter off
- [ ] Verify the Community badge renders on community module cards but is overridden by Featured / Partner / Official priorities
- [ ] Run `protected/humhub/tests/codeception/unit/modules/marketplace/OnlineModuleManagerTest.php` (passes locally, 3/3)