### PR TITLE
Fix space member join/leave activity link target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ HumHub Changelog
 
 1.19 (TBD)
 ----------
+- Fix #8242: Within a space, "member joined"/"left" activities now link to the member's profile instead of the (redundant) space; in the global/dashboard stream and for grouped entries (multiple members) they keep linking to the space
 - Enh: A `UserSource` can declare email optional via `UserSourceInterface::isEmailRequired()` (default `true`); `User::isEmailRequired()` now consults the user's source (through `UserSourceService`), so sources for external/federated users can provision accounts without an email address
 - Fix #8230: Activity summary mails could grow oversized and fail to send ("552 message too large") when a user's last summary date was far in the past — the activity refactoring had dropped the per-mail activity cap, so the entire backlog since the last successful summary was rendered into a single mail; re-applied the cap in `MailSummary::getActivities()`
 - Fix: `migrate/up --includeModuleMigrations=1` now registers Yii namespace aliases for all installed modules before scanning migration paths, so module classes (e.g. in old migrations) are autoloadable even when `#[WithoutModuleAutoload]` skipped their bootstrap registration

--- a/protected/humhub/modules/space/activities/MemberAddedActivity.php
+++ b/protected/humhub/modules/space/activities/MemberAddedActivity.php
@@ -49,6 +49,19 @@ class MemberAddedActivity extends BaseSpaceActivity implements ConfigurableActiv
         };
     }
 
+    public function getUrl(bool $scheme = true): ?string
+    {
+        // Inside the space the space link is redundant, so a single membership
+        // change links to the member's profile. Grouped entries reference
+        // multiple members, and outside the space the entry highlights the
+        // space ("joined the Space {spaceName}") — both keep the space link.
+        if ($this->groupCount > 1 || !$this->inSpaceContext()) {
+            return parent::getUrl($scheme);
+        }
+
+        return $this->user->getUrl($scheme);
+    }
+
     public function getGroupingQuery(): ActiveQueryActivity
     {
         return Activity::find()

--- a/protected/humhub/modules/space/activities/MemberRemovedActivity.php
+++ b/protected/humhub/modules/space/activities/MemberRemovedActivity.php
@@ -49,6 +49,19 @@ class MemberRemovedActivity extends BaseSpaceActivity implements ConfigurableAct
         };
     }
 
+    public function getUrl(bool $scheme = true): ?string
+    {
+        // Inside the space the space link is redundant, so a single membership
+        // change links to the member's profile. Grouped entries reference
+        // multiple members, and outside the space the entry highlights the
+        // space ("left the Space {spaceName}") — both keep the space link.
+        if ($this->groupCount > 1 || !$this->inSpaceContext()) {
+            return parent::getUrl($scheme);
+        }
+
+        return $this->user->getUrl($scheme);
+    }
+
     public function getGroupingQuery(): ActiveQueryActivity
     {
         return Activity::find()

--- a/protected/humhub/modules/space/tests/codeception/unit/MemberActivityTest.php
+++ b/protected/humhub/modules/space/tests/codeception/unit/MemberActivityTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace tests\codeception\unit\modules\space;
+
+use humhub\modules\activity\models\Activity;
+use humhub\modules\activity\services\ActivityManager;
+use humhub\modules\content\components\ContentContainerController;
+use humhub\modules\space\activities\MemberAddedActivity;
+use humhub\modules\space\activities\MemberRemovedActivity;
+use humhub\modules\space\models\Space;
+use humhub\modules\user\models\User;
+use ReflectionClass;
+use tests\codeception\_support\HumHubDbTestCase;
+use Yii;
+
+class MemberActivityTest extends HumHubDbTestCase
+{
+    public function testMemberAddedInSpaceContextLinksToMemberProfile()
+    {
+        $this->becomeUser('Admin');
+
+        $space = Space::findOne(['id' => 2]);
+        $user = User::findOne(['id' => 2]);
+
+        $activity = ActivityManager::dispatch(MemberAddedActivity::class, $space, $user);
+
+        // Viewing the space's own activity stream: the space link is redundant.
+        $this->enterSpaceContext($space);
+
+        $this->assertSame(1, $activity->groupCount);
+        $this->assertSame($user->getUrl(false), $activity->getUrl(false));
+    }
+
+    public function testMemberRemovedInSpaceContextLinksToMemberProfile()
+    {
+        $this->becomeUser('Admin');
+
+        $space = Space::findOne(['id' => 2]);
+        $user = User::findOne(['id' => 2]);
+
+        $activity = ActivityManager::dispatch(MemberRemovedActivity::class, $space, $user);
+
+        $this->enterSpaceContext($space);
+
+        $this->assertSame(1, $activity->groupCount);
+        $this->assertSame($user->getUrl(false), $activity->getUrl(false));
+    }
+
+    public function testMemberAddedOutsideSpaceLinksToSpace()
+    {
+        $this->becomeUser('Admin');
+
+        $space = Space::findOne(['id' => 2]);
+        $user = User::findOne(['id' => 2]);
+
+        $activity = ActivityManager::dispatch(MemberAddedActivity::class, $space, $user);
+
+        // Global/dashboard stream (no space context): the entry highlights the
+        // space ("joined the Space {spaceName}"), so it keeps the space link.
+        $this->assertFalse(Yii::$app->controller instanceof ContentContainerController);
+        $this->assertSame(1, $activity->groupCount);
+        $this->assertSame($space->getUrl(false), $activity->getUrl(false));
+    }
+
+    public function testGroupedMemberAddedLinksToSpaceEvenInSpaceContext()
+    {
+        $this->becomeUser('Admin');
+
+        $space = Space::findOne(['id' => 2]);
+
+        // Two members joining within the same time bucket are grouped, so the
+        // entry references multiple users and must keep the space as link
+        // target — even when viewed inside the space.
+        ActivityManager::dispatch(MemberAddedActivity::class, $space, User::findOne(['id' => 2]));
+        ActivityManager::dispatch(MemberAddedActivity::class, $space, User::findOne(['id' => 3]));
+
+        $record = Activity::find()
+            ->enableGrouping()
+            ->andWhere(['activity.class' => MemberAddedActivity::class])
+            ->andWhere(['activity.contentcontainer_id' => $space->contentContainerRecord->id])
+            ->orderBy(['activity.grouping_key' => SORT_DESC])
+            ->one();
+
+        $activity = ActivityManager::load($record);
+
+        $this->enterSpaceContext($space);
+
+        $this->assertSame(2, $activity->groupCount);
+        $this->assertSame($space->getUrl(false), $activity->getUrl(false));
+    }
+
+    /**
+     * Simulates running inside a content container controller (e.g. the space
+     * activity stream) so that BaseSpaceActivity::inSpaceContext() returns true.
+     */
+    private function enterSpaceContext(Space $space): void
+    {
+        $controller = (new ReflectionClass(ContentContainerController::class))
+            ->newInstanceWithoutConstructor();
+        $controller->contentContainer = $space;
+        Yii::$app->controller = $controller;
+    }
+}


### PR DESCRIPTION
## Problem

Clicking a *"member joined"* / *"member left"* activity opened the **space** instead of the **member's profile**.

`BaseActivity::getUrl()` defaults to the content container's URL (the space), and `MemberAddedActivity` / `MemberRemovedActivity` did not override it — so the whole activity entry always linked to the space.

## Fix

Override `getUrl()` in both membership activities, mirroring the `inSpaceContext()` branching already used in `getMessage()`:

| Context | Single member | Grouped (multiple) |
|---|---|---|
| Inside the space | **Member profile** | Space |
| Global / dashboard stream | Space | Space |

Inside the space the space link is redundant, so a single membership change links to the member's profile. Grouped entries reference several members, and outside the space the entry highlights the space (*"joined the Space {spaceName}"*) — both keep the space link.

## Tests

Added `MemberActivityTest` covering all four cells of the matrix (space context simulated via a `ContentContainerController` stub):

- single join inside space → profile
- single leave inside space → profile
- single join outside space → space
- grouped join (even inside space) → space

Full space unit suite green (10 tests, 50 assertions); activity module unit suite green (24 tests).