### PR TITLE
Fix: register module namespace aliases before running migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ HumHub Changelog
 
 1.19 (TBD)
 ----------
+- Fix: `migrate/up --includeModuleMigrations=1` now registers Yii namespace aliases for all installed modules before scanning migration paths, so module classes (e.g. in old migrations) are autoloadable even when `#[WithoutModuleAutoload]` skipped their bootstrap registration
 - Fix #8227: Clear cache no longer fails with "Permission denied" when the assets mount directory is not deletable (e.g. on Docker); only its contents are removed
 - Enh: Added `#[WithoutModuleAutoload]` attribute for console controllers that do not require module loading (e.g. `settings/*`, `cache/*`)
 - Enh #8214: Introduced `ModuleDiscoveryService` centralising all module filesystem discovery and `ModuleService` encapsulating per-module lifecycle operations (enable, disable, remove); slimmed down `ModuleAutoLoader` and `ModuleManager`

--- a/protected/humhub/commands/MigrateController.php
+++ b/protected/humhub/commands/MigrateController.php
@@ -244,6 +244,16 @@ class MigrateController extends \yii\console\controllers\MigrateController
         $migrationPaths = ['base' => $this->migrationPath];
 
         if ($this->includeModuleMigrations) {
+            // Register namespace aliases for all installed modules so their classes are
+            // autoloadable during migration execution. Reads only module.json — no config.php
+            // is executed, so broken configs cannot interfere.
+            foreach (ModuleDiscoveryService::findInstalledModules() as $moduleId => $info) {
+                Yii::setAlias('@humhub/modules/' . $moduleId, $info['basePath']);
+                if (Yii::getAlias('@' . $moduleId, false) === false) {
+                    Yii::setAlias('@' . $moduleId, $info['basePath']);
+                }
+            }
+
             foreach (ModuleDiscoveryService::locateModuleConfigs() as $basePath => $config) {
                 $migrationsPath = $basePath . DIRECTORY_SEPARATOR . 'migrations';
                 if (is_dir($migrationsPath)) {

--- a/protected/humhub/commands/MigrateController.php
+++ b/protected/humhub/commands/MigrateController.php
@@ -244,9 +244,7 @@ class MigrateController extends \yii\console\controllers\MigrateController
         $migrationPaths = ['base' => $this->migrationPath];
 
         if ($this->includeModuleMigrations) {
-            // Register namespace aliases for all installed modules so their classes are
-            // autoloadable during migration execution. Reads only module.json — no config.php
-            // is executed, so broken configs cannot interfere.
+            // Aliases make module classes autoloadable without executing config.php
             foreach (ModuleDiscoveryService::findInstalledModules() as $moduleId => $info) {
                 Yii::setAlias('@humhub/modules/' . $moduleId, $info['basePath']);
                 if (Yii::getAlias('@' . $moduleId, false) === false) {


### PR DESCRIPTION
## Problem

`migrate/up --includeModuleMigrations=1` could fail with `Class "humhub\modules\<id>\models\<Model>" not found` for old module migrations that reference their own model classes.

Root cause: with `#[WithoutModuleAutoload]`, third-party modules are not registered at bootstrap. `ModuleManager::register()` is what normally sets `Yii::setAlias('@humhub/modules/<id>', $basePath)` — the alias Yii's autoloader needs to resolve `humhub\modules\<id>\*` classes. Without it, any migration that instantiates a module class fails.

## Fix

Before scanning third-party module migration paths, register Yii namespace aliases for all installed modules by reading their `module.json` (no `config.php` executed). This makes module classes autoloadable during migration execution without risking broken config side-effects.