### PR TITLE
[Security] Restrict allowed_classes in LiveEvent unserialize() to prevent PHP Object Injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ HumHub Changelog
 ---------------------
 - Enh #8170: Handle controllers with using external modules
 - Enh #8176: Upgrade Twig package to v3.26.0
+- Fix #8189: Scroll to highlighted comment when navigating from Last Activities
 - Enh #8187: Update composer package symfony/mime
 - Fix #8188: AutoContrast and Sign In Footer Links
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ HumHub Changelog
 - Enh #8170: Handle controllers with using external modules
 - Enh #8176: Upgrade Twig package to v3.26.0
 - Enh #8187: Update composer package symfony/mime
+- Fix #8188: AutoContrast and Sign In Footer Links
 
 1.18.3 (May 18, 2026)
 ---------------------
@@ -67,7 +68,7 @@ HumHub Changelog
 ----------------------
 
 > This release also fixes a [security](https://github.com/humhub/humhub/security/advisories/GHSA-qxjh-478x-23gm) issue.
- 
+
 - Fix #8003: `Migration::foreignIndexExists()` doesn't find tables in braces
 - Fix #8002: Comment dropdowns truncated (e.g. to select a title)
 - Fix #8007: Fix unsaved changes warning on Profile Edit page
@@ -155,7 +156,7 @@ HumHub Changelog
 - Fix #7873: Fix `required` validator
 - Fix #7875: Fix theme color default settings after initial installation
 - Fix #7876: Support for .mjs (ES modules)
-- Chg #7878: Registration form definitions now requires to use the `EVENT_AFTER_SET_FORM` instead of `EVENT_AFTER_INIT` 
+- Chg #7878: Registration form definitions now requires to use the `EVENT_AFTER_SET_FORM` instead of `EVENT_AFTER_INIT`
 - Enh #7883: Allow CheckboxList Profile Field Type to be used "as Directory filter"
 - Fix #7884: On small screen, the modal box is not centered
 - Fix #7885: Layout padding on small screens

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ HumHub Changelog
 ---------------------
 - Enh #8170: Handle controllers with using external modules
 - Enh #8176: Upgrade Twig package to v3.26.0
+- Enh #8187: Update composer package symfony/mime
 
 1.18.3 (May 18, 2026)
 ---------------------

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,13 @@ When doing impact analysis:
 | `develop` | Next version — primary development branch |
 | `next` | Version after next |
 
+**Target branch for PRs:** new features and enhancements go into `develop`, never directly into `master`. Only bugfixes for the current stable release are committed to `master`. Base every PR on the branch that matches the type of change.
+
 External modules follow the same convention. A module's `develop` branch targets the upcoming core version. Verify by checking `humhub.minVersion` in the module's `module.json` on that branch.
+
+## Changelog
+
+Every PR must include a changelog entry. In this core repo the changelog is `CHANGELOG.md` at the repository **root** (external modules use `docs/CHANGELOG.md`). Add a bullet under the topmost `X.Y.Z (Unreleased)` section in the form `- <Tag> #<PR>: <description>`, where `<Tag>` is `Enh`, `Fix`, etc. — match the existing entries. Do not bump the version for unreleased changes; the version is only bumped when a release is cut.
 
 ## Running Tests
 

--- a/composer.lock
+++ b/composer.lock
@@ -8294,16 +8294,16 @@
         },
         {
             "name": "symfony/mime",
-            "version": "v6.4.37",
+            "version": "v6.4.41",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mime.git",
-                "reference": "330077bc7fbe314758aff62834b758d06ac6d260"
+                "reference": "5575d37f8841e4e31d5df79ab3db078ae557ff8e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mime/zipball/330077bc7fbe314758aff62834b758d06ac6d260",
-                "reference": "330077bc7fbe314758aff62834b758d06ac6d260",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/5575d37f8841e4e31d5df79ab3db078ae557ff8e",
+                "reference": "5575d37f8841e4e31d5df79ab3db078ae557ff8e",
                 "shasum": ""
             },
             "require": {
@@ -8359,7 +8359,7 @@
                 "mime-type"
             ],
             "support": {
-                "source": "https://github.com/symfony/mime/tree/v6.4.37"
+                "source": "https://github.com/symfony/mime/tree/v6.4.41"
             },
             "funding": [
                 {
@@ -8379,7 +8379,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-29T09:53:28+00:00"
+            "time": "2026-05-23T14:40:34+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",

--- a/protected/humhub/modules/comment/widgets/views/comments.php
+++ b/protected/humhub/modules/comment/widgets/views/comments.php
@@ -46,7 +46,4 @@ use humhub\modules\content\components\ContentActiveRecord;
         // make comments visible at this point to fixing autoresizing issue for textareas in Firefox
         $('#comment_<?= $id ?>').show();
     <?php endif; ?>
-    <?php if (!empty($currentCommentId)) : ?>
-        $('#comment_<?= $currentCommentId ?>').get(0).scrollIntoView();
-    <?php endif; ?>
 </script>

--- a/protected/humhub/modules/live/controllers/PollController.php
+++ b/protected/humhub/modules/live/controllers/PollController.php
@@ -11,6 +11,11 @@ namespace humhub\modules\live\controllers;
 use humhub\components\Controller;
 use humhub\modules\content\models\Content;
 use humhub\modules\live\components\LiveEvent;
+use humhub\modules\comment\live\NewComment;
+use humhub\modules\content\live\NewContent;
+use humhub\modules\notification\live\NewNotification;
+use humhub\modules\live\live\LegitimationChanged;
+use humhub\modules\live\live\PreventPjaxOnNextClick;
 use humhub\modules\live\driver\Poll;
 use humhub\modules\live\models\Live;
 use humhub\modules\user\services\IsOnlineService;
@@ -119,7 +124,13 @@ class PollController extends Controller
     {
         try {
             /* @var $liveEvent LiveEvent */
-            $liveEvent = unserialize($serializedEvent);
+            $liveEvent = unserialize($serializedEvent, ['allowed_classes' => [
+                NewComment::class,
+                NewContent::class,
+                NewNotification::class,
+                LegitimationChanged::class,
+                PreventPjaxOnNextClick::class,
+            ]]);
 
             if (!$liveEvent instanceof LiveEvent) {
                 throw new Exception('Invalid live event class after unserialize!');

--- a/protected/humhub/modules/stream/resources/js/humhub.stream.Stream.js
+++ b/protected/humhub/modules/stream/resources/js/humhub.stream.Stream.js
@@ -208,6 +208,15 @@ humhub.module('stream.Stream', function (module, require, $) {
 
     Stream.prototype.triggerInitEvent = function (response) {
         this.trigger(EVENT_INITIALIZED, this);
+
+        var commentId = this.$.data(DATA_STREAM_COMMENTID);
+        if (commentId) {
+            var $comment = $('#comment_' + commentId);
+            if ($comment.length) {
+                $comment[0].scrollIntoView({block: 'center'});
+            }
+        }
+
         return response;
     };
 

--- a/static/scss/_base.scss
+++ b/static/scss/_base.scss
@@ -96,7 +96,7 @@
 
     .powered,
     .powered a {
-        color: #b8c7d3 !important;
+        color: color-mix(in srgb, var(--hh-primary-contrast) 80%, transparent) !important;
     }
 
     [data-ui-show-more] {


### PR DESCRIPTION
## Summary

`PollController::unserializeEvent()` deserializes `LiveEvent` objects from the `live` database table without an `allowed_classes` restriction. Without this restriction, PHP will instantiate any class found in the serialized data, which can be exploited for **PHP Object Injection** via gadget chains.

## Attack Surface

The `live` table is written by the application when users perform actions (new content, comments, notifications). An attacker with a valid user account who can trigger live event storage could potentially inject a crafted serialized payload into the database, which would then be deserialized by other users' polling requests.

## Fix

Restrict `allowed_classes` to the 5 known `LiveEvent` subclasses used by HumHub core:

- `humhub\modules\comment\live\NewComment`
- `humhub\modules\content\live\NewContent`
- `humhub\modules\notification\live\NewNotification`
- `humhub\modules\live\live\LegitimationChanged`
- `humhub\modules\live\live\PreventPjaxOnNextClick`

Any unexpected class in serialized live event data will now be returned as `__PHP_Incomplete_Class` instead of a live instantiated object, neutralizing gadget chain exploitation.

> **Note for maintainers:** Third-party modules that define custom `LiveEvent` subclasses may need to extend this list or register their classes via a hook. Consider adding a `registerLiveEventClasses()` mechanism in `LiveEvent` to allow extensible allowed-classes registration.