### PR TITLE
Allow a UserSource to declare email optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ HumHub Changelog
 
 1.19 (TBD)
 ----------
+- Enh: A `UserSource` can declare email optional via `UserSourceInterface::isEmailRequired()` (default `true`); `User::isEmailRequired()` now consults the user's source (through `UserSourceService`), so sources for external/federated users can provision accounts without an email address
 - Fix #8230: Activity summary mails could grow oversized and fail to send ("552 message too large") when a user's last summary date was far in the past — the activity refactoring had dropped the per-mail activity cap, so the entire backlog since the last successful summary was rendered into a single mail; re-applied the cap in `MailSummary::getActivities()`
 - Fix: `migrate/up --includeModuleMigrations=1` now registers Yii namespace aliases for all installed modules before scanning migration paths, so module classes (e.g. in old migrations) are autoloadable even when `#[WithoutModuleAutoload]` skipped their bootstrap registration
 - Fix: The application-wide migration scan (`migrate/up`, admin "Database", installer) again applies only enabled (and core) module migrations; the `ModuleDiscoveryService` refactoring had made it apply migrations of every module present in the modules directory, creating tables for modules that were never enabled

--- a/docs/develop/user-source.md
+++ b/docs/develop/user-source.md
@@ -195,8 +195,15 @@ class MyUserSource extends BaseUserSource
 
     // updateUser() inherited from BaseUserSource — writes $managedAttributes
     // present in $attributes onto User and Profile.
+
+    public function isEmailRequired(): bool
+    {
+        return false; // external/federated source whose users may have no email
+    }
 }
 ```
+
+`isEmailRequired()` defaults to `true` in `BaseUserSource`. Return `false` for sources whose users need no email address (e.g. federated/Fediverse users); `User::isEmailRequired()` then skips the email requirement for those users regardless of the global `user` module `emailRequired` setting.
 
 For config-only sources without custom code, use `GenericUserSource` and configure entirely via `userSourceCollection`.
 

--- a/protected/humhub/modules/user/models/User.php
+++ b/protected/humhub/modules/user/models/User.php
@@ -32,6 +32,7 @@ use humhub\modules\user\helpers\AuthHelper;
 use humhub\modules\user\models\fieldtype\BaseTypeVirtual;
 use humhub\modules\user\Module;
 use humhub\modules\user\services\PasswordRecoveryService;
+use humhub\modules\user\services\UserSourceService;
 use Yii;
 use yii\base\Exception;
 use yii\base\InvalidConfigException;
@@ -206,6 +207,12 @@ class User extends ContentContainerActiveRecord implements IdentityInterface
      */
     public function isEmailRequired(): bool
     {
+        // A UserSource may declare email optional (e.g. federated users). The
+        // service resolves the source safely (falls back to LocalUserSource for
+        // an unknown/misconfigured source), so this never breaks a user save.
+        if (!UserSourceService::getForUser($this)->isEmailRequired()) {
+            return false;
+        }
         /* @var $userModule Module */
         $userModule = Yii::$app->getModule('user');
         return $userModule->emailRequired;

--- a/protected/humhub/modules/user/services/UserSourceService.php
+++ b/protected/humhub/modules/user/services/UserSourceService.php
@@ -143,6 +143,11 @@ class UserSourceService
         return $this->getUserSource()->canDeleteAccount();
     }
 
+    public function isEmailRequired(): bool
+    {
+        return $this->getUserSource()->isEmailRequired();
+    }
+
     /**
      * Returns whether a given auth client is permitted for this user's source.
      * An empty allowed list means all clients are permitted.

--- a/protected/humhub/modules/user/source/BaseUserSource.php
+++ b/protected/humhub/modules/user/source/BaseUserSource.php
@@ -129,6 +129,11 @@ abstract class BaseUserSource extends Component implements UserSourceInterface
         return $this->deleteAccount;
     }
 
+    public function isEmailRequired(): bool
+    {
+        return true;
+    }
+
     public function getUsernameStrategy(): string
     {
         return $this->usernameStrategy;

--- a/protected/humhub/modules/user/source/UserSourceInterface.php
+++ b/protected/humhub/modules/user/source/UserSourceInterface.php
@@ -134,6 +134,13 @@ interface UserSourceInterface
      */
     public function canDeleteAccount(): bool;
 
+    /**
+     * Whether users provisioned by this source must have an email address.
+     * When false, {@see User::isEmailRequired()} returns false for such users
+     * regardless of the global `user` module `emailRequired` setting.
+     */
+    public function isEmailRequired(): bool;
+
     // --- Username Strategy ---
 
     /**

--- a/protected/humhub/modules/user/tests/codeception/unit/UserEmailRequiredTest.php
+++ b/protected/humhub/modules/user/tests/codeception/unit/UserEmailRequiredTest.php
@@ -1,0 +1,135 @@
+<?php
+
+/**
+ * @link https://www.humhub.org/
+ * @copyright Copyright (c) 2024 HumHub GmbH & Co. KG
+ * @license https://www.humhub.com/licences
+ */
+
+namespace humhub\modules\user\tests\codeception\unit;
+
+use humhub\modules\user\models\User;
+use humhub\modules\user\source\BaseUserSource;
+use tests\codeception\_support\HumHubDbTestCase;
+use Yii;
+
+/**
+ * Tests that User::isEmailRequired() consults the UserSource when set.
+ */
+class UserEmailRequiredTest extends HumHubDbTestCase
+{
+    // -------------------------------------------------------------------------
+    // Fallback to global setting when no source / unregistered source
+    // -------------------------------------------------------------------------
+
+    public function testGlobalRequiredWhenNoSource(): void
+    {
+        /** @var \humhub\modules\user\Module $userModule */
+        $userModule = Yii::$app->getModule('user');
+        $userModule->emailRequired = true;
+
+        $user = new User();
+        $user->user_source = '';
+
+        $this->assertTrue($user->isEmailRequired());
+    }
+
+    public function testGlobalNotRequiredWhenNoSource(): void
+    {
+        /** @var \humhub\modules\user\Module $userModule */
+        $userModule = Yii::$app->getModule('user');
+        $userModule->emailRequired = false;
+
+        $user = new User();
+        $user->user_source = '';
+
+        $this->assertFalse($user->isEmailRequired());
+
+        // Restore default
+        $userModule->emailRequired = true;
+    }
+
+    public function testGlobalSettingUsedForUnregisteredSource(): void
+    {
+        /** @var \humhub\modules\user\Module $userModule */
+        $userModule = Yii::$app->getModule('user');
+        $userModule->emailRequired = true;
+
+        $user = new User();
+        $user->user_source = 'nonexistent-source-xyz';
+
+        // getUserSourceInstance() catches the InvalidArgumentException → null → falls back
+        $this->assertTrue($user->isEmailRequired());
+    }
+
+    // -------------------------------------------------------------------------
+    // Source declares email optional → isEmailRequired() must return false
+    // -------------------------------------------------------------------------
+
+    public function testSourceOptionalEmailReturnsFalse(): void
+    {
+        /** @var \humhub\modules\user\Module $userModule */
+        $userModule = Yii::$app->getModule('user');
+        $userModule->emailRequired = true; // global says required, source overrides
+
+        $stub = new class extends BaseUserSource {
+            public function getId(): string { return 'test-optional'; }
+            public function createUser(array $attributes): ?User { return null; }
+            public function isEmailRequired(): bool { return false; }
+        };
+
+        Yii::$app->userSourceCollection->setUserSource('test-optional', $stub);
+
+        $user = new User();
+        $user->user_source = 'test-optional';
+
+        $this->assertFalse($user->isEmailRequired());
+    }
+
+    public function testSourceOptionalEmailReturnsFalseEvenWhenGlobalFalse(): void
+    {
+        /** @var \humhub\modules\user\Module $userModule */
+        $userModule = Yii::$app->getModule('user');
+        $userModule->emailRequired = false;
+
+        $stub = new class extends BaseUserSource {
+            public function getId(): string { return 'test-optional-2'; }
+            public function createUser(array $attributes): ?User { return null; }
+            public function isEmailRequired(): bool { return false; }
+        };
+
+        Yii::$app->userSourceCollection->setUserSource('test-optional-2', $stub);
+
+        $user = new User();
+        $user->user_source = 'test-optional-2';
+
+        $this->assertFalse($user->isEmailRequired());
+
+        // Restore default
+        $userModule->emailRequired = true;
+    }
+
+    // -------------------------------------------------------------------------
+    // Default BaseUserSource returns true (backward-compatibility)
+    // -------------------------------------------------------------------------
+
+    public function testBaseSourceDefaultEmailRequired(): void
+    {
+        /** @var \humhub\modules\user\Module $userModule */
+        $userModule = Yii::$app->getModule('user');
+        $userModule->emailRequired = true;
+
+        $stub = new class extends BaseUserSource {
+            public function getId(): string { return 'test-default'; }
+            public function createUser(array $attributes): ?User { return null; }
+            // isEmailRequired() NOT overridden — must inherit true from BaseUserSource
+        };
+
+        Yii::$app->userSourceCollection->setUserSource('test-default', $stub);
+
+        $user = new User();
+        $user->user_source = 'test-default';
+
+        $this->assertTrue($user->isEmailRequired());
+    }
+}


### PR DESCRIPTION
## What

Adds `UserSourceInterface::isEmailRequired(): bool` (default `true` in `BaseUserSource`) and a matching `UserSourceService::isEmailRequired()` convenience. `User::isEmailRequired()` now consults the user's source (via `UserSourceService`), so a `UserSource` that provisions external users can allow accounts without an email address.

## Why

External identity sources (e.g. a Fediverse/ActivityPub source) create users that have no email. Today email-required is a single global `user` module setting, so the only options are synthetic placeholder addresses or weakening registration site-wide. This lets a source opt out cleanly, per source.

## Backward compatibility

- `BaseUserSource::isEmailRequired()` defaults to `true`, so every existing source (Local, Generic, LDAP, SCIM, Keycloak, JWT, SAML — all extend `BaseUserSource`) is unchanged.
- Users whose `user_source` is unset or unregistered fall back to the global `emailRequired` setting: `UserSourceService::getUserSource()` resolves an unknown/misconfigured source to `LocalUserSource` and never throws.

## Changes

- `UserSourceInterface`: declare `isEmailRequired()`
- `BaseUserSource`: default `true`
- `UserSourceService`: `isEmailRequired()` convenience (mirrors `canChangeEmail()`)
- `User::isEmailRequired()`: consult the source
- Unit test, CHANGELOG, and `docs/develop/user-source.md`
