### PR TITLE
fix: Add placeholder to Group Selector in Sign-up form

### DIFF
--- a/protected/humhub/modules/user/models/forms/Registration.php
+++ b/protected/humhub/modules/user/models/forms/Registration.php
@@ -236,10 +236,16 @@ class Registration extends HForm
      */
     public function validate()
     {
-        // Remove optional group assignment before validation
-        // GroupUser assignment is optional and will be validated on save
         $groupUser = $this->models['GroupUser'];
-        unset($this->models['GroupUser']);
+
+        // Only skip group validation when the selector is not shown as a dropdown.
+        // When a dropdown is visible, the user must actively select a group.
+        $groupFieldType = $this->definition['elements']['GroupUser']['elements']['group_id']['type'] ?? 'hidden';
+        if ($groupFieldType !== 'dropdownlist') {
+            // Group assignment is optional when not shown as a dropdown
+            unset($this->models['GroupUser']);
+        }
+
         $status = parent::validate();
         $this->models['GroupUser'] = $groupUser;
 

--- a/protected/humhub/modules/user/models/forms/Registration.php
+++ b/protected/humhub/modules/user/models/forms/Registration.php
@@ -188,22 +188,28 @@ class Registration extends HForm
     {
         $groupModels = Group::getRegistrationGroups($this->getUser());
 
-        $groupFieldType = (Yii::$app->getModule('user')->settings->get('auth.showRegistrationUserGroup') && count(
-            $groupModels,
-        ) > 1)
+        $isDropdown = Yii::$app->getModule('user')->settings->get('auth.showRegistrationUserGroup') && count($groupModels) > 1;
+        $groupFieldType = $isDropdown
             ? 'dropdownlist'
             : 'hidden'; // TODO: Completely hide the element instead of current <input type="hidden">
+
+        $groupIdDefinition = [
+            'label' => Yii::t('UserModule.auth', 'Group'),
+            'type' => $groupFieldType,
+            'class' => 'form-control',
+            'items' => ArrayHelper::map($groupModels, 'id', 'name'),
+        ];
+
+        if ($isDropdown) {
+            $groupIdDefinition['prompt'] = Yii::t('UserModule.auth', 'Select');
+        } else {
+            $groupIdDefinition['value'] = Yii::$app->getModule('user')->getDefaultGroupId();
+        }
 
         return [
             'type' => 'form',
             'elements' => [
-                'group_id' => [
-                    'label' => Yii::t('UserModule.auth', 'Group'),
-                    'type' => $groupFieldType,
-                    'class' => 'form-control',
-                    'items' => ArrayHelper::map($groupModels, 'id', 'name'),
-                    'value' => Yii::$app->getModule('user')->getDefaultGroupId(),
-                ],
+                'group_id' => $groupIdDefinition,
             ],
         ];
     }

--- a/protected/humhub/modules/user/models/forms/Registration.php
+++ b/protected/humhub/modules/user/models/forms/Registration.php
@@ -270,7 +270,7 @@ class Registration extends HForm
             $this->models['User']->registrationGroupId = $this->models['GroupUser']->group_id;
         }
 
-        if ($this->models['GroupUser']->group_id !== null) {
+        if (!empty($this->models['GroupUser']->group_id)) {
             // Skip adding of the user to a default group if some group is already selected on the registration form
             $this->models['User']->allowAssignDefaultGroup(false);
         }


### PR DESCRIPTION
## Summary

Fixes **humhub/humhub-internal#1194**

The Group Selector dropdown in the registration/sign-up form previously always pre-selected the default user group. This change adds a \Select\ placeholder so the dropdown starts with no selection.

## Changes

- Added \'prompt' => 'Select'\ to the dropdown definition so a placeholder option is shown by default
- Removed the automatic \alue\ pre-selection for the dropdown case
- The hidden input (single group / group selector disabled) still uses \getDefaultGroupId()\ as before — no behavior change there

## Before / After

**Before:** The dropdown always had a group pre-selected (the default group)  
**After:** The dropdown shows a \Select\ placeholder with no group pre-selected