### PR TITLE
Fix clear cache failing when assets mount is not deletable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ HumHub Changelog
 
 1.19 (TBD)
 ----------
-- Fix: Clear cache no longer fails with "Permission denied" when the assets mount directory is not deletable (e.g. on Docker); only its contents are removed
+- Fix #8227: Clear cache no longer fails with "Permission denied" when the assets mount directory is not deletable (e.g. on Docker); only its contents are removed
 - Enh: Added `#[WithoutModuleAutoload]` attribute for console controllers that do not require module loading (e.g. `settings/*`, `cache/*`)
 - Enh #8214: Introduced `ModuleDiscoveryService` centralising all module filesystem discovery and `ModuleService` encapsulating per-module lifecycle operations (enable, disable, remove); slimmed down `ModuleAutoLoader` and `ModuleManager`
 - Enh: Refactored `MarketplaceController` CLI — skips third-party module autoloading at bootstrap (`#[WithoutModuleAutoload]`), loads each module on demand, and runs `update-all` sub-updates in isolated subprocesses

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ HumHub Changelog
 
 1.19 (TBD)
 ----------
+- Fix: Clear cache no longer fails with "Permission denied" when the assets mount directory is not deletable (e.g. on Docker); only its contents are removed
 - Enh: Added `#[WithoutModuleAutoload]` attribute for console controllers that do not require module loading (e.g. `settings/*`, `cache/*`)
 - Enh #8214: Introduced `ModuleDiscoveryService` centralising all module filesystem discovery and `ModuleService` encapsulating per-module lifecycle operations (enable, disable, remove); slimmed down `ModuleAutoLoader` and `ModuleManager`
 - Enh: Refactored `MarketplaceController` CLI — skips third-party module autoloading at bootstrap (`#[WithoutModuleAutoload]`), loads each module on demand, and runs `update-all` sub-updates in isolated subprocesses

--- a/protected/humhub/components/assets/AssetManager.php
+++ b/protected/humhub/components/assets/AssetManager.php
@@ -178,9 +178,21 @@ class AssetManager extends \yii\web\AssetManager
     public function clear()
     {
         $this->enableCache = false;
+
+        // Only remove the contents of the assets mount, not the mount directory itself.
+        // Deleting the root would call rmdir() on the mount, which requires write permission
+        // on its parent directory - not granted in some setups (e.g. Docker), causing the
+        // clear cache action to fail with a "Permission denied" error.
+        foreach ($this->fs->listContents('.')->toArray() as $item) {
+            if ($item->isDir()) {
+                $this->fs->deleteDirectory($item->path());
+            } else {
+                $this->fs->delete($item->path());
+            }
+        }
+
         Yii::$app->cache->delete('assetManagerPublished');
 
-        $this->fs->deleteDirectory('.');
     }
 
     /**


### PR DESCRIPTION
## Problem

Clearing the cache via **Administration → Settings → Clear cache** fails with a `Permission denied` error in some setups (e.g. Docker):

```
League\Flysystem\UnableToDeleteDirectory: Unable to delete directory located at: .
rmdir(/app/public/assets/): Permission denied
```

`AssetManager::clear()` called `$this->fs->deleteDirectory('.')`. Flysystem normalizes `'.'` to the mount root, so the local adapter deletes the assets contents **and then** calls `rmdir()` on the mount directory itself (`/app/public/assets/`). `rmdir()` requires write permission on the *parent* directory — which the web-server user does not have in containerized setups — so the operation fails even though the web server can write *inside* `assets/`.

## Fix

Only remove the *contents* of the assets mount, never the mount directory itself: list the top-level entries and delete each one (files via `delete()`, subdirectories via `deleteDirectory()`).

- Equivalent in cost to the previous behaviour — the same files/directories are deleted exactly once; only the shallow top-level listing is materialized.
- Adapter-agnostic (works for local, S3, etc.).
- Skips solely the `rmdir()` on the mount root that was failing.

Introduced with the FlySystem-based `AssetManager` (#8011), so this affects `develop` / 1.19 only.