### PR TITLE
Fix Mercure live driver conflating internal publish and public subscribe URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ HumHub Changelog
 
 1.19 (TBD)
 ----------
+- Fix: Mercure live driver could not deliver updates when the hub is co-located with the app but the public address is not reachable over loopback (e.g. the Docker image with a non-`localhost` `SERVER_NAME`) — the single `hubUrl` was used for both server-side publishing and browser subscribing. Added `MercurePushDriver::$internalHubUrl` (defaults to `hubUrl`): the server now publishes via `internalHubUrl` while the browser keeps subscribing via the public `hubUrl`
 - Fix: Unfollowing a user threw `Key "object_model" is not a column name` — `Follow::beforeDelete()` still queried the `activity.object_model`/`object_id` columns that the activity restructuring dropped; it now removes the `FollowActivity` via its `class`/`contentcontainer_id`/`created_by`
 - Fix #8242: Within a space, "member joined"/"left" activities now link to the member's profile instead of the (redundant) space; in the global/dashboard stream and for grouped entries (multiple members) they keep linking to the space
 - Enh: A `UserSource` can declare email optional via `UserSourceInterface::isEmailRequired()` (default `true`); `User::isEmailRequired()` now consults the user's source (through `UserSourceService`), so sources for external/federated users can provision accounts without an email address

--- a/protected/humhub/modules/live/driver/MercurePushDriver.php
+++ b/protected/humhub/modules/live/driver/MercurePushDriver.php
@@ -32,7 +32,24 @@ use yii\helpers\Url;
  */
 class MercurePushDriver extends BaseDriver
 {
+    /**
+     * @var string Public hub URL the browser uses to subscribe (SSE).
+     * Defaults to the public site address (`/.well-known/mercure`).
+     */
     public string $hubUrl = '';
+
+    /**
+     * @var string Internal hub URL the server uses to publish updates (PHP -> hub).
+     * Use this when the hub is co-located with the application and must be reached
+     * over loopback instead of the public address — e.g. the official Docker image
+     * runs an embedded hub, where this should point to `http://localhost/.well-known/mercure`
+     * while {@see $hubUrl} keeps deriving from the (public) `SERVER_NAME` for the browser.
+     * Defaults to {@see $hubUrl} when not set (single-URL setups behave as before).
+     *
+     * @since 1.19
+     */
+    public string $internalHubUrl = '';
+
     public string $jwtKeySubscriber = '';
     public string $jwtKeyPublisher = '';
     public string $topicPrefix = '/humhub/live/';
@@ -51,6 +68,10 @@ class MercurePushDriver extends BaseDriver
             $this->hubUrl = Url::to('/.well-known/mercure', true);
         }
 
+        if (empty($this->internalHubUrl)) {
+            $this->internalHubUrl = $this->hubUrl;
+        }
+
         if (empty($this->jwtKeyPublisher) || empty($this->jwtKeySubscriber)) {
             throw new InvalidConfigException('Mercure driver JWT keys are not specified.');
         }
@@ -66,7 +87,7 @@ class MercurePushDriver extends BaseDriver
                 'verify_host' => false,
             ]);
 
-        $this->hub = new Hub($this->hubUrl, $provider, null, null, $client);
+        $this->hub = new Hub($this->internalHubUrl, $provider, null, null, $client);
     }
 
     /**

--- a/protected/humhub/modules/live/tests/codeception/unit/MercurePushDriverTest.php
+++ b/protected/humhub/modules/live/tests/codeception/unit/MercurePushDriverTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace tests\codeception\unit\modules\live;
+
+use humhub\modules\live\driver\MercurePushDriver;
+use tests\codeception\_support\HumHubDbTestCase;
+use yii\helpers\Url;
+
+class MercurePushDriverTest extends HumHubDbTestCase
+{
+    private const JWT_KEYS = [
+        'jwtKeyPublisher' => 'test-publisher-key-0123456789abcdef',
+        'jwtKeySubscriber' => 'test-subscriber-key-0123456789abcdef',
+    ];
+
+    public function testInternalHubUrlFallsBackToHubUrl()
+    {
+        $driver = new MercurePushDriver(array_merge(self::JWT_KEYS, [
+            'hubUrl' => 'https://social.example.com/.well-known/mercure',
+        ]));
+
+        // Browser (subscribe) uses the public hub URL ...
+        static::assertEquals('https://social.example.com/.well-known/mercure', $driver->hubUrl);
+        static::assertEquals('https://social.example.com/.well-known/mercure', $driver->getJsConfig()['options']['url']);
+        // ... and, with no internal URL configured, the server publishes to the same URL (legacy behaviour).
+        static::assertEquals('https://social.example.com/.well-known/mercure', $driver->internalHubUrl);
+    }
+
+    public function testInternalHubUrlSplitsPublishFromSubscribe()
+    {
+        $driver = new MercurePushDriver(array_merge(self::JWT_KEYS, [
+            'hubUrl' => 'https://social.example.com/.well-known/mercure',
+            'internalHubUrl' => 'http://localhost/.well-known/mercure',
+        ]));
+
+        // Server publishes over loopback ...
+        static::assertEquals('http://localhost/.well-known/mercure', $driver->internalHubUrl);
+        // ... while the browser keeps subscribing via the public address.
+        static::assertEquals('https://social.example.com/.well-known/mercure', $driver->hubUrl);
+        static::assertEquals('https://social.example.com/.well-known/mercure', $driver->getJsConfig()['options']['url']);
+    }
+
+    public function testHubUrlDefaultsToPublicSiteAddress()
+    {
+        $driver = new MercurePushDriver(self::JWT_KEYS);
+
+        $expected = Url::to('/.well-known/mercure', true);
+        static::assertEquals($expected, $driver->hubUrl);
+        static::assertEquals($expected, $driver->internalHubUrl);
+    }
+}


### PR DESCRIPTION
## Problem

`MercurePushDriver` uses a single `hubUrl` for **both** the server-side publish leg (PHP → hub) and the client-side subscribe leg (browser → hub). These have conflicting requirements when the hub is co-located with the app: publishing needs a loopback address, while the browser needs the public address.

This breaks the official Docker image as soon as an admin sets `SERVER_NAME` to anything other than `localhost` (a LAN IP or hostname — the normal case). Live updates silently fail because PHP tries to publish to the public address, which the container cannot hairpin back to its own embedded hub:

```
TransportException: Failed to connect to 10.1.1.33 port 81 ...
  "http://10.1.1.33:81/.well-known/mercure"
  .../live/driver/MercurePushDriver.php line 82
```

## Fix

Add `MercurePushDriver::$internalHubUrl` (server → hub publish endpoint), defaulting to `hubUrl`:

- **Publish** now goes through `internalHubUrl`.
- **Subscribe** (`getJsConfig()`) keeps using the public `hubUrl` — unchanged.
- `hubUrl` keeps its existing meaning and default (`Url::to('/.well-known/mercure', true)`), so all current single-URL and external-hub setups behave exactly as before.

Deployments with a co-located hub (e.g. Docker) can now point `internalHubUrl` at loopback while the browser keeps subscribing via the public `SERVER_NAME`-derived address. A matching `humhub/docker` change sets `internalHubUrl` automatically.

## Tests

Added `MercurePushDriverTest` covering the fallback (internal → public), the publish/subscribe split, and the default derivation. Full `live` unit suite green.