### PR TITLE
Enh: Introduce ModuleDiscoveryService and ModuleService, slim down ModuleAutoLoader and ModuleManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ HumHub Changelog
 1.19 (TBD)
 ----------
 - Enh: Added `#[WithoutModuleAutoload]` attribute for console controllers that do not require module loading (e.g. `settings/*`, `cache/*`)
+- Enh: Introduced `ModuleDiscoveryService` centralising all module filesystem discovery and `ModuleService` encapsulating per-module lifecycle operations (enable, disable, remove); slimmed down `ModuleAutoLoader` and `ModuleManager`
 - Enh: Icon-only `Button` automatically derives `aria-label` from tooltip; logs a warning in `YII_DEBUG` mode when neither is set
 - Enh: Improved community module handling in the marketplace — admins can opt in via a new "Include community modules" option to show modules contributed by the community
 - Fix #8181: Encoded HTML entities in notification mail subjects

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ HumHub Changelog
 1.19 (TBD)
 ----------
 - Enh: Added `#[WithoutModuleAutoload]` attribute for console controllers that do not require module loading (e.g. `settings/*`, `cache/*`)
-- Enh: Introduced `ModuleDiscoveryService` centralising all module filesystem discovery and `ModuleService` encapsulating per-module lifecycle operations (enable, disable, remove); slimmed down `ModuleAutoLoader` and `ModuleManager`
+- Enh #8214: Introduced `ModuleDiscoveryService` centralising all module filesystem discovery and `ModuleService` encapsulating per-module lifecycle operations (enable, disable, remove); slimmed down `ModuleAutoLoader` and `ModuleManager`
 - Enh: Icon-only `Button` automatically derives `aria-label` from tooltip; logs a warning in `YII_DEBUG` mode when neither is set
 - Enh: Improved community module handling in the marketplace — admins can opt in via a new "Include community modules" option to show modules contributed by the community
 - Fix #8181: Encoded HTML entities in notification mail subjects

--- a/protected/humhub/commands/MigrateController.php
+++ b/protected/humhub/commands/MigrateController.php
@@ -189,13 +189,14 @@ class MigrateController extends \yii\console\controllers\MigrateController
     }
 
     /**
-     * Returns the migration paths of all enabled modules
+     * Returns the migration paths of all enabled modules.
      *
      * @return string[]
      */
     protected function getMigrationPaths(): array
     {
         $migrationPaths = ['base' => $this->migrationPath];
+
         foreach (($this->module ?? Yii::$app)->getModules() as $id => $config) {
             $class = null;
             if (is_array($config) && isset($config['class'])) {

--- a/protected/humhub/components/Module.php
+++ b/protected/humhub/components/Module.php
@@ -20,6 +20,7 @@ use humhub\modules\marketplace\models\Module as OnlineModelModule;
 use humhub\modules\notification\components\BaseNotification;
 use humhub\modules\queue\helpers\QueueHelper;
 use humhub\services\MigrationService;
+use humhub\services\ModuleService;
 use Throwable;
 use Yii;
 use yii\base\InvalidConfigException;
@@ -222,18 +223,34 @@ class Module extends \yii\base\Module
     }
 
     /**
-     * Enables this module
+     * Enables this module.
      *
-     * @return bool|null Result of migration or null if beforeEnable() returned false (since v1.16)
+     * Override this method to run custom logic when the module is enabled. Call
+     * `parent::enable()` **before** your custom code so the module is already
+     * registered and active when your code runs:
+     *
+     * ```php
+     * public function enable()
+     * {
+     *     parent::enable();
+     *     // custom enable logic here
+     * }
+     * ```
+     *
+     * The base implementation delegates the registration step to {@see ModuleService::enable()}
+     * and then runs pending database migrations via {@see MigrationService::migrateUp()}.
+     * If migrations fail, the registration is rolled back automatically.
+     *
+     * @return bool|null migration result, or false if migrations failed
      * @throws InvalidConfigException
      */
     public function enable()
     {
-        Yii::$app->moduleManager->enable($this);
+        $this->getModuleService()->enable();
         $result = $this->getMigrationService()->migrateUp();
 
         if ($result === false) {
-            Yii::$app->moduleManager->disable($this);
+            $this->getModuleService()->disable();
             Yii::error('Could not enable module. Database Migration failed! See previous error for result.', $this->id);
             return false;
         }
@@ -271,7 +288,7 @@ class Module extends \yii\base\Module
             $result = false;
         }
 
-        Yii::$app->moduleManager->disable($this);
+        $this->getModuleService()->disable();
 
         return $result;
     }
@@ -279,6 +296,14 @@ class Module extends \yii\base\Module
     public function getMigrationService(): MigrationService
     {
         return new MigrationService($this);
+    }
+
+    /**
+     * @since 1.19
+     */
+    public function getModuleService(): ModuleService
+    {
+        return new ModuleService($this);
     }
 
     /**

--- a/protected/humhub/components/ModuleManager.php
+++ b/protected/humhub/components/ModuleManager.php
@@ -11,23 +11,17 @@
 namespace humhub\components;
 
 use ArrayAccess;
-use humhub\components\bootstrap\ModuleAutoLoader;
+use humhub\services\ModuleDiscoveryService;
 use humhub\components\console\Application as ConsoleApplication;
 use humhub\exceptions\InvalidArgumentTypeException;
 use humhub\models\ModuleEnabled;
 use humhub\modules\admin\events\ModulesEvent;
-use humhub\modules\marketplace\Module as ModuleMarketplace;
-use Throwable;
 use Yii;
 use yii\base\Component;
-use yii\base\ErrorException;
 use yii\base\Event;
 use yii\base\Exception;
 use yii\base\InvalidConfigException;
-use yii\db\StaleObjectException;
 use yii\helpers\ArrayHelper;
-use yii\helpers\FileHelper;
-use yii\web\ServerErrorHttpException;
 
 /**
  * ModuleManager handles registration, enabling, and disabling of modules.
@@ -41,7 +35,7 @@ use yii\web\ServerErrorHttpException;
  * - adds console controller mappings for CLI commands
  *
  * Only core modules and currently enabled modules are fully activated. Disabled modules
- * are tracked but remain dormant until explicitly enabled via {@see enable()}.
+ * are tracked but remain dormant until explicitly enabled via {@see Module::enable()}.
  *
  * Event handler registration is intentionally lenient by default: invalid handlers (missing
  * class or method) emit a warning and are skipped rather than throwing an exception. Modules
@@ -571,187 +565,33 @@ class ModuleManager extends Component
      */
     public function flushCache()
     {
-        Yii::$app->cache->delete(ModuleAutoLoader::CACHE_ID);
+        Yii::$app->cache->delete(ModuleDiscoveryService::CACHE_ID);
     }
 
     /**
-     * Checks if the module can be removed
+     * Marks a module ID as enabled in the in-memory list.
      *
-     * @param string $moduleId
-     *
-     * @noinspection PhpDocMissingThrowsInspection
-     * */
-    public function canRemoveModule($moduleId): bool
-    {
-        /** @noinspection PhpUnhandledExceptionInspection */
-        $module = $this->getModule($moduleId, false);
-
-        if ($module === null) {
-            return false;
-        }
-
-        // Check is in dynamic/marketplace module folder
-        /** @var ModuleMarketplace $marketplaceModule */
-        $marketplaceModule = Yii::$app->getModule('marketplace');
-        if ($marketplaceModule !== null) {
-            // Normalize paths before comparing in order to fix issues like Windows path separators `\`
-            // Realpath is required when the modules path is a symlinked
-            $modulePath = FileHelper::normalizePath($module->getBasePath());
-            $aliasPath = FileHelper::normalizePath(realpath(Yii::getAlias($marketplaceModule->modulesPath)));
-            if (str_contains($modulePath, $aliasPath)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * Removes a module
-     *
-     * @param string $moduleId
-     * @param bool $disableBeforeRemove
-     *
-     * @throws Exception
-     * @throws ErrorException
+     * @internal used by {@see \humhub\services\ModuleService}
+     * @since 1.19
      */
-    public function removeModule($moduleId, $disableBeforeRemove = true): ?string
+    public function markAsEnabled(string $moduleId): void
     {
-        $module = $this->getModule($moduleId);
-
-        if ($module === null) {
-            throw new Exception('Could not load module to remove!');
-        }
-
-        /**
-         * Disable Module
-         */
-        if ($disableBeforeRemove && Yii::$app->hasModule($moduleId)) {
-            $module->disable();
-        }
-
-        /**
-         * Remove Folder
-         */
-        if ($this->createBackup) {
-            $moduleBackupFolder = Yii::getAlias('@runtime/module_backups');
-            FileHelper::createDirectory($moduleBackupFolder);
-
-            $backupFolderName = $moduleBackupFolder . DIRECTORY_SEPARATOR . $moduleId . '_' . time();
-            $moduleBasePath = $module->getBasePath();
-            FileHelper::copyDirectory($moduleBasePath, $backupFolderName);
-            FileHelper::removeDirectory($moduleBasePath);
-        } else {
-            $backupFolderName = null;
-            //TODO: Delete directory
-        }
-
-        $this->flushCache();
-
-        return $backupFolderName;
-    }
-
-    /**
-     * Enables a module
-     *
-     * @param Module $module
-     *
-     * @throws InvalidConfigException
-     * @since 1.1
-     */
-    public function enable(Module $module)
-    {
-        $this->checkRequirements($module);
-
-        $this->trigger(static::EVENT_BEFORE_MODULE_ENABLE, new ModuleEvent(['module' => $module]));
-
-        if (!ModuleEnabled::findOne(['module_id' => $module->id])) {
-            (new ModuleEnabled([
-                'module_id' => $module->id,
-                'version' => $module->version,
-            ]))->save();
-        }
-
-        $this->enabledModules[] = $module->id;
-        $this->register($module->getBasePath());
-        $this->flushCache();
-
-        $this->trigger(static::EVENT_AFTER_MODULE_ENABLE, new ModuleEvent(['module' => $module]));
-    }
-
-    public function enableModules($modules = [])
-    {
-        foreach ($modules as $module) {
-            $module = $this->getModule($module);
-            if ($module != null) {
-                $module->enable();
-            }
+        if (!in_array($moduleId, $this->enabledModules, true)) {
+            $this->enabledModules[] = $moduleId;
         }
     }
 
     /**
-     * Disables a module
+     * Marks a module ID as disabled in the in-memory list.
      *
-     * @param Module $module
-     *
-     * @throws Throwable
-     * @throws StaleObjectException
-     * @since 1.1
+     * @internal used by {@see \humhub\services\ModuleService}
+     * @since 1.19
      */
-    public function disable(Module $module)
+    public function markAsDisabled(string $moduleId): void
     {
-        $this->trigger(static::EVENT_BEFORE_MODULE_DISABLE, new ModuleEvent(['module' => $module]));
-
-        $moduleEnabled = ModuleEnabled::findOne(['module_id' => $module->id]);
-        if ($moduleEnabled !== null) {
-            $moduleEnabled->delete();
-        }
-
-        if (($key = array_search($module->id, $this->enabledModules, true)) !== false) {
+        if (($key = array_search($moduleId, $this->enabledModules, true)) !== false) {
             unset($this->enabledModules[$key]);
         }
-
-        Yii::$app->setModule($module->id, null);
-
-        $this->flushCache();
-
-        $this->trigger(static::EVENT_AFTER_MODULE_DISABLE, new ModuleEvent(['module' => $module]));
     }
 
-    /**
-     * @param array $modules
-     *
-     * @throws Exception
-     */
-    public function disableModules($modules = [])
-    {
-        foreach ($modules as $module) {
-            $module = $this->getModule($module);
-            if ($module !== null) {
-                $module->disable();
-            }
-        }
-    }
-
-    /**
-     * Check module requirements
-     *
-     * @param Module $module
-     * @throws ServerErrorHttpException
-     * @since 1.16
-     */
-    private function checkRequirements(Module $module)
-    {
-        $requirementsPath = $module->getBasePath() . DIRECTORY_SEPARATOR . 'requirements.php';
-        if (!file_exists($requirementsPath)) {
-            return;
-        }
-
-        $requirementCheckResult = include($requirementsPath);
-
-        if (is_string($requirementCheckResult)) {
-            Yii::error('Error enabling the "' . $module->id . '" module: ' . $requirementCheckResult, 'module');
-            throw new ServerErrorHttpException($requirementCheckResult);
-        }
-    }
 }

--- a/protected/humhub/components/bootstrap/ModuleAutoLoader.php
+++ b/protected/humhub/components/bootstrap/ModuleAutoLoader.php
@@ -12,43 +12,35 @@ use humhub\components\Application;
 use humhub\components\console\WithoutModuleAutoload;
 use humhub\components\InstallationState;
 use humhub\modules\installer\libs\EnvironmentChecker;
+use humhub\services\ModuleDiscoveryService;
 use ReflectionClass;
 use Yii;
 use yii\base\BootstrapInterface;
 use yii\base\ErrorException;
-use yii\base\InvalidArgumentException;
 use yii\base\InvalidConfigException;
-use yii\helpers\FileHelper;
 
 /**
- * ModuleAutoLoader discovers and registers all available modules during application bootstrap.
- *
- * It scans all paths listed in the `moduleAutoloadPaths` application parameter for directories
- * containing a `config.php` file and passes the resulting configurations to
- * {@see \humhub\components\ModuleManager::registerBulk()}.
+ * ModuleAutoLoader bootstraps the module system by delegating discovery to
+ * {@see ModuleDiscoveryService} and registration to {@see \humhub\components\ModuleManager}.
  *
  * **Console commands without module dependencies** ({@see WithoutModuleAutoload}):
- * Console controllers annotated with `#[WithoutModuleAutoload]` skip loading external modules
- * from `moduleAutoloadPaths`. Core modules under {@see CORE_MODULE_PATH} are always registered.
- * Use this for lightweight utility commands (e.g. `settings/set`, `cache/flush-all`) that must
- * run cleanly at any point in the application lifecycle, including during upgrades when external
- * module configs may reference removed core classes.
+ * Controllers annotated with `#[WithoutModuleAutoload]` only load core modules, skipping
+ * third-party module configs. Use for commands that must run cleanly during upgrades when
+ * external module configs may reference removed core classes (e.g. `migrate/up`, `settings/*`).
  *
  * @author luke
  */
 class ModuleAutoLoader implements BootstrapInterface
 {
-    public const CACHE_ID = 'module_configs';
-    public const CONFIGURATION_FILE = 'config.php';
-    public const CORE_MODULE_PATH = '@humhub/modules';
+    /**
+     * @deprecated since 1.19 — use {@see ModuleDiscoveryService::CONFIGURATION_FILE}
+     */
+    public const CONFIGURATION_FILE = ModuleDiscoveryService::CONFIGURATION_FILE;
 
     /**
-     * Bootstrap method to be called during application bootstrap stage.
-     *
      * @param Application $app the application currently running
-     *
-     * @throws InvalidConfigException Module a configuration does not have both an id and class attribute
-     * @throws ErrorException On invalid module autoload path
+     * @throws InvalidConfigException
+     * @throws ErrorException
      */
     public function bootstrap($app)
     {
@@ -58,22 +50,21 @@ class ModuleAutoLoader implements BootstrapInterface
         }
 
         if ($app->request->isConsoleRequest && self::hasWithoutModuleAutoloadAttribute()) {
-            $modules = self::findModules([self::CORE_MODULE_PATH]);
+            $modules = ModuleDiscoveryService::loadModuleConfigs([ModuleDiscoveryService::CORE_MODULE_PATH]);
             Yii::$app->moduleManager->registerBulk($modules);
             return;
         }
 
-        $modules = self::locateModules();
+        $modules = ModuleDiscoveryService::locateModuleConfigs();
         Yii::$app->moduleManager->registerBulk($modules);
     }
 
     /**
      * Returns true if the current console command's controller class is annotated
-     * with {@see WithoutModuleAutoload}, indicating it does not require modules.
+     * with {@see WithoutModuleAutoload}.
      *
-     * Module loading is only skipped when the database is available — broken module
-     * configs can only occur on an installed system, not during initial setup or CI
-     * environments where the database has not yet been created.
+     * Only returns true when the database exists — broken module configs can only
+     * occur on an installed system, not during initial setup or CI.
      */
     private static function hasWithoutModuleAutoloadAttribute(): bool
     {
@@ -98,112 +89,5 @@ class ModuleAutoLoader implements BootstrapInterface
         }
 
         return !empty((new ReflectionClass($controllerClass))->getAttributes(WithoutModuleAutoload::class));
-    }
-
-    /**
-     * Find available modules
-     *
-     * @return array[] Array of module configurations with module ID as index.
-     *          Read from cache if available and YII_DEBUG is disabled
-     * @throws ErrorException On invalid module autoload path
-     */
-    public static function locateModules(): array
-    {
-        $modules = Yii::$app->cache->get(self::CACHE_ID);
-
-        if ($modules === false || YII_DEBUG) {
-            $modules = static::findModules(Yii::$app->params['moduleAutoloadPaths']);
-            Yii::$app->cache->set(self::CACHE_ID, $modules);
-        }
-
-        return $modules;
-    }
-
-    /**
-     * Find all modules with configured paths
-     *
-     * @param string[] $paths
-     *
-     * @return array[] Array of module configurations with module ID as index
-     * @throws ErrorException On invalid module autoload path
-     */
-    private static function findModules(iterable $paths): array
-    {
-        $folders = [];
-        foreach ($paths as $path) {
-            try {
-                $folders = array_merge($folders, self::findModulesByPath($path));
-            } catch (InvalidArgumentException) {
-                throw new ErrorException('Invalid module autoload path: ' . $path);
-            }
-        }
-
-        $modules = [];
-        $moduleIdFolders = [];
-        $preventDuplicatedModules = Yii::$app->moduleManager->preventDuplicatedModules;
-
-        foreach ($folders as $folder) {
-            try {
-                $moduleConfig = static::getModuleConfigByPath($folder);
-                if ($preventDuplicatedModules && isset($moduleIdFolders[$moduleConfig['id']])) {
-                    Yii::error(
-                        'Duplicated module "' . $moduleConfig['id'] . '"(' . $folder . ') is already loaded from the folder "' . $moduleIdFolders[$moduleConfig['id']] . '"',
-                    );
-                } else {
-                    $modules[$folder] = $moduleConfig;
-                    $moduleIdFolders[$moduleConfig['id']] = $folder;
-                }
-            } catch (\Throwable $e) {
-                Yii::error($e);
-            }
-        }
-
-        if ($preventDuplicatedModules) {
-            // Overwrite module paths from config
-            foreach (Yii::$app->moduleManager->overwriteModuleBasePath as $overwriteModuleId => $overwriteModulePath) {
-                if (isset($moduleIdFolders[$overwriteModuleId]) && $moduleIdFolders[$overwriteModuleId] !== $overwriteModulePath) {
-                    try {
-                        $moduleConfig = static::getModuleConfigByPath($overwriteModulePath);
-
-                        Yii::info(
-                            'Overwrite path of the module "' . $overwriteModuleId . '" to the folder "' . $overwriteModulePath . '"',
-                        );
-                        // Remove original config
-                        unset($modules[$moduleIdFolders[$overwriteModuleId]]);
-                        // Use config from the overwritten path
-                        $modules[$overwriteModulePath] = $moduleConfig;
-                        $moduleIdFolders[$overwriteModuleId] = $overwriteModulePath;
-                    } catch (\Throwable $e) {
-                        Yii::error($e);
-                    }
-                }
-            }
-        }
-
-        return $modules;
-    }
-
-    private static function getModuleConfigByPath(string $modulePath): array
-    {
-        return include $modulePath . DIRECTORY_SEPARATOR . self::CONFIGURATION_FILE;
-    }
-
-
-    /**
-     * Find all directories with a configuration file inside
-     *
-     * @param string $path
-     *
-     * @return string[]
-     * @throws InvalidArgumentException
-     */
-    private static function findModulesByPath(string $path): array
-    {
-        $hasConfigurationFile = (static fn($path) => is_file($path . DIRECTORY_SEPARATOR . self::CONFIGURATION_FILE));
-
-        return FileHelper::findDirectories(
-            Yii::getAlias($path, true),
-            ['filter' => $hasConfigurationFile, 'recursive' => false],
-        );
     }
 }

--- a/protected/humhub/migrations/m250405_072758_1_18_switch_to_humhub_theme_and_disable_themes.php
+++ b/protected/humhub/migrations/m250405_072758_1_18_switch_to_humhub_theme_and_disable_themes.php
@@ -2,6 +2,7 @@
 
 use humhub\components\InstallationState;
 use humhub\helpers\ThemeHelper;
+use humhub\services\ModuleService;
 use humhub\modules\user\helpers\LoginBackgroundImageHelper;
 use yii\db\Migration;
 
@@ -101,8 +102,9 @@ class m250405_072758_1_18_switch_to_humhub_theme_and_disable_themes extends Migr
         // Uninstall the Theme Builder module1
         $moduleManager = Yii::$app->moduleManager;
         $themeBuilderModuleId = 'theme-builder';
-        if ($moduleManager->getModule($themeBuilderModuleId, false)) {
-            $moduleManager->removeModule($themeBuilderModuleId);
+        $themeBuilderModule = $moduleManager->getModule($themeBuilderModuleId, false);
+        if ($themeBuilderModule) {
+            (new ModuleService($themeBuilderModule))->remove();
         }
 
         // Loop over all /themes/* folder and rename all old theme folders to e.g. /themes/Example.bs3.old

--- a/protected/humhub/modules/admin/controllers/ModuleController.php
+++ b/protected/humhub/modules/admin/controllers/ModuleController.php
@@ -142,14 +142,10 @@ class ModuleController extends Controller
 
         $moduleId = Yii::$app->request->get('moduleId');
 
-        if (Yii::$app->moduleManager->hasModule($moduleId) && Yii::$app->moduleManager->canRemoveModule($moduleId)) {
-            /* @var Module $module */
-            $module = Yii::$app->moduleManager->getModule($moduleId);
+        /* @var Module $module */
+        $module = Yii::$app->moduleManager->getModule($moduleId, false);
 
-            if ($module == null) {
-                throw new HttpException(500, Yii::t('AdminModule.modules', 'Could not find requested module!'));
-            }
-
+        if ($module !== null && $module->getModuleService()->canRemove()) {
             if (!is_writable(realpath($module->getBasePath()))) {
                 throw new HttpException(500, Yii::t('AdminModule.modules', 'Module path %path% is not writeable!', ['%path%' => $module->getBasePath()]));
             }

--- a/protected/humhub/modules/admin/jobs/RemoveModuleJob.php
+++ b/protected/humhub/modules/admin/jobs/RemoveModuleJob.php
@@ -10,6 +10,7 @@ namespace humhub\modules\admin\jobs;
 
 use humhub\modules\queue\ActiveJob;
 use humhub\modules\queue\interfaces\ExclusiveJobInterface;
+use humhub\services\ModuleService;
 use Yii;
 
 class RemoveModuleJob extends ActiveJob implements ExclusiveJobInterface
@@ -24,6 +25,7 @@ class RemoveModuleJob extends ActiveJob implements ExclusiveJobInterface
 
     public function run()
     {
-        Yii::$app->moduleManager->removeModule($this->moduleId);
+        $module = Yii::$app->moduleManager->getModule($this->moduleId);
+        (new ModuleService($module))->remove();
     }
 }

--- a/protected/humhub/modules/admin/widgets/InstalledModuleControls.php
+++ b/protected/humhub/modules/admin/widgets/InstalledModuleControls.php
@@ -78,7 +78,7 @@ class InstalledModuleControls extends Menu
             ]));
         }
 
-        if (Yii::$app->moduleManager->canRemoveModule($this->module->id)) {
+        if ($this->module->getModuleService()->canRemove()) {
             $this->addEntry(new MenuLink([
                 'id' => 'uninstall',
                 'label' => Yii::t('AdminModule.base', 'Uninstall'),

--- a/protected/humhub/modules/marketplace/commands/MarketplaceController.php
+++ b/protected/humhub/modules/marketplace/commands/MarketplaceController.php
@@ -9,8 +9,8 @@
 namespace humhub\modules\marketplace\commands;
 
 use humhub\components\Module;
-use humhub\models\ModuleEnabled;
 use humhub\modules\admin\libs\HumHubAPI;
+use humhub\services\ModuleService;
 use Yii;
 use yii\base\ErrorException;
 use yii\base\Exception;
@@ -127,7 +127,7 @@ class MarketplaceController extends Controller
             return;
         }
 
-        Yii::$app->moduleManager->removeModule($module->id);
+        (new ModuleService($module))->remove();
 
         print "\nModule " . $moduleId . " successfully uninstalled!\n";
     }

--- a/protected/humhub/modules/marketplace/commands/MarketplaceController.php
+++ b/protected/humhub/modules/marketplace/commands/MarketplaceController.php
@@ -9,6 +9,7 @@
 namespace humhub\modules\marketplace\commands;
 
 use humhub\components\Module;
+use humhub\models\ModuleEnabled;
 use humhub\modules\admin\libs\HumHubAPI;
 use humhub\services\ModuleService;
 use Yii;

--- a/protected/humhub/modules/marketplace/components/OnlineModuleManager.php
+++ b/protected/humhub/modules/marketplace/components/OnlineModuleManager.php
@@ -11,6 +11,8 @@ namespace humhub\modules\marketplace\components;
 use humhub\components\ModuleEvent;
 use humhub\models\ModuleEnabled;
 use humhub\modules\admin\libs\HumHubAPI;
+use humhub\services\ModuleDiscoveryService;
+use humhub\services\ModuleService;
 use humhub\modules\marketplace\models\Module as ModelModule;
 use humhub\modules\marketplace\Module;
 use humhub\modules\marketplace\services\MarketplaceService;
@@ -213,7 +215,10 @@ class OnlineModuleManager extends Component
             Yii::$app->setModule($moduleId, null);
         }
 
-        Yii::$app->moduleManager->removeModule($moduleId, false);
+        $moduleToRemove = Yii::$app->moduleManager->getModule($moduleId, false);
+        if ($moduleToRemove !== null) {
+            (new ModuleService($moduleToRemove))->remove(false);
+        }
 
         $this->install($moduleId);
 
@@ -335,22 +340,40 @@ class OnlineModuleManager extends Component
         $updates = [];
 
         foreach ($this->getModules($cached) as $moduleId => $moduleInfo) {
+            if (!isset($moduleInfo['latestCompatibleVersion'])) {
+                continue;
+            }
 
-            if (isset($moduleInfo['latestCompatibleVersion']) && Yii::$app->moduleManager->hasModule($moduleId)) {
+            $installedVersion = $this->getInstalledVersion($moduleId);
+            if ($installedVersion === null) {
+                continue;
+            }
 
-                $module = Yii::$app->moduleManager->getModule($moduleId);
-
-                if ($module !== null) {
-                    if (version_compare($moduleInfo['latestCompatibleVersion'], $module->getVersion(), 'gt')) {
-                        $updates[$moduleId] = $moduleInfo;
-                    }
-                } else {
-                    Yii::error('Could not load module: ' . $moduleId . ' to get updates');
-                }
+            if (version_compare($moduleInfo['latestCompatibleVersion'], $installedVersion, 'gt')) {
+                $updates[$moduleId] = $moduleInfo;
             }
         }
 
         return $updates;
+    }
+
+    /**
+     * Returns the installed version of a module.
+     *
+     * Prefers the loaded module instance for accuracy; falls back to reading module.json
+     * from the filesystem when the module could not be loaded (e.g. during upgrades when
+     * the module config references a removed core class).
+     */
+    private function getInstalledVersion(string $moduleId): ?string
+    {
+        if (Yii::$app->moduleManager->hasModule($moduleId)) {
+            $module = Yii::$app->moduleManager->getModule($moduleId, false);
+            if ($module !== null) {
+                return $module->getVersion();
+            }
+        }
+
+        return ModuleDiscoveryService::findInstalledVersion($moduleId);
     }
 
     /**

--- a/protected/humhub/services/ModuleDiscoveryService.php
+++ b/protected/humhub/services/ModuleDiscoveryService.php
@@ -1,0 +1,260 @@
+<?php
+
+/*
+ * @link https://www.humhub.org/
+ * @copyright Copyright (c) 2026 HumHub GmbH & Co. KG
+ * @license https://www.humhub.com/licences
+ */
+
+namespace humhub\services;
+
+use Yii;
+use yii\base\InvalidArgumentException;
+use yii\helpers\ArrayHelper;
+use yii\helpers\FileHelper;
+use yii\helpers\Json;
+
+/**
+ * ModuleDiscoveryService is the single place for all module discovery.
+ *
+ * It provides two tiers:
+ *
+ * **Safe discovery** (no config.php loaded) — used during upgrades when module configs may
+ * reference core classes that have been removed:
+ * - {@see scanPath()} — list subdirectories of an alias path
+ * - {@see findMigrationPaths()} — locate module migration directories by filesystem convention
+ * - {@see findInstalledModules()} — read module metadata from module.json files
+ *
+ * **Full config loading** — used during normal application bootstrap:
+ * - {@see locateModuleConfigs()} — cached scan of all moduleAutoloadPaths, returns config.php arrays
+ * - {@see loadModuleConfigs()} — uncached, loads config.php from the given paths
+ *
+ * @since 1.19
+ */
+class ModuleDiscoveryService
+{
+    public const CACHE_ID = 'module_configs';
+    public const CONFIGURATION_FILE = 'config.php';
+    public const CORE_MODULE_PATH = '@humhub/modules';
+
+    // -------------------------------------------------------------------------
+    // Safe discovery — no config.php loading
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns all immediate subdirectories of a resolved alias path.
+     *
+     * Shared scanning primitive for all find* methods and for {@see ModuleAutoLoader}.
+     * Returns an empty array for invalid or missing paths.
+     *
+     * @return string[] absolute directory paths
+     */
+    public static function scanPath(string $path): array
+    {
+        $resolvedPath = Yii::getAlias($path, false);
+        if ($resolvedPath === false || !is_dir($resolvedPath)) {
+            return [];
+        }
+
+        try {
+            return FileHelper::findDirectories($resolvedPath, ['recursive' => false]);
+        } catch (InvalidArgumentException) {
+            return [];
+        }
+    }
+
+    /**
+     * Returns migration directory paths for all modules discovered by filesystem convention.
+     *
+     * Scans all paths listed in the `moduleAutoloadPaths` application parameter for
+     * subdirectories containing a `migrations/` folder. The module ID is read from
+     * `module.json`; directories without a valid `module.json` are skipped.
+     * No module config.php is loaded.
+     *
+     * @param string $coreBasePath alias path to the core migration directory (e.g. '@humhub/migrations')
+     * @return array<string, string> map of [moduleId => absoluteMigrationsPath], with key 'base' for core
+     */
+    public static function findMigrationPaths(string $coreBasePath): array
+    {
+        $paths = ['base' => $coreBasePath];
+
+        foreach (Yii::$app->params['moduleAutoloadPaths'] as $autoloadPath) {
+            foreach (self::scanPath($autoloadPath) as $moduleDir) {
+                $migrationsDir = $moduleDir . DIRECTORY_SEPARATOR . 'migrations';
+                if (!is_dir($migrationsDir)) {
+                    continue;
+                }
+
+                $moduleId = self::readModuleId($moduleDir);
+                if ($moduleId !== null) {
+                    $paths[$moduleId] = $migrationsDir;
+                }
+            }
+        }
+
+        return $paths;
+    }
+
+    /**
+     * Returns metadata for all installed modules by reading their module.json files.
+     *
+     * No module config.php is loaded. Modules without a module.json are ignored.
+     *
+     * @return array<string, array{basePath: string, version: string|null}> map of moduleId => metadata
+     */
+    public static function findInstalledModules(): array
+    {
+        $modules = [];
+
+        foreach (Yii::$app->params['moduleAutoloadPaths'] as $autoloadPath) {
+            foreach (self::scanPath($autoloadPath) as $moduleDir) {
+                $moduleJsonPath = $moduleDir . DIRECTORY_SEPARATOR . 'module.json';
+                if (!file_exists($moduleJsonPath)) {
+                    continue;
+                }
+
+                try {
+                    $info = Json::decode(file_get_contents($moduleJsonPath));
+                    $moduleId = $info['id'] ?? null;
+                    if ($moduleId !== null) {
+                        $modules[$moduleId] = [
+                            'basePath' => $moduleDir,
+                            'version' => $info['version'] ?? null,
+                        ];
+                    }
+                } catch (\Throwable) {
+                    // malformed module.json — skip
+                }
+            }
+        }
+
+        return $modules;
+    }
+
+    /**
+     * Returns the base path of an installed module, or null if not found.
+     */
+    public static function findModuleBasePath(string $moduleId): ?string
+    {
+        return self::findInstalledModules()[$moduleId]['basePath'] ?? null;
+    }
+
+    /**
+     * Returns the installed version of a module read from its module.json, or null if not found.
+     */
+    public static function findInstalledVersion(string $moduleId): ?string
+    {
+        return self::findInstalledModules()[$moduleId]['version'] ?? null;
+    }
+
+    /**
+     * Returns the module ID declared in a module's module.json, or null if the file is absent or malformed.
+     */
+    private static function readModuleId(string $modulePath): ?string
+    {
+        $moduleJsonPath = $modulePath . DIRECTORY_SEPARATOR . 'module.json';
+        if (!file_exists($moduleJsonPath)) {
+            return null;
+        }
+
+        try {
+            $info = Json::decode(file_get_contents($moduleJsonPath));
+            return $info['id'] ?? null;
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Full config loading — loads config.php
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns all available module configurations, reading from cache when possible.
+     *
+     * Scans `moduleAutoloadPaths` and loads each module's config.php. The result is cached
+     * unless {@see YII_DEBUG} is enabled.
+     *
+     * @return array[] module configurations keyed by base path
+     */
+    public static function locateModuleConfigs(): array
+    {
+        $modules = Yii::$app->cache->get(self::CACHE_ID);
+
+        if ($modules === false || YII_DEBUG) {
+            $modules = static::loadModuleConfigs(Yii::$app->params['moduleAutoloadPaths']);
+            Yii::$app->cache->set(self::CACHE_ID, $modules);
+        }
+
+        return $modules;
+    }
+
+    /**
+     * Loads module configurations from the given paths by including each module's config.php.
+     *
+     * Handles duplicate module IDs and path overwrites configured in ModuleManager.
+     * Errors in individual config.php files are logged and skipped.
+     *
+     * @param iterable<string> $paths alias paths to scan
+     * @return array[] module configurations keyed by base path
+     */
+    public static function loadModuleConfigs(iterable $paths): array
+    {
+        $folders = [];
+        foreach ($paths as $path) {
+            $dirs = array_filter(
+                self::scanPath($path),
+                static fn(string $dir) => is_file($dir . DIRECTORY_SEPARATOR . self::CONFIGURATION_FILE),
+            );
+            $folders = array_merge($folders, $dirs);
+        }
+
+        $modules = [];
+        $moduleIdFolders = [];
+        $preventDuplicates = Yii::$app->moduleManager->preventDuplicatedModules;
+
+        foreach ($folders as $folder) {
+            try {
+                $moduleConfig = static::readModuleConfig($folder);
+                if ($preventDuplicates && isset($moduleIdFolders[$moduleConfig['id']])) {
+                    Yii::error(
+                        'Duplicated module "' . $moduleConfig['id'] . '" (' . $folder . ') is already loaded from "' . $moduleIdFolders[$moduleConfig['id']] . '"',
+                    );
+                } else {
+                    $modules[$folder] = $moduleConfig;
+                    $moduleIdFolders[$moduleConfig['id']] = $folder;
+                }
+            } catch (\Throwable $e) {
+                Yii::error($e);
+            }
+        }
+
+        if ($preventDuplicates) {
+            foreach (Yii::$app->moduleManager->overwriteModuleBasePath as $overwriteId => $overwritePath) {
+                if (isset($moduleIdFolders[$overwriteId]) && $moduleIdFolders[$overwriteId] !== $overwritePath) {
+                    try {
+                        $moduleConfig = static::readModuleConfig($overwritePath);
+                        Yii::info('Overwrite path of module "' . $overwriteId . '" to "' . $overwritePath . '"');
+                        unset($modules[$moduleIdFolders[$overwriteId]]);
+                        $modules[$overwritePath] = $moduleConfig;
+                        $moduleIdFolders[$overwriteId] = $overwritePath;
+                    } catch (\Throwable $e) {
+                        Yii::error($e);
+                    }
+                }
+            }
+        }
+
+        return $modules;
+    }
+
+    /**
+     * Includes and returns the config.php for a module at the given path.
+     *
+     * @return array the module configuration
+     */
+    public static function readModuleConfig(string $modulePath): array
+    {
+        return include $modulePath . DIRECTORY_SEPARATOR . self::CONFIGURATION_FILE;
+    }
+}

--- a/protected/humhub/services/ModuleService.php
+++ b/protected/humhub/services/ModuleService.php
@@ -1,0 +1,198 @@
+<?php
+
+/*
+ * @link https://www.humhub.org/
+ * @copyright Copyright (c) 2026 HumHub GmbH & Co. KG
+ * @license https://www.humhub.com/licences
+ */
+
+namespace humhub\services;
+
+use humhub\components\Module;
+use humhub\components\ModuleEvent;
+use humhub\components\ModuleManager;
+use humhub\models\ModuleEnabled;
+use humhub\modules\marketplace\Module as MarketplaceModule;
+use Yii;
+use yii\base\ErrorException;
+use yii\base\Exception;
+use yii\helpers\FileHelper;
+use yii\web\ServerErrorHttpException;
+
+/**
+ * ModuleService handles lifecycle and removal operations for a single module instance.
+ *
+ * Obtain an instance via the module:
+ * ```php
+ * $module->getModuleService()->canRemove();
+ * $module->getModuleService()->remove();
+ * ```
+ *
+ * **Extension point for module authors:** override {@see Module::enable()} and
+ * {@see Module::disable()} in your Module class — not the methods here. The `enable()`
+ * and `disable()` methods on this service are `@internal` building blocks called by
+ * `Module::enable()` / `Module::disable()` and are not part of the public API.
+ *
+ * @since 1.19
+ */
+class ModuleService
+{
+    public function __construct(private readonly Module $module)
+    {
+    }
+
+    /**
+     * Registers the module as enabled: saves the DB record, updates in-memory state,
+     * re-registers the module config, flushes the module cache, and fires the enable
+     * events on ModuleManager.
+     *
+     * This is the **registration step only** — it does not run database migrations.
+     * Call {@see Module::enable()} for the full enable flow including migrations.
+     *
+     * To add custom logic at enable time, override {@see Module::enable()} in your
+     * Module class rather than this method.
+     *
+     * @internal called by {@see Module::enable()}
+     * @throws ServerErrorHttpException if module requirements are not met
+     */
+    public function enable(): void
+    {
+        $this->checkRequirements();
+
+        $moduleManager = $this->getModuleManager();
+
+        $moduleManager->trigger(
+            ModuleManager::EVENT_BEFORE_MODULE_ENABLE,
+            new ModuleEvent(['module' => $this->module]),
+        );
+
+        if (!ModuleEnabled::findOne(['module_id' => $this->module->id])) {
+            (new ModuleEnabled([
+                'module_id' => $this->module->id,
+                'version' => $this->module->version,
+            ]))->save();
+        }
+
+        $moduleManager->markAsEnabled($this->module->id);
+        $moduleManager->register($this->module->getBasePath());
+        $moduleManager->flushCache();
+
+        $moduleManager->trigger(
+            ModuleManager::EVENT_AFTER_MODULE_ENABLE,
+            new ModuleEvent(['module' => $this->module]),
+        );
+    }
+
+    /**
+     * Deregisters the module: removes the DB record, updates in-memory state, unsets the module
+     * from the application, flushes the module cache, and fires the disable events on ModuleManager.
+     *
+     * This is the **deregistration step only** — it does not run uninstall migrations or clean up
+     * module data. Call {@see Module::disable()} for the full disable flow.
+     *
+     * To add custom cleanup logic at disable time, override {@see Module::disable()} in your
+     * Module class rather than this method.
+     *
+     * @internal called by {@see Module::disable()}
+     */
+    public function disable(): void
+    {
+        $moduleManager = $this->getModuleManager();
+
+        $moduleManager->trigger(
+            ModuleManager::EVENT_BEFORE_MODULE_DISABLE,
+            new ModuleEvent(['module' => $this->module]),
+        );
+
+        $moduleEnabled = ModuleEnabled::findOne(['module_id' => $this->module->id]);
+        if ($moduleEnabled !== null) {
+            $moduleEnabled->delete();
+        }
+
+        $moduleManager->markAsDisabled($this->module->id);
+        Yii::$app->setModule($this->module->id, null);
+        $moduleManager->flushCache();
+
+        $moduleManager->trigger(
+            ModuleManager::EVENT_AFTER_MODULE_DISABLE,
+            new ModuleEvent(['module' => $this->module]),
+        );
+    }
+
+    /**
+     * Returns true if the module can be removed (i.e. is located in the marketplace module directory).
+     */
+    public function canRemove(): bool
+    {
+        /** @var MarketplaceModule|null $marketplaceModule */
+        $marketplaceModule = Yii::$app->getModule('marketplace');
+        if ($marketplaceModule === null) {
+            return false;
+        }
+
+        $modulePath = FileHelper::normalizePath($this->module->getBasePath());
+        $marketplacePath = FileHelper::normalizePath(realpath(Yii::getAlias($marketplaceModule->modulesPath)));
+
+        return str_contains($modulePath, $marketplacePath);
+    }
+
+    /**
+     * Removes the module directory, optionally disabling it first.
+     *
+     * When {@see ModuleManager::$createBackup} is enabled (default), a backup copy is created
+     * under `@runtime/module_backups/` before deletion.
+     *
+     * @return string|null path to the backup directory, or null if no backup was created
+     * @throws Exception
+     * @throws ErrorException
+     */
+    public function remove(bool $disableBeforeRemove = true): ?string
+    {
+        if ($disableBeforeRemove && Yii::$app->hasModule($this->module->id)) {
+            $this->module->disable();
+        }
+
+        $moduleManager = $this->getModuleManager();
+
+        if ($moduleManager->createBackup) {
+            $backupFolder = Yii::getAlias('@runtime/module_backups');
+            FileHelper::createDirectory($backupFolder);
+
+            $backupPath = $backupFolder . DIRECTORY_SEPARATOR . $this->module->id . '_' . time();
+            FileHelper::copyDirectory($this->module->getBasePath(), $backupPath);
+            FileHelper::removeDirectory($this->module->getBasePath());
+        } else {
+            $backupPath = null;
+            // TODO: Delete directory
+        }
+
+        $moduleManager->flushCache();
+
+        return $backupPath;
+    }
+
+    /**
+     * Checks whether the module's requirements are satisfied.
+     *
+     * @throws ServerErrorHttpException if a requirement is not met
+     */
+    public function checkRequirements(): void
+    {
+        $requirementsPath = $this->module->getBasePath() . DIRECTORY_SEPARATOR . 'requirements.php';
+        if (!file_exists($requirementsPath)) {
+            return;
+        }
+
+        $result = include $requirementsPath;
+
+        if (is_string($result)) {
+            Yii::error('Error enabling the "' . $this->module->id . '" module: ' . $result, 'module');
+            throw new ServerErrorHttpException($result);
+        }
+    }
+
+    private function getModuleManager(): ModuleManager
+    {
+        return Yii::$app->moduleManager;
+    }
+}

--- a/protected/humhub/tests/codeception/_support/HumHubApiTestCest.php
+++ b/protected/humhub/tests/codeception/_support/HumHubApiTestCest.php
@@ -28,7 +28,7 @@ class HumHubApiTestCest
             return;
         }
 
-        Yii::$app->moduleManager->enableModules(['rest']);
+        Yii::$app->moduleManager->getModule('rest')->enable();
 
         /* @var Module $module */
         $module = Yii::$app->moduleManager->getModule('rest');

--- a/protected/humhub/tests/codeception/_support/HumHubDbTestCase.php
+++ b/protected/humhub/tests/codeception/_support/HumHubDbTestCase.php
@@ -91,7 +91,9 @@ class HumHubDbTestCase extends Unit
         $cfg = Configuration::config();
 
         if (!empty($cfg['humhub_modules'])) {
-            Yii::$app->moduleManager->enableModules($cfg['humhub_modules']);
+            foreach ($cfg['humhub_modules'] as $moduleId) {
+                Yii::$app->moduleManager->getModule($moduleId)->enable();
+            }
         }
     }
 

--- a/protected/humhub/tests/codeception/_support/HumHubHelper.php
+++ b/protected/humhub/tests/codeception/_support/HumHubHelper.php
@@ -91,7 +91,9 @@ class HumHubHelper extends Module
     {
         $modules = array_map(fn(Module $module) => $module->id, Yii::$app->moduleManager->getModules());
 
-        Yii::$app->moduleManager->disableModules($modules);
+        foreach ($modules as $moduleId) {
+            Yii::$app->moduleManager->getModule($moduleId)?->disable();
+        }
 
         if (!empty($this->config['modules'])) {
             foreach ($this->config['modules'] as $moduleId) {

--- a/protected/humhub/tests/codeception/_support/WebHelper.php
+++ b/protected/humhub/tests/codeception/_support/WebHelper.php
@@ -38,7 +38,9 @@ class WebHelper extends Module
     {
         $cfg = \Codeception\Configuration::config();
         if (!empty($cfg['humhub_modules'])) {
-            Yii::$app->moduleManager->enableModules($cfg['humhub_modules']);
+            foreach ($cfg['humhub_modules'] as $moduleId) {
+                Yii::$app->moduleManager->getModule($moduleId)->enable();
+            }
         }
     }
 

--- a/protected/humhub/tests/codeception/unit/components/ModuleManagerTest.php
+++ b/protected/humhub/tests/codeception/unit/components/ModuleManagerTest.php
@@ -17,6 +17,7 @@ use humhub\components\ModuleManager;
 use humhub\exceptions\InvalidArgumentTypeException;
 use humhub\models\ModuleEnabled;
 use humhub\modules\admin\events\ModulesEvent;
+use humhub\services\ModuleService;
 use humhub\tests\codeception\unit\ModuleAutoLoaderTest;
 use Some\Name\Space\module1\Module as Module1;
 use Some\Name\Space\module2\Module as Module2;
@@ -465,16 +466,16 @@ class ModuleManagerTest extends HumHubDbTestCase
         [$basePath, $config] = $this->getModuleConfig(static::$testModuleRoot . '/module1');
 
         // cannot be removed, since it does not exist
-        static::assertFalse($this->moduleManager->canRemoveModule($this->moduleId));
+        static::assertFalse($this->moduleManager->getModule($this->moduleId, false)?->getModuleService()->canRemove() ?? false);
 
         $module = $this->registerModuleAsEnabled($basePath, $config);
 
-        static::assertTrue($this->moduleManager->canRemoveModule($this->moduleId));
+        static::assertTrue($module->getModuleService()->canRemove());
 
         $module->setBasePath(static::$coreModuleRoot . "/admin");
 
         // cannot be removed, since it does not exist within the marketplace dir
-        static::assertFalse($this->moduleManager->canRemoveModule($this->moduleId));
+        static::assertFalse($module->getModuleService()->canRemove());
     }
 
     /**
@@ -494,7 +495,7 @@ class ModuleManagerTest extends HumHubDbTestCase
         $module->setBasePath($tmp);
 
         static::assertTrue($this->moduleManager->createBackup);
-        $backup = $this->moduleManager->removeModule($this->moduleId, false);
+        $backup = (new ModuleService($module))->remove(false);
 
         static::assertDirectoryDoesNotExist($tmp);
         static::assertDirectoryExists($backup);
@@ -506,7 +507,7 @@ class ModuleManagerTest extends HumHubDbTestCase
         $tmp = $this->createTempDir();
         $module->setBasePath($tmp);
 
-        $backup = $this->moduleManager->removeModule($this->moduleId, false);
+        $backup = (new ModuleService($module))->remove(false);
 
         static::assertNull($backup);
         static::assertDirectoryExists($tmp);
@@ -538,7 +539,7 @@ class ModuleManagerTest extends HumHubDbTestCase
 
         static::assertRecordCount(0, ModuleEnabled::tableName(), ['module_id' => $this->moduleId]);
 
-        $this->moduleManager->enable($module);
+        $module->getModuleService()->enable();
 
         static::assertRecordCount(1, ModuleEnabled::tableName(), ['module_id' => $this->moduleId]);
 
@@ -562,7 +563,7 @@ class ModuleManagerTest extends HumHubDbTestCase
             ],
         ]);
 
-        $this->moduleManager->disable($module);
+        $module->getModuleService()->disable();
 
         static::assertCount(count(static::$moduleEnabledList), $this->moduleManager->myEnabledModules());
         static::assertRecordCount(0, ModuleEnabled::tableName(), ['module_id' => $this->moduleId]);
@@ -619,7 +620,8 @@ class ModuleManagerTest extends HumHubDbTestCase
 
         static::logInitialize();
 
-        $this->moduleManager->enableModules([$module, static::$testModuleRoot . '/module2']);
+        $module->enable();
+        $this->moduleManager->getModule(static::$testModuleRoot . '/module2')->enable();
 
         Yii::$app->set('moduleManager', $oldMM);
 
@@ -672,7 +674,7 @@ class ModuleManagerTest extends HumHubDbTestCase
             'Could not find/load requested module: ' . static::$testModuleRoot . '/non-existing-module',
         );
 
-        $this->moduleManager->enableModules([static::$testModuleRoot . '/non-existing-module']);
+        $this->moduleManager->getModule(static::$testModuleRoot . '/non-existing-module');
     }
 
     /**
@@ -757,10 +759,8 @@ class ModuleManagerTest extends HumHubDbTestCase
     {
         Yii::$app->set('moduleManager', $this->moduleManager);
 
-        $this->moduleManager->enableModules([
-            static::$testModuleRoot . '/module1',
-            static::$testModuleRoot . '/module2',
-        ]);
+        $this->moduleManager->getModule(static::$testModuleRoot . '/module1')->enable();
+        $this->moduleManager->getModule(static::$testModuleRoot . '/module2')->enable();
 
         static::assertEquals(
             ['module1' => Module1::class, 'module2' => Module2::class],

--- a/protected/humhub/tests/codeception/unit/components/ModuleManagerTest.php
+++ b/protected/humhub/tests/codeception/unit/components/ModuleManagerTest.php
@@ -10,13 +10,13 @@
 
 namespace humhub\tests\codeception\unit\components;
 
-use humhub\components\bootstrap\ModuleAutoLoader;
 use humhub\components\InstallationState;
 use humhub\components\ModuleEvent;
 use humhub\components\ModuleManager;
 use humhub\exceptions\InvalidArgumentTypeException;
 use humhub\models\ModuleEnabled;
 use humhub\modules\admin\events\ModulesEvent;
+use humhub\services\ModuleDiscoveryService;
 use humhub\services\ModuleService;
 use humhub\tests\codeception\unit\ModuleAutoLoaderTest;
 use Some\Name\Space\module1\Module as Module1;
@@ -487,6 +487,9 @@ class ModuleManagerTest extends HumHubDbTestCase
     {
         $this->skipIfMarketplaceNotEnabled();
 
+        $oldMM = Yii::$app->moduleManager;
+        Yii::$app->set('moduleManager', $this->moduleManager);
+
         [$basePath, $config] = $this->getModuleConfig(static::$testModuleRoot . '/module1');
 
         $module = $this->registerModuleAsEnabled($basePath, $config);
@@ -513,6 +516,8 @@ class ModuleManagerTest extends HumHubDbTestCase
         static::assertDirectoryExists($tmp);
 
         FileHelper::removeDirectory($tmp);
+
+        Yii::$app->set('moduleManager', $oldMM);
     }
 
     /**
@@ -526,6 +531,9 @@ class ModuleManagerTest extends HumHubDbTestCase
      */
     public function testEnableAndDisableModules()
     {
+        $oldMM = Yii::$app->moduleManager;
+        Yii::$app->set('moduleManager', $this->moduleManager);
+
         $this->moduleManager->on(ModuleManager::EVENT_BEFORE_MODULE_ENABLE, $this->handleEvent(...));
         $this->moduleManager->on(ModuleManager::EVENT_AFTER_MODULE_ENABLE, $this->handleEvent(...));
         $this->moduleManager->on(ModuleManager::EVENT_BEFORE_MODULE_DISABLE, $this->handleEvent(...));
@@ -588,6 +596,8 @@ class ModuleManagerTest extends HumHubDbTestCase
                 'module' => ['module1' => Module1::class],
             ],
         ]);
+
+        Yii::$app->set('moduleManager', $oldMM);
     }
 
     /**
@@ -889,13 +899,13 @@ class ModuleManagerTest extends HumHubDbTestCase
         Yii::$app->set('cache', new ArrayCache());
         static::assertInstanceOf(ArrayCache::class, $cache = Yii::$app->cache);
 
-        static::assertFalse($cache->get(ModuleAutoLoader::CACHE_ID));
-        Yii::$app->cache->set(ModuleAutoLoader::CACHE_ID, ['foo' => 'bar']);
-        static::assertEquals(['foo' => 'bar'], $cache->get(ModuleAutoLoader::CACHE_ID));
+        static::assertFalse($cache->get(ModuleDiscoveryService::CACHE_ID));
+        Yii::$app->cache->set(ModuleDiscoveryService::CACHE_ID, ['foo' => 'bar']);
+        static::assertEquals(['foo' => 'bar'], $cache->get(ModuleDiscoveryService::CACHE_ID));
 
         $this->moduleManager->flushCache();
 
-        static::assertFalse($cache->get(ModuleAutoLoader::CACHE_ID));
+        static::assertFalse($cache->get(ModuleDiscoveryService::CACHE_ID));
 
         Yii::$app->set('cache', $oldCache);
     }

--- a/protected/humhub/tests/codeception/unit/components/bootstrap/ModuleAutoLoaderTest.php
+++ b/protected/humhub/tests/codeception/unit/components/bootstrap/ModuleAutoLoaderTest.php
@@ -9,7 +9,7 @@
 namespace humhub\tests\codeception\unit;
 
 use Codeception\Test\Unit;
-use humhub\components\bootstrap\ModuleAutoLoader;
+use humhub\services\ModuleDiscoveryService;
 use Yii;
 
 /**
@@ -54,7 +54,7 @@ class ModuleAutoLoaderTest extends Unit
     public function testCoreModuleLoading()
     {
         $modules = array_column(
-            ModuleAutoLoader::locateModules(),
+            ModuleDiscoveryService::locateModuleConfigs(),
             'id',
         );
 
@@ -63,17 +63,14 @@ class ModuleAutoLoaderTest extends Unit
     }
 
     /**
-     * Test that an invalid path for module loading leads to an exception
+     * Test that an invalid path for module loading is silently skipped
      */
     public function testInvalidModulePath()
     {
         array_push(Yii::$app->params['moduleAutoloadPaths'], '/dev/null');
 
-        try {
-            ModuleAutoLoader::locateModules();
-            $this->fail('no expection when invalid path for moduleAutoloadPaths');
-        } catch (\ErrorException) {
-        }
+        $modules = ModuleDiscoveryService::locateModuleConfigs();
+        static::assertIsArray($modules);
 
         array_pop(Yii::$app->params['moduleAutoloadPaths']);
     }


### PR DESCRIPTION
## Summary

- **`ModuleDiscoveryService`** — centralises all module filesystem discovery. Two tiers: *safe discovery* (no `config.php` loading) for migration paths and installed-module metadata; *full config loading* for bootstrap.
- **`ModuleService`** — plain PHP class instantiated per module (like `MigrationService`) that encapsulates all lifecycle operations: `enable()`, `disable()`, `canRemove()`, `remove()`. `Module::enable()` / `Module::disable()` remain as documented extension points for module authors and delegate to `ModuleService` internally.
- **`ModuleAutoLoader`** slimmed to ~110 lines — pure bootstrap orchestrator, all discovery delegated to `ModuleDiscoveryService`. Deprecated constants `CACHE_ID` and `CORE_MODULE_PATH` removed (no external usage found); `CONFIGURATION_FILE` kept as deprecated alias (`humhub/rest` references it).
- **`ModuleManager`** lifecycle methods removed after migrating all callers: `enable()`, `disable()`, `removeModule()`, `canRemoveModule()`, `enableModules()`, `disableModules()`. Adds `markAsEnabled()` / `markAsDisabled()` as `@internal` helpers for `ModuleService`.

## Notes

- `Module::enable()` / `Module::disable()` are kept and documented as the intended extension point for module authors — ~60 external modules override them. `ModuleService::enable()` / `disable()` are marked `@internal`.
- `#[WithoutModuleAutoload]` for `migrate/up` and `marketplace/*` is intentionally excluded — that requires a separate design decision around module class autoloading during migrations.

## Test plan

- [ ] Enable / disable a module via the admin UI
- [ ] Remove a module via the admin UI
- [ ] Run `php yii migrate/up` — module migrations still run correctly
- [ ] Run `php yii marketplace/update-all`
- [ ] Run the `ModuleManagerTest` suite