### PR TITLE
Fix API tests for new Activity structure

### DIFF
--- a/protected/humhub/tests/codeception/_support/HumHubApiTestCest.php
+++ b/protected/humhub/tests/codeception/_support/HumHubApiTestCest.php
@@ -48,7 +48,7 @@ class HumHubApiTestCest
             $recordModelClass = $this->recordModelClass;
         }
 
-        $record = $recordModelClass::findOne(['id' => $id]);
+        $record = $recordModelClass::findOne([$recordModelClass::tableName() . '.id' => $id]);
 
         return ($record ? call_user_func($this->recordDefinitionFunction, $record) : []);
     }
@@ -63,7 +63,7 @@ class HumHubApiTestCest
             $recordDefinitionFunction = $this->recordDefinitionFunction;
         }
 
-        $recordsQuery = $recordModelClass::find()->where(['IN', 'id', $ids]);
+        $recordsQuery = $recordModelClass::find()->where(['IN', $recordModelClass::tableName() . '.id', $ids]);
 
         $records = [];
         foreach ($recordsQuery->all() as $record) {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix

**Other information:**
We neeed this fix to avoid errors in API tests for new Activity because it has by default `->leftJoin('content')` and `->leftJoin('user')` inside the `ActiveQueryActivity`,

Error is [here](https://github.com/humhub/rest/actions/runs/26950978346/job/79515872178#step:26:115):
```
Column 'id' in where clause is ambiguous.
The SQL being executed was:
SELECT `activity`.* FROM `activity` 
LEFT JOIN `content` ON content.id = activity.content_id 
LEFT JOIN `user` ON user.id = activity.created_by 
WHERE `id` IN (100, 101, 102, 103)
```