### PR TITLE
Fix svg and webp assets not served as static files in test server

### DIFF
--- a/index-test.php
+++ b/index-test.php
@@ -13,7 +13,7 @@ if (!in_array(@$_SERVER['REMOTE_ADDR'], ['127.0.0.1', '::1'])) {
     die('You are not allowed to access this file.');
 }
 
-if (isset($_SERVER['REQUEST_URI']) && preg_match('/^[^?]*\.(?:css|(?<!manifest\.)json|(?<!sw\.)js|png|jpg|jpeg|gif|ttf|woff|woff2)(\?.+)?$/i', $_SERVER['REQUEST_URI'])) {
+if (isset($_SERVER['REQUEST_URI']) && preg_match('/^[^?]*\.(?:css|(?<!manifest\.)json|(?<!sw\.)js|png|jpg|jpeg|gif|svg|webp|ttf|woff|woff2)(\?.+)?$/i', $_SERVER['REQUEST_URI'])) {
     return false; // serve the requested resource as-is.
 }
 


### PR DESCRIPTION
## Summary

- The `index-test.php` built-in test server script uses a regex to decide which file extensions to serve as static assets. `svg` and `webp` were missing from the list.
- Any request for an `.svg` or `.webp` file in the `assets/` directory was passed through the full PHP/HumHub application instead of being served directly, causing a redirect to `/dashboard`.

## Root cause

Line 16 of `index-test.php`:
```php
preg_match('/^[^?]*\.(?:css|(?<!manifest\.)json|(?<!sw\.)js|png|jpg|jpeg|gif|ttf|woff|woff2)(\?.+)?$/i', ...)
```
`svg` and `webp` were not included.

## Fix

Add `svg` and `webp` to the regex so they are served as static files.

Reported in: https://github.com/humhub/humhub-internal/issues/1218#issuecomment-4629234619