### PR TITLE
WCAG: Auto-derive aria-label for icon-only buttons from tooltip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ HumHub Changelog
 
 1.19 (TBD)
 ----------
+- Enh: Icon-only `Button` automatically derives `aria-label` from tooltip; logs a warning in `YII_DEBUG` mode when neither is set
 - Enh: Improved community module handling in the marketplace — admins can opt in via a new "Include community modules" option to show modules contributed by the community
 - Fix #8181: Encoded HTML entities in notification mail subjects
 - Enh #8179: Do not override meta tags set by modules with proper key

--- a/docs/develop/module-migrate.md
+++ b/docs/develop/module-migrate.md
@@ -6,6 +6,10 @@ Each minor release line has its own file with the breaking changes, new APIs and
 
 ## Unreleased
 
+- Icon-only `Button` widgets (no visible label, only an icon) now automatically set `aria-label` from
+  the tooltip text. Module developers should always call `->tooltip('...')` on icon-only buttons —
+  omitting it logs a `Yii::warning()` in `YII_DEBUG` mode.
+  Explicit `aria-label` via `->options(['aria-label' => '...'])` always takes precedence.
 - Split rich text short converters by output safety
   - Added `humhub\modules\content\widgets\richtext\converter\RichTextToShortHtmlConverter`
     producing HTML encoded short previews (with the `nl2br` option). Use this whenever

--- a/protected/humhub/widgets/bootstrap/Button.php
+++ b/protected/humhub/widgets/bootstrap/Button.php
@@ -218,6 +218,18 @@ class Button extends \yii\bootstrap5\Button
 
         if ($this->label === null && $this->icon !== null) {
             $this->cssClass('btn-icon-only');
+
+            if (!isset($this->options['aria-label'])) {
+                $tooltip = $this->options['data-bs-title'] ?? null;
+                if ($tooltip) {
+                    $this->options['aria-label'] = $tooltip;
+                } elseif (YII_DEBUG) {
+                    Yii::warning(
+                        'Icon-only button rendered without tooltip/aria-label (icon: ' . $this->icon->name . ')',
+                        'accessibility',
+                    );
+                }
+            }
         }
 
         $text = $this->icon . ($this->encodeLabel ? Html::encode($this->label) : $this->label);


### PR DESCRIPTION
## Summary

- Icon-only `Button` widgets (no visible label, only an icon) now automatically set `aria-label` from the tooltip text (`data-bs-title`) when no `aria-label` is explicitly set in `options`
- If an icon-only button is rendered without a tooltip (and no explicit `aria-label`), a `Yii::warning()` is logged in `YII_DEBUG` mode to encourage developers to always provide a tooltip on icon-only buttons
- Explicit `aria-label` via `options(['aria-label' => '...'])` always takes precedence

## Why

Icon-only buttons have no visible text, so screen readers had no accessible name to announce. The tooltip text is already the semantic description of what the button does, making it the natural source for `aria-label`.

## No breaking changes

Existing buttons without a tooltip continue to work — they only receive a dev-mode log warning.