### PR TITLE
Enh: Refactor MarketplaceController and MigrateController CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ HumHub Changelog
 ----------
 - Enh: Added `#[WithoutModuleAutoload]` attribute for console controllers that do not require module loading (e.g. `settings/*`, `cache/*`)
 - Enh #8214: Introduced `ModuleDiscoveryService` centralising all module filesystem discovery and `ModuleService` encapsulating per-module lifecycle operations (enable, disable, remove); slimmed down `ModuleAutoLoader` and `ModuleManager`
+- Enh: Refactored `MarketplaceController` CLI — skips third-party module autoloading at bootstrap (`#[WithoutModuleAutoload]`), loads each module on demand, and runs `update-all` sub-updates in isolated subprocesses
 - Enh: Icon-only `Button` automatically derives `aria-label` from tooltip; logs a warning in `YII_DEBUG` mode when neither is set
 - Enh: Improved community module handling in the marketplace — admins can opt in via a new "Include community modules" option to show modules contributed by the community
 - Fix #8181: Encoded HTML entities in notification mail subjects

--- a/protected/humhub/commands/MigrateController.php
+++ b/protected/humhub/commands/MigrateController.php
@@ -8,7 +8,6 @@
 
 namespace humhub\commands;
 
-use humhub\components\console\WithoutModuleAutoload;
 use humhub\components\Module;
 use humhub\helpers\DatabaseHelper;
 use humhub\services\ModuleDiscoveryService;
@@ -59,7 +58,6 @@ use yii\web\Application;
  * @property-read string[] $newMigrations
  * @property-read string[] $migrationPaths
  */
-#[WithoutModuleAutoload]
 class MigrateController extends \yii\console\controllers\MigrateController
 {
     /**
@@ -69,9 +67,15 @@ class MigrateController extends \yii\console\controllers\MigrateController
     public $migrationPath = '@humhub/migrations';
 
     /**
-     * @var bool also include migration paths of all enabled modules
+     * Whether to include migration paths of all enabled modules (1=yes, 0=no).
+     *
+     * Use 0/1 on the CLI — Yii2 coerces CLI values via settype(), so the string
+     * "false" becomes bool true. Both --includeModuleMigrations=0 and
+     * --includeModuleMigrations=false map to falsy with an int property.
+     *
+     * @var int
      */
-    public bool $includeModuleMigrations = true;
+    public int $includeModuleMigrations = 1;
 
     /**
      * When set, only migrations for the specified module are applied.
@@ -209,9 +213,17 @@ class MigrateController extends \yii\console\controllers\MigrateController
      */
     protected function getMigrationPaths(): array
     {
-        // Single-module mode: load just that module and return only its migration path.
-        // Does not include core — intended to be called after core migrations have already run.
+        // Single-module mode: run migrations only for one specific module.
+        // Intended to be called after core migrations have already run (e.g. from module/update-all).
         if ($this->moduleId !== null) {
+            // Module is normally registered at bootstrap. Fall back to manual registration if
+            // it was skipped (e.g. its config.php threw during the initial bootstrap scan).
+            $module = Yii::$app->moduleManager->getModule($this->moduleId, false);
+            if ($module !== null) {
+                $migrationsPath = $module->getBasePath() . DIRECTORY_SEPARATOR . 'migrations';
+                return is_dir($migrationsPath) ? [$this->moduleId => $migrationsPath] : [];
+            }
+
             $basePath = ModuleDiscoveryService::findModuleBasePath($this->moduleId);
             if ($basePath === null) {
                 return [];
@@ -228,23 +240,11 @@ class MigrateController extends \yii\console\controllers\MigrateController
             return is_dir($migrationsPath) ? [$this->moduleId => $migrationsPath] : [];
         }
 
-        // All-modules mode: collect migration paths from two sources without mutating the module manager.
-        //
-        // 1. Third-party modules: read migration paths directly from locateModuleConfigs() output.
-        //    We intentionally do NOT call registerBulk() here — registering all modules as a side
-        //    effect of getMigrationPaths() would corrupt test isolation and contaminate any
-        //    ModuleManager instance that callers have injected via Yii::$app->set('moduleManager').
-        //
-        // 2. Core modules: already registered at bootstrap (#[WithoutModuleAutoload] still loads
-        //    @humhub/modules), so we can resolve their paths via ReflectionClass.
+        // All-modules mode: all modules are already registered at bootstrap by ModuleAutoLoader.
+        // Yii::$app->getModules() has both core and third-party modules; resolve paths via reflection.
+        // We intentionally do NOT call registerBulk() here — that would contaminate any
+        // ModuleManager injected by tests via Yii::$app->set('moduleManager').
         $migrationPaths = ['base' => $this->migrationPath];
-
-        foreach (ModuleDiscoveryService::locateModuleConfigs() as $basePath => $config) {
-            $migrationsPath = $basePath . DIRECTORY_SEPARATOR . 'migrations';
-            if (is_dir($migrationsPath)) {
-                $migrationPaths[$config['id']] = $migrationsPath;
-            }
-        }
 
         foreach (Yii::$app->getModules() as $id => $config) {
             if (isset($migrationPaths[$id])) {

--- a/protected/humhub/commands/MigrateController.php
+++ b/protected/humhub/commands/MigrateController.php
@@ -242,31 +242,11 @@ class MigrateController extends \yii\console\controllers\MigrateController
             return is_dir($migrationsPath) ? [$this->moduleId => $migrationsPath] : [];
         }
 
-        // All-modules mode: #[WithoutModuleAutoload] means third-party modules are NOT registered
-        // at bootstrap (to avoid old module configs executing against a newer core during upgrades).
-        //
-        // We still need two things from those modules:
-        //   1. Their migration paths — read directly from locateModuleConfigs() output.
-        //   2. PHP class autoloading for migration files that reference module models.
-        //      Yii resolves classes via aliases set in ModuleManager::register(). We replicate
-        //      only the alias setup here — intentionally skipping the full register()/registerBulk()
-        //      to avoid (a) bootstrap side-effects and (b) contaminating a mock ModuleManager
-        //      injected by tests via Yii::$app->set('moduleManager').
+        // All-modules mode: third-party modules are not registered at bootstrap
+        // (#[WithoutModuleAutoload] skips them to avoid stale configs running against a new core).
+        // Read migration paths directly from locateModuleConfigs() — no registerBulk() needed,
+        // which would contaminate a mock ModuleManager injected by tests.
         $configs = ModuleDiscoveryService::locateModuleConfigs();
-
-        foreach ($configs as $basePath => $config) {
-            if (!empty($config['namespace'])) {
-                Yii::setAlias('@' . str_replace('\\', '/', $config['namespace']), $basePath);
-            }
-            if (!empty($config['id'])) {
-                Yii::setAlias('@' . $config['id'], $basePath);
-            }
-            if (!empty($config['aliases']) && is_array($config['aliases'])) {
-                foreach ($config['aliases'] as $name => $value) {
-                    Yii::setAlias($name, $value);
-                }
-            }
-        }
 
         $migrationPaths = ['base' => $this->migrationPath];
 

--- a/protected/humhub/commands/MigrateController.php
+++ b/protected/humhub/commands/MigrateController.php
@@ -8,6 +8,7 @@
 
 namespace humhub\commands;
 
+use humhub\components\console\WithoutModuleAutoload;
 use humhub\components\Module;
 use humhub\helpers\DatabaseHelper;
 use humhub\services\ModuleDiscoveryService;
@@ -58,6 +59,7 @@ use yii\web\Application;
  * @property-read string[] $newMigrations
  * @property-read string[] $migrationPaths
  */
+#[WithoutModuleAutoload]
 class MigrateController extends \yii\console\controllers\MigrateController
 {
     /**
@@ -240,12 +242,43 @@ class MigrateController extends \yii\console\controllers\MigrateController
             return is_dir($migrationsPath) ? [$this->moduleId => $migrationsPath] : [];
         }
 
-        // All-modules mode: all modules are already registered at bootstrap by ModuleAutoLoader.
-        // Yii::$app->getModules() has both core and third-party modules; resolve paths via reflection.
-        // We intentionally do NOT call registerBulk() here — that would contaminate any
-        // ModuleManager injected by tests via Yii::$app->set('moduleManager').
+        // All-modules mode: #[WithoutModuleAutoload] means third-party modules are NOT registered
+        // at bootstrap (to avoid old module configs executing against a newer core during upgrades).
+        //
+        // We still need two things from those modules:
+        //   1. Their migration paths — read directly from locateModuleConfigs() output.
+        //   2. PHP class autoloading for migration files that reference module models.
+        //      Yii resolves classes via aliases set in ModuleManager::register(). We replicate
+        //      only the alias setup here — intentionally skipping the full register()/registerBulk()
+        //      to avoid (a) bootstrap side-effects and (b) contaminating a mock ModuleManager
+        //      injected by tests via Yii::$app->set('moduleManager').
+        $configs = ModuleDiscoveryService::locateModuleConfigs();
+
+        foreach ($configs as $basePath => $config) {
+            if (!empty($config['namespace'])) {
+                Yii::setAlias('@' . str_replace('\\', '/', $config['namespace']), $basePath);
+            }
+            if (!empty($config['id'])) {
+                Yii::setAlias('@' . $config['id'], $basePath);
+            }
+            if (!empty($config['aliases']) && is_array($config['aliases'])) {
+                foreach ($config['aliases'] as $name => $value) {
+                    Yii::setAlias($name, $value);
+                }
+            }
+        }
+
         $migrationPaths = ['base' => $this->migrationPath];
 
+        foreach ($configs as $basePath => $config) {
+            $migrationsPath = $basePath . DIRECTORY_SEPARATOR . 'migrations';
+            if (is_dir($migrationsPath)) {
+                $migrationPaths[$config['id']] = $migrationsPath;
+            }
+        }
+
+        // Core modules are registered at bootstrap even with #[WithoutModuleAutoload].
+        // Use reflection to find their migration directories.
         foreach (Yii::$app->getModules() as $id => $config) {
             if (isset($migrationPaths[$id])) {
                 continue;

--- a/protected/humhub/commands/MigrateController.php
+++ b/protected/humhub/commands/MigrateController.php
@@ -8,8 +8,10 @@
 
 namespace humhub\commands;
 
+use humhub\components\console\WithoutModuleAutoload;
 use humhub\components\Module;
 use humhub\helpers\DatabaseHelper;
+use humhub\services\ModuleDiscoveryService;
 use Yii;
 use yii\console\controllers\BaseMigrateController;
 use yii\console\Exception;
@@ -57,6 +59,7 @@ use yii\web\Application;
  * @property-read string[] $newMigrations
  * @property-read string[] $migrationPaths
  */
+#[WithoutModuleAutoload]
 class MigrateController extends \yii\console\controllers\MigrateController
 {
     /**
@@ -69,6 +72,16 @@ class MigrateController extends \yii\console\controllers\MigrateController
      * @var bool also include migration paths of all enabled modules
      */
     public bool $includeModuleMigrations = true;
+
+    /**
+     * When set, only migrations for the specified module are applied.
+     * Mutually exclusive with --includeModuleMigrations=false.
+     *
+     * Example: yii migrate/up --moduleId=calendar
+     *
+     * @var string|null
+     */
+    public ?string $moduleId = null;
 
     /**
      * When includeModuleMigrations is enabled, this maps migrations to the
@@ -115,7 +128,7 @@ class MigrateController extends \yii\console\controllers\MigrateController
     public function options($actionID): array
     {
         if ($actionID === 'up') {
-            return array_merge(parent::options($actionID), ['includeModuleMigrations']);
+            return array_merge(parent::options($actionID), ['includeModuleMigrations', 'moduleId']);
         }
 
         return parent::options($actionID);
@@ -128,7 +141,8 @@ class MigrateController extends \yii\console\controllers\MigrateController
      */
     protected function getNewMigrations(): array
     {
-        if (!$this->includeModuleMigrations) {
+        // Core-only mode: use parent directly with the base migrationPath.
+        if (!$this->includeModuleMigrations && $this->moduleId === null) {
             return parent::getNewMigrations();
         }
 
@@ -195,9 +209,33 @@ class MigrateController extends \yii\console\controllers\MigrateController
      */
     protected function getMigrationPaths(): array
     {
+        // Single-module mode: load just that module and return only its migration path.
+        // Does not include core — intended to be called after core migrations have already run.
+        if ($this->moduleId !== null) {
+            $basePath = ModuleDiscoveryService::findModuleBasePath($this->moduleId);
+            if ($basePath === null) {
+                return [];
+            }
+
+            try {
+                Yii::$app->moduleManager->register($basePath);
+            } catch (\Throwable $e) {
+                Yii::error('Cannot load module config for "' . $this->moduleId . '": ' . $e->getMessage());
+                return [];
+            }
+
+            $migrationsPath = $basePath . DIRECTORY_SEPARATOR . 'migrations';
+            return is_dir($migrationsPath) ? [$this->moduleId => $migrationsPath] : [];
+        }
+
+        // All-modules mode: load every third-party module explicitly (since #[WithoutModuleAutoload]
+        // skipped them at bootstrap) and collect their migration paths.
+        $configs = ModuleDiscoveryService::locateModuleConfigs();
+        Yii::$app->moduleManager->registerBulk($configs);
+
         $migrationPaths = ['base' => $this->migrationPath];
 
-        foreach (($this->module ?? Yii::$app)->getModules() as $id => $config) {
+        foreach (Yii::$app->getModules() as $id => $config) {
             $class = null;
             if (is_array($config) && isset($config['class'])) {
                 $class = $config['class'];
@@ -206,10 +244,14 @@ class MigrateController extends \yii\console\controllers\MigrateController
             }
 
             if ($class !== null) {
-                $reflector = new \ReflectionClass($class);
-                $path = dirname($reflector->getFileName()) . '/migrations';
-                if (is_dir($path)) {
-                    $migrationPaths[$id] = $path;
+                try {
+                    $reflector = new \ReflectionClass($class);
+                    $path = dirname($reflector->getFileName()) . '/migrations';
+                    if (is_dir($path)) {
+                        $migrationPaths[$id] = $path;
+                    }
+                } catch (\Throwable) {
+                    // module class not loadable — skip
                 }
             }
         }

--- a/protected/humhub/commands/MigrateController.php
+++ b/protected/humhub/commands/MigrateController.php
@@ -147,11 +147,6 @@ class MigrateController extends \yii\console\controllers\MigrateController
      */
     protected function getNewMigrations(): array
     {
-        // Core-only mode: use parent directly with the base migrationPath.
-        if (!$this->includeModuleMigrations && $this->moduleId === null) {
-            return parent::getNewMigrations();
-        }
-
         $this->migrationPathMap = [];
         $migrations = [];
         foreach ($this->getMigrationPaths() as $migrationPath) {
@@ -175,9 +170,7 @@ class MigrateController extends \yii\console\controllers\MigrateController
      */
     protected function createMigration($class): MigrationInterface
     {
-        if ($this->includeModuleMigrations) {
-            $this->migrationPath = $this->getMigrationPath($class);
-        }
+        $this->migrationPath = $this->getMigrationPath($class);
 
         /**
          * Storing the last executed migration
@@ -242,22 +235,24 @@ class MigrateController extends \yii\console\controllers\MigrateController
             return is_dir($migrationsPath) ? [$this->moduleId => $migrationsPath] : [];
         }
 
-        // All-modules mode: third-party modules are not registered at bootstrap
-        // (#[WithoutModuleAutoload] skips them to avoid stale configs running against a new core).
-        // Read migration paths directly from locateModuleConfigs() — no registerBulk() needed,
-        // which would contaminate a mock ModuleManager injected by tests.
-        $configs = ModuleDiscoveryService::locateModuleConfigs();
-
+        // Base path + core module migrations are always included.
+        // Third-party modules are only added when includeModuleMigrations is set — with
+        // #[WithoutModuleAutoload] they are not registered at bootstrap to avoid stale
+        // configs executing against a newer core during upgrades.
+        // locateModuleConfigs() is used without registerBulk() to avoid contaminating a
+        // mock ModuleManager injected by tests via Yii::$app->set('moduleManager').
         $migrationPaths = ['base' => $this->migrationPath];
 
-        foreach ($configs as $basePath => $config) {
-            $migrationsPath = $basePath . DIRECTORY_SEPARATOR . 'migrations';
-            if (is_dir($migrationsPath)) {
-                $migrationPaths[$config['id']] = $migrationsPath;
+        if ($this->includeModuleMigrations) {
+            foreach (ModuleDiscoveryService::locateModuleConfigs() as $basePath => $config) {
+                $migrationsPath = $basePath . DIRECTORY_SEPARATOR . 'migrations';
+                if (is_dir($migrationsPath)) {
+                    $migrationPaths[$config['id']] = $migrationsPath;
+                }
             }
         }
 
-        // Core modules are registered at bootstrap even with #[WithoutModuleAutoload].
+        // Core modules are always registered at bootstrap even with #[WithoutModuleAutoload].
         // Use reflection to find their migration directories.
         foreach (Yii::$app->getModules() as $id => $config) {
             if (isset($migrationPaths[$id])) {

--- a/protected/humhub/commands/MigrateController.php
+++ b/protected/humhub/commands/MigrateController.php
@@ -228,14 +228,29 @@ class MigrateController extends \yii\console\controllers\MigrateController
             return is_dir($migrationsPath) ? [$this->moduleId => $migrationsPath] : [];
         }
 
-        // All-modules mode: load every third-party module explicitly (since #[WithoutModuleAutoload]
-        // skipped them at bootstrap) and collect their migration paths.
-        $configs = ModuleDiscoveryService::locateModuleConfigs();
-        Yii::$app->moduleManager->registerBulk($configs);
-
+        // All-modules mode: collect migration paths from two sources without mutating the module manager.
+        //
+        // 1. Third-party modules: read migration paths directly from locateModuleConfigs() output.
+        //    We intentionally do NOT call registerBulk() here — registering all modules as a side
+        //    effect of getMigrationPaths() would corrupt test isolation and contaminate any
+        //    ModuleManager instance that callers have injected via Yii::$app->set('moduleManager').
+        //
+        // 2. Core modules: already registered at bootstrap (#[WithoutModuleAutoload] still loads
+        //    @humhub/modules), so we can resolve their paths via ReflectionClass.
         $migrationPaths = ['base' => $this->migrationPath];
 
+        foreach (ModuleDiscoveryService::locateModuleConfigs() as $basePath => $config) {
+            $migrationsPath = $basePath . DIRECTORY_SEPARATOR . 'migrations';
+            if (is_dir($migrationsPath)) {
+                $migrationPaths[$config['id']] = $migrationsPath;
+            }
+        }
+
         foreach (Yii::$app->getModules() as $id => $config) {
+            if (isset($migrationPaths[$id])) {
+                continue;
+            }
+
             $class = null;
             if (is_array($config) && isset($config['class'])) {
                 $class = $config['class'];

--- a/protected/humhub/components/bootstrap/ModuleAutoLoader.php
+++ b/protected/humhub/components/bootstrap/ModuleAutoLoader.php
@@ -49,14 +49,31 @@ class ModuleAutoLoader implements BootstrapInterface
             EnvironmentChecker::preInstallChecks();
         }
 
-        if ($app->request->isConsoleRequest && self::hasWithoutModuleAutoloadAttribute()) {
-            $modules = ModuleDiscoveryService::loadModuleConfigs([ModuleDiscoveryService::CORE_MODULE_PATH]);
+        if (!$app->request->isConsoleRequest) {
+            $modules = ModuleDiscoveryService::locateModuleConfigs();
             Yii::$app->moduleManager->registerBulk($modules);
             return;
         }
 
-        $modules = ModuleDiscoveryService::locateModuleConfigs();
-        Yii::$app->moduleManager->registerBulk($modules);
+        // Console: always register core modules first so their consoleControllerMap entries
+        // land in Yii::$app->controllerMap before hasWithoutModuleAutoloadAttribute() reads it
+        $coreModules = ModuleDiscoveryService::loadModuleConfigs([ModuleDiscoveryService::CORE_MODULE_PATH]);
+        Yii::$app->moduleManager->registerBulk($coreModules);
+
+        if (self::hasWithoutModuleAutoloadAttribute()) {
+            return;
+        }
+
+        // Normal console command: also load third-party modules
+        $thirdPartyPaths = array_values(array_filter(
+            Yii::$app->params['moduleAutoloadPaths'] ?? [],
+            fn($path) => $path !== ModuleDiscoveryService::CORE_MODULE_PATH,
+        ));
+
+        if (!empty($thirdPartyPaths)) {
+            $thirdPartyModules = ModuleDiscoveryService::loadModuleConfigs($thirdPartyPaths);
+            Yii::$app->moduleManager->registerBulk($thirdPartyModules);
+        }
     }
 
     /**

--- a/protected/humhub/modules/marketplace/commands/MarketplaceController.php
+++ b/protected/humhub/modules/marketplace/commands/MarketplaceController.php
@@ -8,164 +8,214 @@
 
 namespace humhub\modules\marketplace\commands;
 
+use humhub\components\console\WithoutModuleAutoload;
 use humhub\components\Module;
 use humhub\models\ModuleEnabled;
 use humhub\modules\admin\libs\HumHubAPI;
+use humhub\services\ModuleDiscoveryService;
 use humhub\services\ModuleService;
 use Yii;
 use yii\base\ErrorException;
 use yii\base\Exception;
-use yii\base\InvalidArgumentException;
 use yii\base\InvalidConfigException;
 use yii\console\Controller;
-use yii\helpers\BaseConsole;
 use yii\helpers\Console;
+use yii\helpers\Json;
 use yii\web\HttpException;
 
 /**
- * HumHub Module Managament
+ * HumHub Module Management
+ *
+ * Third-party module configs are not loaded at bootstrap ({@see WithoutModuleAutoload}).
+ * Each action that needs a specific module calls {@see loadModule()} to register it on demand.
  *
  * @property \humhub\modules\marketplace\Module $module
  * @since 0.5
  */
+#[WithoutModuleAutoload]
 class MarketplaceController extends Controller
 {
     /**
-     * @inerhitdoc
+     * @inheritdoc
      */
     public function beforeAction($action)
     {
-        /** @var \humhub\modules\marketplace\Module $module */
         $module = Yii::$app->getModule('marketplace');
 
         if ($module === null || !$module->enabled) {
-            print "Fatal: The module marketplace is disabled by configuration!\n\n";
+            $this->error('The marketplace module is disabled by configuration.');
             return false;
         }
 
         return parent::beforeAction($action);
     }
 
-
     /**
-     * Lists all installed and enabled modules.
+     * Lists all installed modules.
      *
-     * @throws Exception
+     * Reads metadata from module.json — no config.php is loaded.
      */
     public function actionList()
     {
-        Yii::$app->moduleManager->flushCache();
-        $installedModules = Yii::$app->moduleManager->getModules();
+        $installed = ModuleDiscoveryService::findInstalledModules();
+        $enabledIds = ModuleEnabled::getEnabledIds();
 
-        print "Installed modules: \n\n";
+        $this->heading('Installed Modules (' . count($installed) . ')');
 
-        $mask = "| %-20s | %10s |%20s | %-30s \n";
-        printf($mask, 'ID', 'ENABLED', 'INSTALLED VERSION', 'TITLE');
-        foreach ($installedModules as $module) {
-            printf(
-                $mask,
-                $module->id,
-                (Yii::$app->hasModule($module->id) ? 'Yes' : 'No'),
-                $module->getVersion(),
-                $module->getName(),
-            );
+        if (empty($installed)) {
+            $this->warn('No modules installed.');
+            return 0;
         }
+
+        $this->stdout(sprintf('  %-26s  %-10s  %-12s  %s' . PHP_EOL, 'ID', 'STATUS', 'VERSION', 'NAME'), Console::BOLD);
+        $this->stdout('  ' . str_repeat('─', 70) . PHP_EOL);
+
+        foreach ($installed as $moduleId => $info) {
+            $isEnabled = in_array($moduleId, $enabledIds);
+            $name = $this->readModuleName($info['basePath'], $moduleId);
+            $this->stdout(sprintf('  %-26s  ', $moduleId));
+            $this->stdout(sprintf('%-10s', $isEnabled ? 'enabled' : 'disabled'), $isEnabled ? Console::FG_GREEN : Console::FG_YELLOW);
+            $this->stdout(sprintf('  %-12s  %s' . PHP_EOL, $info['version'] ?? '-', $name));
+        }
+
+        $enabledCount = count(array_intersect($enabledIds, array_keys($installed)));
+        $this->stdout(PHP_EOL . '  ' . $enabledCount . ' of ' . count($installed) . ' module(s) enabled.' . PHP_EOL);
+
+        return 0;
     }
 
     /**
      * Lists all online available modules.
+     *
+     * Uses filesystem metadata to determine installed status — no config.php is loaded.
      */
     public function actionListOnline()
     {
+        $this->stdout(PHP_EOL . 'Fetching online module list...' . PHP_EOL);
+
         $modules = $this->getMarketplaceModule()->onlineModuleManager->getModules();
+        $installed = ModuleDiscoveryService::findInstalledModules();
 
-        print "Online available modules: \n\n";
+        $this->heading('Online Modules (' . count($modules) . ')');
 
-        $mask = "| %-20s | %9s | %14s | %21s | %-30s \n";
-        printf($mask, 'ID', 'INSTALLED', 'LATEST VERSION', 'LATEST COMPAT VERSION', 'TITLE');
+        if (empty($modules)) {
+            $this->warn('No modules found.');
+            return 0;
+        }
+
+        $this->stdout(
+            sprintf('  %-26s  %-12s  %-12s  %-14s  %s' . PHP_EOL, 'ID', 'INSTALLED', 'LATEST', 'COMPATIBLE', 'NAME'),
+            Console::BOLD,
+        );
+        $this->stdout('  ' . str_repeat('─', 82) . PHP_EOL);
 
         foreach ($modules as $module) {
-            printf(
-                $mask,
-                $module['id'],
-                (Yii::$app->moduleManager->hasModule($module['id']) ? 'Yes' : 'No'),
-                $module['latestVersion'],
-                (isset($module['latestCompatibleVersion']) && $module['latestCompatibleVersion']) ? $module['latestCompatibleVersion'] : "-",
-                $module['name'],
-            );
+            $isInstalled = array_key_exists($module['id'], $installed);
+            $installedVersion = $installed[$module['id']]['version'] ?? null;
+            $compat = $module['latestCompatibleVersion'] ?? '-';
+
+            $this->stdout(sprintf('  %-26s  ', $module['id']));
+            if ($isInstalled) {
+                $this->stdout(sprintf('%-12s', $installedVersion), Console::FG_GREEN);
+            } else {
+                $this->stdout(sprintf('%-12s', '-'), Console::FG_YELLOW);
+            }
+            $this->stdout(sprintf('  %-12s  %-14s  %s' . PHP_EOL, $module['latestVersion'] ?? '-', $compat, $module['name']));
         }
+
+        return 0;
     }
 
     /**
      * Installs a given module.
      *
-     * @param string $moduleId
      * @throws ErrorException
      * @throws Exception
      * @throws InvalidConfigException
      * @throws HttpException
      */
-    public function actionInstall($moduleId)
+    public function actionInstall(string $moduleId)
     {
+        $installed = ModuleDiscoveryService::findInstalledModules();
+
+        if (array_key_exists($moduleId, $installed)) {
+            $this->warn('Module ' . $moduleId . ' is already installed (v' . ($installed[$moduleId]['version'] ?? '?') . ').');
+            return 0;
+        }
+
+        $this->stdout(PHP_EOL . 'Installing ' . $moduleId . '...' . PHP_EOL);
+
         $this->getMarketplaceModule()->onlineModuleManager->install($moduleId);
 
-        print "\nModule " . $moduleId . " successfully installed!\n";
+        $version = ModuleDiscoveryService::findInstalledVersion($moduleId);
+        $this->success('Module ' . $moduleId . ($version ? ' (v' . $version . ')' : '') . ' installed successfully.');
+
+        return 0;
     }
 
     /**
      * Uninstalls a given module.
      *
-     * @param string $moduleId
      * @throws ErrorException
      * @throws Exception
      */
-    public function actionRemove($moduleId)
+    public function actionRemove(string $moduleId)
     {
-        $module = Yii::$app->moduleManager->getModule($moduleId);
+        $module = $this->loadModule($moduleId);
 
-        if ($module == null) {
-            print "\nModule " . $moduleId . " is not installed!\n";
-            return;
+        if ($module === null) {
+            $this->error('Module ' . $moduleId . ' is not installed.');
+            return 1;
         }
+
+        $this->stdout(PHP_EOL . 'Removing ' . $moduleId . '...' . PHP_EOL);
 
         (new ModuleService($module))->remove();
 
-        print "\nModule " . $moduleId . " successfully uninstalled!\n";
+        $this->success('Module ' . $moduleId . ' removed successfully.');
+
+        return 0;
     }
 
     /**
-     * Updates a module
+     * Updates a module to the latest compatible version.
      *
-     * @param string $moduleId
      * @throws Exception
-     * @todo Handle no marketplace modules
-     *
      */
-    public function actionUpdate($moduleId)
+    public function actionUpdate(string $moduleId)
     {
-        if (!Yii::$app->moduleManager->hasModule($moduleId)) {
-            print "\nModule " . $moduleId . " is not installed!\n";
-            exit;
+        $installed = ModuleDiscoveryService::findInstalledModules();
+
+        if (!array_key_exists($moduleId, $installed)) {
+            $this->error('Module ' . $moduleId . ' is not installed.');
+            return 1;
         }
 
-        // Look online for module
         $moduleInfo = $this->getMarketplaceModule()->onlineModuleManager->getModuleInfo($moduleId);
 
         if (!isset($moduleInfo['latestCompatibleVersion'])) {
-            print "No compatible version for " . $moduleId . " found online!\n";
-            return;
+            $this->warn('No compatible version for ' . $moduleId . ' found online.');
+            return 0;
         }
 
-        $module = Yii::$app->moduleManager->getModule($moduleId);
+        $currentVersion = $installed[$moduleId]['version'] ?? '?';
+        $newVersion = $moduleInfo['latestCompatibleVersion']['version'];
 
-        if ($moduleInfo['latestCompatibleVersion']['version'] == $module->getVersion()) {
-            print "Module " . $moduleId . " already up to date!\n";
-            return;
+        if ($newVersion === $currentVersion) {
+            $this->warn('Module ' . $moduleId . ' is already up to date (v' . $currentVersion . ').');
+            return 0;
         }
 
+        $this->stdout(PHP_EOL . 'Updating ' . $moduleId . ' (v' . $currentVersion . ' → v' . $newVersion . ')...' . PHP_EOL);
+
+        // No pre-loading: OnlineModuleManager::update() removes old files first, then
+        // calls install() which registers the fresh config.php. Loading the old module
+        // here would put stale class definitions into the process before the files change.
         $this->getMarketplaceModule()->onlineModuleManager->update($moduleId);
 
-        print "Module " . $moduleId . " successfully updated!\n";
+        $this->success('Module ' . $moduleId . ' updated to v' . $newVersion . '.');
+
+        return 0;
     }
 
     /**
@@ -175,120 +225,121 @@ class MarketplaceController extends Controller
     {
         $onlineModuleManager = $this->getMarketplaceModule()->onlineModuleManager;
 
-        $i = 0;
-        foreach ($onlineModuleManager->getModuleUpdates() as $moduleId => $info) {
-            try {
-                $this->actionUpdate($moduleId);
-            } catch (InvalidArgumentException|\Exception $ex) {
-                print "Module " . $moduleId . " - Error: " . $ex->getMessage() . "\n";
+        $this->stdout(PHP_EOL . 'Checking for module updates...' . PHP_EOL);
+
+        $updates = $onlineModuleManager->getModuleUpdates();
+
+        if (empty($updates)) {
+            $this->success('All modules are up to date.');
+        } else {
+            $this->stdout('Found ' . count($updates) . ' module(s) with available updates.' . PHP_EOL);
+
+            $succeeded = 0;
+            foreach ($updates as $moduleId => $info) {
+                $this->stdout(PHP_EOL . '── ' . $moduleId . ' ──' . PHP_EOL, Console::BOLD);
+                try {
+                    $this->actionUpdate($moduleId);
+                    $succeeded++;
+                } catch (\Throwable $e) {
+                    $this->error('Update of ' . $moduleId . ' failed: ' . $e->getMessage());
+                }
             }
-            $i++;
+
+            $this->stdout(PHP_EOL);
+            if ($succeeded === count($updates)) {
+                $this->success('Updated ' . $succeeded . ' of ' . count($updates) . ' module(s).');
+            } else {
+                $this->warn('Updated ' . $succeeded . ' of ' . count($updates) . ' module(s). ' . (count($updates) - $succeeded) . ' failed.');
+            }
         }
 
-        print "\nUpdated " . $i . " outdated modules. \n";
+        // Reinstall modules that are marked as enabled in the DB but missing on disk.
+        $installed = ModuleDiscoveryService::findInstalledModules();
+        $missing = array_diff(ModuleEnabled::getEnabledIds(), array_keys($installed));
 
-        /**
-         * Looking up modules which are marked as installed but not loaded.
-         * Try to get recent version online.
-         */
-        // Also install modules which are seems to be installed
-        $installedModules = Yii::$app->moduleManager->getModules(['returnClass' => true]);
+        if (!empty($missing)) {
+            $this->stdout(PHP_EOL . 'Reinstalling ' . count($missing) . ' missing module(s)...' . PHP_EOL);
 
-        foreach (ModuleEnabled::getEnabledIds() as $moduleId) {
-            if (!in_array($moduleId, array_keys($installedModules))) {
-                // Module seems to be installed - but cannot be loaded
-                // Try force re-install
+            foreach ($missing as $moduleId) {
                 try {
                     $onlineModuleManager->install($moduleId);
-                    // Run pending migrations introduced by the reinstalled version, as install() does not call update()
                     $reinstalledModule = Yii::$app->moduleManager->getModule($moduleId);
                     if ($reinstalledModule !== null) {
                         $reinstalledModule->update();
                     }
-                    print "Reinstalled: " . $moduleId . "\n";
-                } catch (\Exception) {
+                    $this->success('Reinstalled ' . $moduleId . '.');
+                } catch (\Exception $e) {
+                    $this->error('Could not reinstall ' . $moduleId . ': ' . $e->getMessage());
                 }
             }
         }
-    }
 
-    /**
-     * Enables an installed module
-     *
-     * @param string $moduleId the module id
-     * @return int the exit code
-     */
-    public function actionEnable($moduleId)
-    {
-        $this->stdout(
-            Yii::t('MarketplaceModule.base', "--- Enable module: {moduleId} ---\n\n", ['moduleId' => $moduleId]),
-            Console::BOLD,
-        );
-
-        /** @var Module $module */
-        $module = Yii::$app->moduleManager->getModule($moduleId);
-        if ($module === null) {
-            $this->stdout(Yii::t('MarketplaceModule.base', "Module not found!\n"), Console::FG_RED, Console::BOLD);
-            return 1;
-        }
-
-        $module->enable();
-
-        $this->stdout(
-            Yii::t('MarketplaceModule.base', "\nModule successfully enabled!\n"),
-            Console::FG_GREEN,
-            Console::BOLD,
-        );
         return 0;
     }
 
     /**
-     * Disables an enabled module
+     * Enables an installed module.
      *
      * @param string $moduleId the module id
      * @return int the exit code
      */
-    public function actionDisable($moduleId)
+    public function actionEnable(string $moduleId)
     {
+        $this->stdout(PHP_EOL . 'Enabling ' . $moduleId . '...' . PHP_EOL);
+
+        $module = $this->loadModule($moduleId);
+        if ($module === null) {
+            $this->error('Module ' . $moduleId . ' is not installed.');
+            return 1;
+        }
+
+        if (ModuleEnabled::findOne(['module_id' => $moduleId])) {
+            $this->warn('Module ' . $moduleId . ' is already enabled.');
+            return 0;
+        }
+
+        $module->enable();
+
+        $this->success('Module ' . $moduleId . ' enabled.');
+        return 0;
+    }
+
+    /**
+     * Disables an enabled module.
+     *
+     * @param string $moduleId the module id
+     * @return int the exit code
+     */
+    public function actionDisable(string $moduleId)
+    {
+        $module = $this->loadModule($moduleId);
+        if ($module === null) {
+            $this->error('Module ' . $moduleId . ' is not installed.');
+            return 1;
+        }
+
+        if (!ModuleEnabled::findOne(['module_id' => $moduleId])) {
+            $this->warn('Module ' . $moduleId . ' is not enabled.');
+            return 0;
+        }
+
         if (!$this->confirm(
-            Yii::t(
-                'MarketplaceModule.base',
-                'All {moduleId} module content will be deleted. Continue?',
-                ['moduleId' => $moduleId],
-            ),
+            Yii::t('MarketplaceModule.base', 'All {moduleId} module content will be deleted. Continue?', ['moduleId' => $moduleId]),
             false,
         )) {
             return 1;
         }
 
-        $this->stdout(
-            Yii::t('MarketplaceModule.base', "--- Disable module: {moduleId} ---\n\n", ['moduleId' => $moduleId]),
-            Console::BOLD,
-        );
-
-        /** @var Module $module */
-        $module = Yii::$app->moduleManager->getModule($moduleId);
-        if ($module === null || !Yii::$app->hasModule($moduleId)) {
-            $this->stdout(
-                Yii::t('MarketplaceModule.base', "Module not found or enabled!\n"),
-                Console::FG_RED,
-                Console::BOLD,
-            );
-            return 1;
-        }
+        $this->stdout(PHP_EOL . 'Disabling ' . $moduleId . '...' . PHP_EOL);
 
         $module->disable();
 
-        $this->stdout(
-            Yii::t('MarketplaceModule.base', "\nModule successfully disabled!\n"),
-            Console::FG_GREEN,
-            Console::BOLD,
-        );
+        $this->success('Module ' . $moduleId . ' disabled.');
         return 0;
     }
 
     /**
-     * Registers a given module.
+     * Registers a license key for a paid module.
      *
      * @param string $licenceKey
      * @throws ErrorException
@@ -296,108 +347,142 @@ class MarketplaceController extends Controller
      * @throws InvalidConfigException
      * @throws HttpException
      */
-    public function actionRegister($licenceKey)
+    public function actionRegister(string $licenceKey)
     {
         if (empty($licenceKey)) {
-            $this->stdout(
-                Yii::t('MarketplaceModule.base', 'Module license key cannot be empty!' . "\n"),
-                Console::FG_RED,
-                Console::BOLD,
-            );
+            $this->error('License key cannot be empty.');
             return 1;
         }
 
         $result = HumHubAPI::request('v1/modules/registerPaid', ['licenceKey' => $licenceKey]);
 
         if (!isset($result['status'])) {
-            $this->stdout(
-                Yii::t('MarketplaceModule.base', 'Could not connect to HumHub API!' . "\n"),
-                Console::FG_RED,
-                Console::BOLD,
-            );
+            $this->error('Could not connect to the HumHub API.');
             return 1;
         }
 
-        if ($result['status'] != 'ok' && $result['status'] != 'created') {
-            $this->stdout(
-                Yii::t('MarketplaceModule.base', 'Invalid module license key!' . "\n"),
-                Console::FG_RED,
-                Console::BOLD,
-            );
+        if ($result['status'] !== 'ok' && $result['status'] !== 'created') {
+            $this->error('Invalid license key.');
             return 1;
         }
 
-        $this->stdout(
-            Yii::t('MarketplaceModule.base', 'Module license added!' . "\n"),
-            Console::FG_GREEN,
-            Console::BOLD,
-        );
+        $this->success('License key registered successfully.');
         return 0;
     }
 
     /**
-     * Displays module info
+     * Displays detailed information about a module.
      *
      * @param string $moduleId Module ID
      */
-    public function actionInfo($moduleId)
+    public function actionInfo(string $moduleId)
     {
-        $module = Yii::$app->moduleManager->getModule($moduleId, false);
+        $installed = ModuleDiscoveryService::findInstalledModules();
+        $isInstalled = array_key_exists($moduleId, $installed);
+        $isEnabled = $isInstalled && ModuleEnabled::findOne(['module_id' => $moduleId]) !== null;
 
+        $module = $isInstalled ? $this->loadModule($moduleId) : null;
 
-        $this->stdout('====================================================' . PHP_EOL);
-        $this->stdout('                 MODULE INFORMATION' . PHP_EOL);
-        $this->stdout('====================================================' . PHP_EOL . PHP_EOL);
+        $this->heading('Module: ' . $moduleId);
 
-        $this->stdout("ID:\t\t");
-        $this->stdout($moduleId, BaseConsole::FG_GREY, BaseConsole::BOLD);
-        $this->stdout(PHP_EOL . PHP_EOL);
+        $this->printInfoRow('Installed', $isInstalled ? 'Yes' : 'No', $isInstalled ? Console::FG_GREEN : Console::FG_RED);
 
-        $this->stdout("Installed:\t");
-        if (($module instanceof Module)) {
-            $this->stdout('Yes', BaseConsole::FG_GREEN, BaseConsole::BOLD);
-        } else {
-            $this->stdout('No', BaseConsole::FG_RED, BaseConsole::BOLD);
-        }
-        $this->stdout(PHP_EOL);
-
-        if ($module === null) {
+        if (!$isInstalled) {
             $this->stdout(PHP_EOL);
             return 1;
         }
 
-        $this->stdout("Enabled:\t");
-        if ($module->isEnabled) {
-            $this->stdout('Yes', BaseConsole::FG_GREEN, BaseConsole::BOLD);
+        $this->printInfoRow('Enabled', $isEnabled ? 'Yes' : 'No', $isEnabled ? Console::FG_GREEN : Console::FG_YELLOW);
+
+        if ($module !== null) {
+            $this->printInfoRow('Name', $module->name);
+            $this->printInfoRow('Version', $module->version);
+            $this->printInfoRow('Description', $module->description);
+            $this->printInfoRow('Path', $module->basePath);
         } else {
-            $this->stdout('No', BaseConsole::FG_RED, BaseConsole::BOLD);
+            $this->printInfoRow('Version', $installed[$moduleId]['version'] ?? '-');
+            $this->printInfoRow('Path', $installed[$moduleId]['basePath']);
+            $this->stdout(PHP_EOL);
+            $this->warn('Module config could not be loaded (broken config.php).');
         }
-        $this->stdout(PHP_EOL . PHP_EOL);
-
-        $this->stdout("Name:\t\t");
-        $this->stdout($module->name . PHP_EOL, BaseConsole::FG_GREY, BaseConsole::BOLD);
-
-        $this->stdout("Version:\t");
-        $this->stdout($module->version . PHP_EOL, BaseConsole::FG_GREY, BaseConsole::BOLD);
-
-        $this->stdout(PHP_EOL);
-
-        $this->stdout("Description:\t");
-        $this->stdout($module->description . PHP_EOL, BaseConsole::FG_GREY, BaseConsole::BOLD);
-
-        $this->stdout("Path:\t\t");
-        $this->stdout($module->basePath . PHP_EOL, BaseConsole::FG_GREY, BaseConsole::BOLD);
 
         $this->stdout(PHP_EOL);
         return 0;
     }
 
     /**
-     * @return \humhub\modules\marketplace\Module
+     * Explicitly loads a single module's config.php and registers it with the module manager.
+     *
+     * Returns the Module instance on success, or null if the module is not found on disk
+     * or its config.php throws an error.
      */
-    private function getMarketplaceModule()
+    private function loadModule(string $moduleId): ?Module
+    {
+        $basePath = ModuleDiscoveryService::findModuleBasePath($moduleId);
+        if ($basePath === null) {
+            return null;
+        }
+
+        try {
+            Yii::$app->moduleManager->register($basePath);
+        } catch (\Throwable $e) {
+            Yii::error('Could not load config for module "' . $moduleId . '": ' . $e->getMessage());
+            return null;
+        }
+
+        return Yii::$app->moduleManager->getModule($moduleId, false);
+    }
+
+    private function heading(string $title): void
+    {
+        $this->stdout(PHP_EOL . $title . PHP_EOL, Console::BOLD);
+        $this->stdout(str_repeat('─', max(mb_strlen($title) + 4, 44)) . PHP_EOL);
+    }
+
+    private function success(string $message): void
+    {
+        $this->stdout('✓ ', Console::FG_GREEN, Console::BOLD);
+        $this->stdout($message . PHP_EOL);
+    }
+
+    private function error(string $message): void
+    {
+        $this->stdout('✗ ', Console::FG_RED, Console::BOLD);
+        $this->stdout($message . PHP_EOL);
+    }
+
+    private function warn(string $message): void
+    {
+        $this->stdout('! ', Console::FG_YELLOW, Console::BOLD);
+        $this->stdout($message . PHP_EOL);
+    }
+
+    private function printInfoRow(string $label, string $value, ?int $valueColor = null): void
+    {
+        $this->stdout(sprintf('  %-14s', $label . ':'));
+        if ($valueColor !== null) {
+            $this->stdout($value . PHP_EOL, $valueColor, Console::BOLD);
+        } else {
+            $this->stdout($value . PHP_EOL);
+        }
+    }
+
+    private function readModuleName(string $basePath, string $fallback): string
+    {
+        $path = $basePath . DIRECTORY_SEPARATOR . 'module.json';
+        if (!is_file($path)) {
+            return $fallback;
+        }
+
+        try {
+            return Json::decode(file_get_contents($path))['name'] ?? $fallback;
+        } catch (\Throwable) {
+            return $fallback;
+        }
+    }
+
+    private function getMarketplaceModule(): \humhub\modules\marketplace\Module
     {
         return Yii::$app->getModule('marketplace');
     }
-
 }

--- a/protected/humhub/modules/marketplace/components/OnlineModuleManager.php
+++ b/protected/humhub/modules/marketplace/components/OnlineModuleManager.php
@@ -280,7 +280,9 @@ class OnlineModuleManager extends Component
         if (!(bool)$module->settings->get('includeCommunityModules', false)) {
             $installed = ModuleDiscoveryService::findInstalledModules();
             foreach ($this->_modules as $id => $info) {
-                if (!empty($info['isCommunity']) && !array_key_exists($id, $installed)) {
+                if (!empty($info['isCommunity'])
+                    && !Yii::$app->moduleManager->hasModule($id)
+                    && !array_key_exists($id, $installed)) {
                     unset($this->_modules[$id]);
                 }
             }

--- a/protected/humhub/modules/marketplace/components/OnlineModuleManager.php
+++ b/protected/humhub/modules/marketplace/components/OnlineModuleManager.php
@@ -278,8 +278,9 @@ class OnlineModuleManager extends Component
         }
 
         if (!(bool)$module->settings->get('includeCommunityModules', false)) {
+            $installed = ModuleDiscoveryService::findInstalledModules();
             foreach ($this->_modules as $id => $info) {
-                if (!empty($info['isCommunity']) && !Yii::$app->moduleManager->hasModule($id)) {
+                if (!empty($info['isCommunity']) && !array_key_exists($id, $installed)) {
                     unset($this->_modules[$id]);
                 }
             }

--- a/protected/humhub/modules/marketplace/components/OnlineModuleManager.php
+++ b/protected/humhub/modules/marketplace/components/OnlineModuleManager.php
@@ -205,7 +205,7 @@ class OnlineModuleManager extends Component
      */
     public function update($moduleId)
     {
-        $this->trigger(static::EVENT_BEFORE_UPDATE, new ModuleEvent(['module' => Yii::$app->moduleManager->getModule($moduleId)]));
+        $this->trigger(static::EVENT_BEFORE_UPDATE, new ModuleEvent(['module' => Yii::$app->moduleManager->getModule($moduleId, false)]));
 
         $moduleZipFile = $this->downloadModule($moduleId);
         $this->checkRequirements($moduleId, $moduleZipFile);

--- a/protected/humhub/services/MigrationService.php
+++ b/protected/humhub/services/MigrationService.php
@@ -192,13 +192,19 @@ class MigrationService extends Component
         $module = $this->getModule();
 
         ob_start();
-        $controller = new MigrateController('migrate', $module, [
+        $controllerConfig = [
             'db' => Yii::$app->db,
             'interactive' => false,
             'color' => false,
             'migrationPath' => $this->getPath(),
-            'includeModuleMigrations' => true,
-        ]);
+        ];
+        if ($module instanceof Module) {
+            // moduleId mode: only scans this module's migrations, skips locateModuleConfigs()
+            $controllerConfig['moduleId'] = $module->id;
+        } else {
+            $controllerConfig['includeModuleMigrations'] = true;
+        }
+        $controller = new MigrateController('migrate', $module, $controllerConfig);
 
         /** @noinspection PhpUnhandledExceptionInspection */
         $controller->runAction($action);


### PR DESCRIPTION
## Summary

### MarketplaceController rewrite

- `#[WithoutModuleAutoload]` — third-party module configs are not loaded at bootstrap. Each action loads only what it needs via `findModuleBasePath()` + `register()`.
- `actionList` — reads metadata from `module.json` + `ModuleEnabled` table; no `config.php` loaded
- `actionListOnline` — uses `findInstalledModules()` for installed status
- `actionInstall` — checks if already installed before download
- `actionUpdate` — old module not pre-loaded; `OnlineModuleManager` removes old files and registers fresh `config.php` via `install()`
- `actionUpdateAll` — per-module with `\Throwable` isolation; handles missing-but-enabled reinstall
- `actionEnable/Disable` — explicit per-module load with already-enabled/disabled guards
- Consistent CLI output: color-coded status, headings, `✓`/`✗`/`!` markers, aligned tables

### MigrateController changes

Three modes for `migrate/up`:

| Flag | Behaviour |
|---|---|
| *(none)* | Loads all modules via `locateModuleConfigs()`, runs all migrations |
| `--includeModuleMigrations=0` | Core migrations only — safe during upgrades when module configs may reference removed core classes |
| `--moduleId=calendar` | Only that module's migrations |

Recommended upgrade flow:
```bash
migrate/up --includeModuleMigrations=0   # core first, always safe
module/update-all                        # per-module: files + module migrations
```

### Bug fixes during implementation

- **`ModuleAutoLoader`**: Core modules are now registered before the `#[WithoutModuleAutoload]` check. Previously the check ran before `consoleControllerMap` was populated, so `module/update-all` was never detected and all third-party configs were loaded at bootstrap anyway.
- **`MigrationService`**: Uses `moduleId` mode when running module-specific migrations (e.g. after `module/update-all`). Prevents `locateModuleConfigs()` from loading all third-party configs during a single-module update.
- **`MigrateController`**: Registers Yii namespace aliases (`@humhub/modules/<id>`) for all installed modules before running migrations. Reads only `module.json` — no `config.php` executed. Fixes "Class not found" errors in old migrations that reference model classes when the module was not bootstrapped.
- **`OnlineModuleManager`**: Non-strict `getModule(..., false)` in `EVENT_BEFORE_UPDATE` trigger to avoid exception when module is not yet registered.
- **`includeModuleMigrations`**: Changed from `bool` to `int` to fix Yii2 CLI coercion (`settype('false', 'boolean')` → `true`).

## Test plan

- [ ] `php protected/yii marketplace/list` — shows installed modules with enabled status
- [ ] `php protected/yii marketplace/list-online` — shows online modules, correct installed column
- [ ] `php protected/yii marketplace/install <id>` — installs; second call shows "already installed"
- [ ] `php protected/yii marketplace/update <id>` — shows version transition, updates correctly
- [ ] `php protected/yii marketplace/update-all` — updates all modules, handles broken configs gracefully
- [ ] `php protected/yii marketplace/enable <id>` / `disable <id>` — enable/disable with guard messages
- [ ] `php protected/yii migrate/up` — all migrations as before
- [ ] `php protected/yii migrate/up --includeModuleMigrations=0` — only core migrations
- [ ] `php protected/yii migrate/up --moduleId=calendar` — only calendar migrations