### PR TITLE
Fix unfollow crash from dropped activity.object_model column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ HumHub Changelog
 
 1.19 (TBD)
 ----------
+- Fix: Unfollowing a user threw `Key "object_model" is not a column name` — `Follow::beforeDelete()` still queried the `activity.object_model`/`object_id` columns that the activity restructuring dropped; it now removes the `FollowActivity` via its `class`/`contentcontainer_id`/`created_by`
 - Enh: A `UserSource` can declare email optional via `UserSourceInterface::isEmailRequired()` (default `true`); `User::isEmailRequired()` now consults the user's source (through `UserSourceService`), so sources for external/federated users can provision accounts without an email address
 - Fix #8230: Activity summary mails could grow oversized and fail to send ("552 message too large") when a user's last summary date was far in the past — the activity refactoring had dropped the per-mail activity cap, so the entire backlog since the last successful summary was rendered into a single mail; re-applied the cap in `MailSummary::getActivities()`
 - Fix: `migrate/up --includeModuleMigrations=1` now registers Yii namespace aliases for all installed modules before scanning migration paths, so module classes (e.g. in old migrations) are autoloadable even when `#[WithoutModuleAutoload]` skipped their bootstrap registration

--- a/protected/humhub/modules/user/models/Follow.php
+++ b/protected/humhub/modules/user/models/Follow.php
@@ -121,11 +121,22 @@ class Follow extends ActiveRecord
 
             // ToDo: Handle this via event of User Module
             if ($this->object_model === User::class) {
+                $target = $this->getTarget();
+
                 $notification = new Followed();
                 $notification->originator = $this->user;
-                $notification->delete($this->getTarget());
+                $notification->delete($target);
 
-                foreach (Activity::findAll(['object_model' => static::class, 'object_id' => $this->id]) as $activity) {
+                // The FollowActivity is stored against the followed user's content
+                // container (see ActivityManager::dispatch); the activity table no
+                // longer has the polymorphic object_model/object_id columns.
+                foreach (
+                    Activity::findAll([
+                        'class' => FollowActivity::class,
+                        'contentcontainer_id' => $target->contentcontainer_id,
+                        'created_by' => $this->user_id,
+                    ]) as $activity
+                ) {
                     $activity->delete();
                 }
             }

--- a/protected/humhub/modules/user/tests/codeception/unit/FollowTest.php
+++ b/protected/humhub/modules/user/tests/codeception/unit/FollowTest.php
@@ -2,6 +2,8 @@
 
 namespace tests\codeception\unit;
 
+use humhub\modules\activity\models\Activity;
+use humhub\modules\user\activities\FollowActivity;
 use humhub\modules\user\models\Follow;
 use humhub\modules\user\models\User;
 use humhub\modules\user\notifications\Followed;
@@ -22,5 +24,30 @@ class FollowTest extends HumHubDbTestCase
         $this->assertNotNull($follow);
         $this->assertMailSent(1);
         $this->assertHasNotification(Followed::class, $follow, Yii::$app->user->id, 'Approval Request Notification');
+    }
+
+    public function testUnfollowUserRemovesActivity()
+    {
+        $this->becomeUser('User1');
+
+        $user = User::findOne(['id' => 1]);
+        $this->assertTrue($user->follow());
+
+        // Following a user creates a FollowActivity on the followed user's
+        // content container, authored by the follower.
+        $activity = Activity::findOne([
+            'class' => FollowActivity::class,
+            'contentcontainer_id' => $user->contentcontainer_id,
+            'created_by' => Yii::$app->user->id,
+        ]);
+        $this->assertNotNull($activity);
+
+        // Unfollowing must not raise (regression: Follow::beforeDelete used to
+        // query the dropped activity.object_model/object_id columns) and must
+        // clean up both the follow record and its activity.
+        $this->assertTrue($user->unfollow());
+
+        $this->assertNull(Follow::findOne(['object_model' => User::class, 'object_id' => 1, 'user_id' => 2]));
+        $this->assertNull(Activity::findOne(['id' => $activity->id]));
     }
 }


### PR DESCRIPTION
## Problem

Unfollowing a user (any user — local or a federated shadow account) fails with a 500:

```
yii\base\InvalidArgumentException: Key "object_model" is not a column name and can not be used as a filter
  at Follow::beforeDelete() → Activity::findAll(['object_model' => …, 'object_id' => …])
```

The activity restructuring (`m260108_115053_new_structure`) dropped the polymorphic `activity.object_model` / `activity.object_id` columns and moved association onto `contentcontainer_id` / `content_id`. But `Follow::beforeDelete()` was never updated and still queries the dropped columns, so deleting any user-follow record throws.

This affects **every** unfollow of a `User` (the `object_model === User::class` branch), not just an edge case. It's the only remaining core spot that queries `Activity` by the removed columns.

## Fix

`ActivityManager::dispatch()` now stores a `FollowActivity` against the **followed user's content container**, authored by the **follower**. `Follow::beforeDelete()` deletes it via that same key (`class` + `contentcontainer_id` + `created_by`) instead of the old `object_model`/`object_id` filter. `(follower, followed)` is unique, so this targets exactly that follow's activity, and the per-row `->delete()` is kept so `GroupingService` cleanup still runs.

## Test

`FollowTest::testUnfollowUserRemovesActivity` follows then unfollows a user, asserting the unfollow doesn't raise and that both the follow record and its `FollowActivity` are removed.