### PR TITLE
Add progress logging to queued search index rebuild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ HumHub Changelog
 - Enh #8223: Define default user idle timeout to 4 hours
 - Enh #8232: Fix absolute URLs in mail summary
 - Enh #8237: Allow symfony/mailer ^7.0 and widen all mailer bridge constraints to unblock symfony/event-dispatcher 7.x
+- Enh: Log progress of the queued search index rebuild (`SearchRebuildIndex`) — start, interim item count, completion, and failures/skips, each prefixed with the worker process ID — via the `search-indexing` log category
 
 1.18.4 (Unreleased)
 ---------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ HumHub Changelog
 - Enh #8223: Define default user idle timeout to 4 hours
 - Enh #8232: Fix absolute URLs in mail summary
 - Enh #8237: Allow symfony/mailer ^7.0 and widen all mailer bridge constraints to unblock symfony/event-dispatcher 7.x
-- Enh: Log progress of the queued search index rebuild (`SearchRebuildIndex`) — start, interim item count, completion, and failures/skips, each prefixed with the worker process ID — via the `search-indexing` log category
+- Enh #8244: Log progress of the queued search index rebuild (`SearchRebuildIndex`) — start, interim item count, completion, and failures/skips, each prefixed with the worker process ID — via the `search-indexing` log category
 
 1.18.4 (Unreleased)
 ---------------------

--- a/protected/humhub/modules/content/jobs/SearchRebuildIndex.php
+++ b/protected/humhub/modules/content/jobs/SearchRebuildIndex.php
@@ -13,9 +13,20 @@ use humhub\modules\content\services\ContentSearchService;
 use humhub\modules\content\services\SearchJobService;
 use humhub\modules\queue\interfaces\ExclusiveJobInterface;
 use humhub\modules\queue\LongRunningActiveJob;
+use Yii;
 
 class SearchRebuildIndex extends LongRunningActiveJob implements ExclusiveJobInterface
 {
+    /**
+     * Number of processed items between interim progress log messages.
+     */
+    public const LOG_PROGRESS_INTERVAL = 100;
+
+    /**
+     * Log category used for all search index rebuild messages.
+     */
+    public const LOG_CATEGORY = 'search-indexing';
+
     /**
      * @inhertidoc
      */
@@ -30,11 +41,22 @@ class SearchRebuildIndex extends LongRunningActiveJob implements ExclusiveJobInt
     public function run()
     {
         return $this->getService()->run(function (): void {
+            $pid = getmypid() ?: 'unknown';
+
+            Yii::warning(sprintf('Search index rebuild [PID %s] started.', $pid), self::LOG_CATEGORY);
+
+            $processed = 0;
             foreach (Content::find()->each() as $content) {
                 (new ContentSearchService($content))->update(false);
+
+                if (++$processed % self::LOG_PROGRESS_INTERVAL === 0) {
+                    Yii::warning(sprintf('Search index rebuild [PID %s] processed: %d items.', $pid, $processed), self::LOG_CATEGORY);
+                }
             }
 
             ContentSearchService::flushCache();
+
+            Yii::warning(sprintf('Search index rebuild [PID %s] finished. %d items indexed.', $pid, $processed), self::LOG_CATEGORY);
         });
     }
 

--- a/protected/humhub/modules/content/services/SearchJobService.php
+++ b/protected/humhub/modules/content/services/SearchJobService.php
@@ -8,6 +8,7 @@
 
 namespace humhub\modules\content\services;
 
+use humhub\modules\content\jobs\SearchRebuildIndex;
 use Yii;
 
 class SearchJobService
@@ -19,14 +20,16 @@ class SearchJobService
     public function run(callable $callable): bool
     {
         if (!Yii::$app->mutex->acquire(self::MUTEX_ID, $this->retryDelayInSeconds)) {
+            Yii::warning(sprintf('Search index rebuild [PID %s] skipped: another rebuild process is already running.', getmypid() ?: 'unknown'), SearchRebuildIndex::LOG_CATEGORY);
             return false;
         }
 
         try {
             call_user_func($callable);
             Yii::$app->mutex->release(self::MUTEX_ID);
-        } catch (\Exception) {
+        } catch (\Exception $e) {
             Yii::$app->mutex->release(self::MUTEX_ID);
+            Yii::warning(sprintf('Search index rebuild [PID %s] failed: %s', getmypid() ?: 'unknown', $e->getMessage()), SearchRebuildIndex::LOG_CATEGORY);
             return false;
         }
 


### PR DESCRIPTION
## What

Adds application-log tracking to the queued search index rebuild (`SearchRebuildIndex`), which previously ran as a black box in the queue worker with no observability.

## Changes

- `SearchRebuildIndex::run()` logs **start**, an **interim processed-item count** (every `LOG_PROGRESS_INTERVAL` = 100 items), and **completion** with the total indexed count.
- `SearchJobService::run()` logs when the rebuild is **skipped** (another rebuild already holds the mutex) and when it **fails** (the exception was previously swallowed silently).
- All messages are level `warning`, category `search-indexing`, and prefixed with the queue worker process ID (`getmypid()`, with an `unknown` fallback) so lines from one process can be correlated.

Scope is intentionally the queued rebuild only; the synchronous `content/search/rebuild` command already prints live progress to stdout.