### PR TITLE
Fix activity migration: clean up unresolvable records

### DIFF
--- a/protected/humhub/modules/activity/migrations/m260108_115053_new_structure.php
+++ b/protected/humhub/modules/activity/migrations/m260108_115053_new_structure.php
@@ -184,32 +184,27 @@ class m260108_115053_new_structure extends Migration
                     continue;
                 }
 
-                // Not a ContentProvider (e.g. leftover Follow records): drop bogus
-                // FollowActivity rows and their record_map entries, warn otherwise.
+                // Model is not a ContentProvider (e.g. a ContentActiveRecord like
+                // ContainerSnippet, or a class that no longer exists). Its activities
+                // were already handled by the content-JOIN UPDATEs in Phase 2 above.
+                // Any that still have content_id=NULL here have no resolvable parent
+                // (deleted content, removed module) and must be cleaned up so they
+                // do not violate future NOT NULL constraints on content_id.
                 $orphanRecordMapIds = (new Query())
                     ->select('content_addon_record_id')
                     ->distinct()
                     ->from(Activity::tableName())
-                    ->where([
-                        'content_id' => null,
-                        'object_model' => $model,
-                        'class' => \humhub\modules\user\activities\FollowActivity::class,
-                    ])
+                    ->where(['content_id' => null, 'object_model' => $model])
                     ->andWhere('content_addon_record_id IS NOT NULL')
                     ->column();
 
                 if ($orphanRecordMapIds !== []) {
+                    Yii::warning(
+                        'Deleting ' . count($orphanRecordMapIds) . ' unresolvable activity record(s) for model: ' . $model,
+                        'activity',
+                    );
                     $this->delete('activity', ['content_addon_record_id' => $orphanRecordMapIds]);
                     $this->delete('record_map', ['id' => $orphanRecordMapIds]);
-                }
-
-                $hasRemaining = (new Query())
-                    ->from(Activity::tableName())
-                    ->where(['content_id' => null, 'object_model' => $model])
-                    ->andWhere('content_addon_record_id IS NOT NULL')
-                    ->exists();
-                if ($hasRemaining) {
-                    Yii::warning('Unresolved activity content_addon_record for model: ' . $model, 'activity');
                 }
             }
         }


### PR DESCRIPTION
## Problem

During the `m260108_115053_new_structure` migration, activities that point to a model which is **not a `ContentProvider`** (e.g. `ContainerSnippet` from the `custom_pages` module, or any other `ContentActiveRecord` subclass) cannot get a `content_id` assigned via the addon-model loop. These activities were previously left in place with `content_id = NULL`, causing a warning in the migration log:

```
Warnung — activity: Unresolved activity content_addon_record for model: humhub\modules\custom_pages\models\ContainerSnippet
```

## Root cause

`ContentActiveRecord` models (like `ContainerSnippet`) are not `ContentProvider` subclasses — they *have* a `content` row rather than referencing one via `content_id`. Their activities are correctly handled earlier in Phase 2 via the bulk `UPDATE activity LEFT JOIN content` statement. Any rows that still have `content_id = NULL` after that step have no resolvable parent (deleted content or removed module) and cannot be displayed in the activity stream.

The previous code only deleted `FollowActivity`-specific orphans and warned about all others, leaving dangling rows.

## Fix

Generalise the orphan-cleanup: for any model that is not a `ContentProvider`, delete all activity rows that still have `content_id = NULL` after the Phase 2 UPDATEs, and remove their `record_map` entries. Log the count before deleting.