### PR TITLE
Re-apply activity cap to mail summary to prevent oversized mails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ HumHub Changelog
 
 1.19 (TBD)
 ----------
+- Fix #8230: Activity summary mails could grow oversized and fail to send ("552 message too large") when a user's last summary date was far in the past — the activity refactoring had dropped the per-mail activity cap, so the entire backlog since the last successful summary was rendered into a single mail; re-applied the cap in `MailSummary::getActivities()`
 - Fix: `migrate/up --includeModuleMigrations=1` now registers Yii namespace aliases for all installed modules before scanning migration paths, so module classes (e.g. in old migrations) are autoloadable even when `#[WithoutModuleAutoload]` skipped their bootstrap registration
 - Fix #8227: Clear cache no longer fails with "Permission denied" when the assets mount directory is not deletable (e.g. on Docker); only its contents are removed
 - Enh: Added `#[WithoutModuleAutoload]` attribute for console controllers that do not require module loading (e.g. `settings/*`, `cache/*`)

--- a/protected/humhub/modules/activity/components/MailSummary.php
+++ b/protected/humhub/modules/activity/components/MailSummary.php
@@ -123,6 +123,7 @@ class MailSummary extends Component
         $query->subscribedContentContainers($this->user);
         $query->mailLimitContentContainer($this->user);
         $query->mailLimitTypes($this->user);
+        $query->limit($this->maxActivityCount);
 
         return $query->all();
     }


### PR DESCRIPTION
## Problem

On a community running the upcoming release, the mail queue logs repeated SMTP failures:

```
Expected response code "250" but got code "552", with message
"552 Message too large (maximum size 14MB)".
```

The failing job is the activity **mail summary** (`queue/exec` → `SendMailSummary`). One captured mail was **64 MB**, containing **~5,700 activities** in a single summary.

## Root cause

`MailSummary::getActivities()` lost its `limit($this->maxActivityCount)` (50) during the activity refactoring (#7933) — the `$maxActivityCount = 50` property still exists but is no longer applied.

The summary window is `activity.created_at > mailSummaryLast`, and `mailSummaryLast` is only advanced **on a successful send** (`setLastSummaryDate()` runs inside `if ($mail->send())`). So for a user whose last successful summary is far in the past, the window spans a very long time.

The two combine into a failure loop:

1. A user's `mailSummaryLast` is stale (in the analysed case **2024-03-12**, 2+ years old — e.g. because summaries were effectively inactive for that user for a long time).
2. Without the cap, the summary renders **every** activity in that multi-year window — tens of thousands of rows → a mail far over the SMTP size limit.
3. The mail fails to send (552), so `mailSummaryLast` is **not** advanced.
4. Every subsequent run rebuilds the same (ever-growing) mail → it never recovers.

The old 50-cap prevented this entirely: regardless of how wide the window was, only 50 activities were rendered, so the mail stayed small, sent successfully, and `mailSummaryLast` advanced. Activity timestamps themselves are fine (verified: `created_at` is spread naturally across years, not corrupted) — the issue is purely the missing cap.

## Fix

Re-apply `limit($this->maxActivityCount)` in `MailSummary::getActivities()`. The mail is capped again, so it sends, `mailSummaryLast` advances, and the window resets to normal on the next run.

Grouping in summary mails is intentionally left off.

## Notes

- Targets `develop` — the regression only exists on the refactored branch; `master` still has the original limit-based implementation.
- A separate, minor data-quality observation (some `activity.created_at` values differ from their linked content's date) is unrelated to this size issue and is not addressed here.