### PR TITLE
Document that module migrations run without the module bootstrapped

### DIFF
--- a/docs/develop/concept-models.md
+++ b/docs/develop/concept-models.md
@@ -55,6 +55,39 @@ grunt migrate-up
 
 Missing migrations are also executed when accessing `Administration -> Information -> Database`.
 
+## Migrations run without your module loaded
+
+Migrations execute via the console (`migrate/up`), where your module is **not
+bootstrapped** — its `config.php` and `Module::init()` never run. Keep every
+migration self-contained:
+
+- Your module's **classes are autoloadable** (core registers an
+  `@humhub/modules/<id>` alias before running migrations), so referencing a model
+  or a class constant from a migration is fine.
+- But `Yii::$app->getModule('<id>')` returns **`null`**. Do not call `->settings`,
+  `->getConfig()`, or any code that reaches through `getModule()` — including a
+  settings model whose `init()` does so. It fatals with
+  `Attempt to read property "settings" on null`.
+- Read and write settings with plain DB operations on the `setting` table:
+
+  ```php
+  // Instead of: Yii::$app->getModule('mymodule')->settings->set('foo', $value);
+  $this->upsert('setting',
+      ['module_id' => 'mymodule', 'name' => 'foo', 'value' => $value],
+      ['value' => $value]);
+
+  // Instead of: Yii::$app->getModule('mymodule')->settings->delete('foo');
+  $this->delete('setting',
+      ['module_id' => 'mymodule', 'name' => 'foo', 'contentcontainer_id' => null]);
+  ```
+
+- Prefer literal values over runtime constants
+  (e.g. `defaultValue(1)` rather than `defaultValue(MyModel::STATUS_OPEN)`).
+
+This applies to your `uninstall.php` migration too — `Module::disable()` already
+clears your module's global and container settings (see [Settings](concept-settings.md)),
+so an uninstall migration only needs to drop tables and columns.
+
 ## Uninstall Migration
 
 Your module should also provide an `uninstall.php` file.

--- a/docs/develop/module-migrate.md
+++ b/docs/develop/module-migrate.md
@@ -220,6 +220,7 @@ Each minor release line has its own file with the breaking changes, new APIs and
   - `LdapAuth::$connectionId` and `LdapUserSource::$connectionId` are now required (no default `'ldap'` fallback) — instantiating either class without a connection ID throws `InvalidConfigException`. The bootstrap registers them per connection ID from the registry.
   - The LDAP UserSource is now registered via its own event hook on `UserSourceCollection::EVENT_BEFORE_USER_SOURCES_SET` (`Events::onUserSourceCollectionSet`), separate from the AuthClient registration on `Collection::EVENT_BEFORE_CLIENTS_SET`. The two collections are no longer coupled through a single event handler.
 - `MigrateController::$includeModuleMigrations` is now `true` by default
+- **Modules are no longer bootstrapped during `migrate/up`** — `Yii::$app->getModule('<id>')` is `null` inside migrations, so they must not access `->settings` / `->getConfig()` (module classes remain autoloadable). See [Migrations run without your module loaded](concept-models.md#migrations-run-without-your-module-loaded).
 - SiteIcon: Remove support for manually uploaded `@web/uploads/icon/` icons
 - New `AssetImage` class
   - `LogoImage`, `SiteIcon`, `LoginBackground`, `MailHeader`, `ProfileImage`, `ProfileBannerImage` are now deprecated or removed.


### PR DESCRIPTION
Adds a "Migrations run without your module loaded" section to the module developer guide (`docs/develop/concept-models.md`).

Since the migrate command runs without bootstrapping modules (`#[WithoutModuleAutoload]`), migrations that reach through `Yii::$app->getModule('<id>')->settings` fatal with `Attempt to read property "settings" on null`. The new section documents:

- what migrations **can** rely on — module classes are autoloadable via the registered `@humhub/modules/<id>` aliases;
- what they **can't** — `getModule()` returns `null`, so no `->settings` / `->getConfig()` access (including via a settings model's `init()`);
- the raw-SQL pattern for reading/writing settings on the `setting` table, and preferring literal values over runtime constants.

Also notes it applies to `uninstall.php`. Companion to the core fix that registers module namespace aliases before running migrations.