### PR TITLE
Fix: apply migrations only for enabled modules in app-wide scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ HumHub Changelog
 ----------
 - Fix #8230: Activity summary mails could grow oversized and fail to send ("552 message too large") when a user's last summary date was far in the past — the activity refactoring had dropped the per-mail activity cap, so the entire backlog since the last successful summary was rendered into a single mail; re-applied the cap in `MailSummary::getActivities()`
 - Fix: `migrate/up --includeModuleMigrations=1` now registers Yii namespace aliases for all installed modules before scanning migration paths, so module classes (e.g. in old migrations) are autoloadable even when `#[WithoutModuleAutoload]` skipped their bootstrap registration
+- Fix: The application-wide migration scan (`migrate/up`, admin "Database", installer) again applies only enabled (and core) module migrations; the `ModuleDiscoveryService` refactoring had made it apply migrations of every module present in the modules directory, creating tables for modules that were never enabled
 - Fix #8227: Clear cache no longer fails with "Permission denied" when the assets mount directory is not deletable (e.g. on Docker); only its contents are removed
 - Enh: Added `#[WithoutModuleAutoload]` attribute for console controllers that do not require module loading (e.g. `settings/*`, `cache/*`)
 - Enh #8214: Introduced `ModuleDiscoveryService` centralising all module filesystem discovery and `ModuleService` encapsulating per-module lifecycle operations (enable, disable, remove); slimmed down `ModuleAutoLoader` and `ModuleManager`

--- a/protected/humhub/commands/MigrateController.php
+++ b/protected/humhub/commands/MigrateController.php
@@ -9,8 +9,10 @@
 namespace humhub\commands;
 
 use humhub\components\console\WithoutModuleAutoload;
+use humhub\components\InstallationState;
 use humhub\components\Module;
 use humhub\helpers\DatabaseHelper;
+use humhub\models\ModuleEnabled;
 use humhub\services\ModuleDiscoveryService;
 use Yii;
 use yii\console\controllers\BaseMigrateController;
@@ -252,11 +254,27 @@ class MigrateController extends \yii\console\controllers\MigrateController
                 }
             }
 
+            // Only enabled (and core) modules: a module that is merely present in the
+            // modules directory but never enabled must not have its migrations applied — its
+            // tables are created when it is enabled (see Module::enable()). This mirrors
+            // ModuleManager::register(), which never registers a disabled non-core module as a
+            // Yii application module. Reading the enabled ids straight from the database keeps
+            // this working under #[WithoutModuleAutoload], where modules are not bootstrapped.
+            $enabledModuleIds = Yii::$app->installationState->hasState(InstallationState::STATE_DATABASE_CREATED)
+                ? ModuleEnabled::getEnabledIds()
+                : [];
+
             foreach (ModuleDiscoveryService::locateModuleConfigs() as $basePath => $config) {
                 $migrationsPath = $basePath . DIRECTORY_SEPARATOR . 'migrations';
-                if (is_dir($migrationsPath)) {
-                    $migrationPaths[$config['id']] = $migrationsPath;
+                if (!is_dir($migrationsPath)) {
+                    continue;
                 }
+
+                if (empty($config['isCoreModule']) && !in_array($config['id'], $enabledModuleIds, true)) {
+                    continue;
+                }
+
+                $migrationPaths[$config['id']] = $migrationsPath;
             }
         }
 

--- a/protected/humhub/tests/codeception/unit/commands/MigrateControllerTest.php
+++ b/protected/humhub/tests/codeception/unit/commands/MigrateControllerTest.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * @link      https://www.humhub.org/
+ * @copyright Copyright (c) 2026 HumHub GmbH & Co. KG
+ * @license   https://www.humhub.com/licences
+ */
+
+namespace humhub\tests\codeception\unit\commands;
+
+use humhub\commands\MigrateController;
+use humhub\models\ModuleEnabled;
+use ReflectionMethod;
+use tests\codeception\_support\HumHubDbTestCase;
+use Yii;
+
+/**
+ * Verifies that the application-wide migration scan only applies migrations of enabled
+ * (and core) modules. A module that is merely present in the modules directory but never
+ * enabled must not have its migrations applied.
+ *
+ * @since 1.19
+ */
+class MigrateControllerTest extends HumHubDbTestCase
+{
+    /**
+     * Test fixture module that ships a real migrations/ directory but is not a core module.
+     * Its config.php id (used by locateModuleConfigs / ModuleEnabled) is "moduleWithMigration".
+     */
+    private const FIXTURE_MODULE_ID = 'moduleWithMigration';
+
+    private array $originalAutoloadPaths;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Make the _data/ModuleConfig fixture modules discoverable in addition to the
+        // regular module paths so that "moduleWithMigration" shows up on the filesystem.
+        $this->originalAutoloadPaths = Yii::$app->params['moduleAutoloadPaths'];
+        Yii::$app->params['moduleAutoloadPaths'][] = dirname(__DIR__, 2) . '/_data/ModuleConfig';
+
+        $this->forgetFixtureModule();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->forgetFixtureModule();
+        Yii::$app->params['moduleAutoloadPaths'] = $this->originalAutoloadPaths;
+
+        parent::tearDown();
+    }
+
+    public function testDisabledModuleMigrationsAreExcluded(): void
+    {
+        $paths = $this->resolveMigrationPaths();
+
+        static::assertArrayHasKey('base', $paths, 'core base migrations must always be included');
+        static::assertArrayNotHasKey(
+            self::FIXTURE_MODULE_ID,
+            $paths,
+            'a module present on disk but not enabled must not contribute migrations',
+        );
+    }
+
+    public function testEnabledModuleMigrationsAreIncluded(): void
+    {
+        (new ModuleEnabled(['module_id' => self::FIXTURE_MODULE_ID]))->save();
+
+        $paths = $this->resolveMigrationPaths();
+
+        static::assertArrayHasKey(
+            self::FIXTURE_MODULE_ID,
+            $paths,
+            'an enabled module must contribute its migrations',
+        );
+    }
+
+    private function resolveMigrationPaths(): array
+    {
+        // Drop cached module configs and enabled-module ids so each scan reflects current state.
+        Yii::$app->cache->flush();
+
+        $controller = new MigrateController('migrate', Yii::$app, ['includeModuleMigrations' => 1]);
+
+        $method = new ReflectionMethod($controller, 'getMigrationPaths');
+        $method->setAccessible(true);
+
+        return $method->invoke($controller);
+    }
+
+    private function forgetFixtureModule(): void
+    {
+        ModuleEnabled::deleteAll(['module_id' => self::FIXTURE_MODULE_ID]);
+        Yii::$app->cache->flush();
+    }
+}


### PR DESCRIPTION
## Problem

A regression introduced by the `ModuleDiscoveryService` refactoring (#8214 / #8219): the application-wide migration scan now applies migrations for **every module present in the modules directory**, creating tables for modules that were never enabled.

Reported behaviour change between v1.18 (master) and v1.19 (develop): on a dev system with a folder containing all modules, every module created all its tables even though it was not activated.

## Root cause

`MigrateController::getMigrationPaths()` switched its module-discovery source:

- **master (v1.18):** iterated `Yii::$app->getModules()`. `ModuleManager::register()` returns early for a disabled non-core module *before* calling `Yii::$app->setModule()`, so disabled modules never appeared there — their migrations never ran.
- **develop (v1.19):** the controller carries `#[WithoutModuleAutoload]` and no longer bootstraps modules, so it scans the filesystem via `ModuleDiscoveryService::locateModuleConfigs()`, which has no notion of enabled/disabled → all installed modules were migrated.

Reachable from all app-wide paths: CLI `migrate/up`, admin *Information → Database* (`MigrationService::create()`), and the installer. The per-module path on enable (`Module::enable()` → per-module `MigrationService`) was always correct and is unchanged.

## Fix

Restrict the app-wide scan to **enabled (and core)** modules again, reading the enabled ids straight from the database (`ModuleEnabled::getEnabledIds()`), guarded by `installationState->hasState(STATE_DATABASE_CREATED)` so fresh installs (before the `module_enabled` table exists) keep working. This restores the master semantics without giving up the `#[WithoutModuleAutoload]` approach. A module's tables are created when it is enabled; a module merely present on disk must not have its migrations applied.

## Tests

New `MigrateControllerTest` using the `_data/ModuleConfig` fixtures:
- `testDisabledModuleMigrationsAreExcluded` — failed before the fix (disabled `moduleWithMigration` was included), passes now.
- `testEnabledModuleMigrationsAreIncluded` — guards the other direction.

`ModuleManagerTest` (33 tests, incl. enable/disable + migration) and `ModuleAutoLoaderTest` remain green.