### PR TITLE
Fix unfollow crash from ambiguous activity columns and stale follow cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ HumHub Changelog
 
 1.19 (TBD)
 ----------
+- Fix #8252: Unfollowing a user still crashed with an ambiguous-column SQL error and never removed the follow — the `FollowActivity` lookup in `Follow::beforeDelete()` did not qualify the columns shared by the `content`/`user` tables that `ActiveQueryActivity` left-joins, and `Followable::follow()`/`unfollow()` did not invalidate the cached follow record, so a follow + unfollow within the same request left the record in place (follow-up to #8249)
 - Fix: Mercure live driver could not deliver updates when the hub is co-located with the app but the public address is not reachable over loopback (e.g. the Docker image with a non-`localhost` `SERVER_NAME`) — the single `hubUrl` was used for both server-side publishing and browser subscribing. Added `MercurePushDriver::$internalHubUrl` (defaults to `hubUrl`): the server now publishes via `internalHubUrl` while the browser keeps subscribing via the public `hubUrl`
 - Fix: Unfollowing a user threw `Key "object_model" is not a column name` — `Follow::beforeDelete()` still queried the `activity.object_model`/`object_id` columns that the activity restructuring dropped; it now removes the `FollowActivity` via its `class`/`contentcontainer_id`/`created_by`
 - Fix #8242: Within a space, "member joined"/"left" activities now link to the member's profile instead of the (redundant) space; in the global/dashboard stream and for grouped entries (multiple members) they keep linking to the space

--- a/protected/humhub/modules/user/behaviors/Followable.php
+++ b/protected/humhub/modules/user/behaviors/Followable.php
@@ -43,12 +43,35 @@ class Followable extends Behavior
     public function getFollowRecord($userId)
     {
         $userId = ($userId instanceof User) ? $userId->id : $userId;
-        return Yii::$app->runtimeCache->getOrSet(__METHOD__ . $this->owner->getPrimaryKey() . '-' . $userId, fn() => Follow::find()
+        return Yii::$app->runtimeCache->getOrSet($this->getFollowRecordCacheKey($userId), fn() => Follow::find()
             ->where([
                 'object_model' => $this->owner::class,
                 'object_id' => $this->owner->getPrimaryKey(),
                 'user_id' => $userId,
             ])->one());
+    }
+
+    /**
+     * Builds the runtime cache key used by {@see getFollowRecord()}.
+     *
+     * @param int $userId
+     * @return string
+     */
+    private function getFollowRecordCacheKey($userId): string
+    {
+        $userId = ($userId instanceof User) ? $userId->id : $userId;
+        return self::class . '::getFollowRecord' . $this->owner->getPrimaryKey() . '-' . $userId;
+    }
+
+    /**
+     * Invalidates the cached follow record for the given user, so a follow or
+     * unfollow within the same request is reflected by later lookups.
+     *
+     * @param int $userId
+     */
+    private function invalidateFollowRecordCache($userId): void
+    {
+        Yii::$app->runtimeCache->delete($this->getFollowRecordCacheKey($userId));
     }
 
     /**
@@ -85,6 +108,10 @@ class Followable extends Behavior
             return false;
         }
 
+        // getFollowRecord() above cached the (then missing) record; refresh it
+        // so a subsequent lookup in the same request sees the new follow.
+        $this->invalidateFollowRecordCache($userId);
+
         return true;
     }
 
@@ -105,6 +132,7 @@ class Followable extends Behavior
         $record = $this->getFollowRecord($userId);
         if ($record !== null) {
             if ($record->delete()) {
+                $this->invalidateFollowRecordCache($userId);
                 return true;
             }
         } else {

--- a/protected/humhub/modules/user/models/Follow.php
+++ b/protected/humhub/modules/user/models/Follow.php
@@ -130,11 +130,13 @@ class Follow extends ActiveRecord
                 // The FollowActivity is stored against the followed user's content
                 // container (see ActivityManager::dispatch); the activity table no
                 // longer has the polymorphic object_model/object_id columns.
+                // Columns are qualified because ActiveQueryActivity left-joins the
+                // content and user tables, which share these column names.
                 foreach (
                     Activity::findAll([
-                        'class' => FollowActivity::class,
-                        'contentcontainer_id' => $target->contentcontainer_id,
-                        'created_by' => $this->user_id,
+                        'activity.class' => FollowActivity::class,
+                        'activity.contentcontainer_id' => $target->contentcontainer_id,
+                        'activity.created_by' => $this->user_id,
                     ]) as $activity
                 ) {
                     $activity->delete();

--- a/protected/humhub/modules/user/tests/codeception/unit/FollowTest.php
+++ b/protected/humhub/modules/user/tests/codeception/unit/FollowTest.php
@@ -34,11 +34,13 @@ class FollowTest extends HumHubDbTestCase
         $this->assertTrue($user->follow());
 
         // Following a user creates a FollowActivity on the followed user's
-        // content container, authored by the follower.
+        // content container, authored by the follower. Columns are qualified
+        // because ActiveQueryActivity left-joins the content and user tables,
+        // which share these column names.
         $activity = Activity::findOne([
-            'class' => FollowActivity::class,
-            'contentcontainer_id' => $user->contentcontainer_id,
-            'created_by' => Yii::$app->user->id,
+            'activity.class' => FollowActivity::class,
+            'activity.contentcontainer_id' => $user->contentcontainer_id,
+            'activity.created_by' => Yii::$app->user->id,
         ]);
         $this->assertNotNull($activity);
 
@@ -48,6 +50,6 @@ class FollowTest extends HumHubDbTestCase
         $this->assertTrue($user->unfollow());
 
         $this->assertNull(Follow::findOne(['object_model' => User::class, 'object_id' => 1, 'user_id' => 2]));
-        $this->assertNull(Activity::findOne(['id' => $activity->id]));
+        $this->assertNull(Activity::findOne(['activity.id' => $activity->id]));
     }
 }


### PR DESCRIPTION
## Problem

CI on `develop` is red: `FollowTest::testUnfollowUserRemovesActivity` (the regression test added in #8249) errors with:

```
[yii\db\IntegrityException] SQLSTATE[23000]: Integrity constraint violation:
1052 Column 'contentcontainer_id' in where clause is ambiguous
```

Run: https://github.com/humhub/humhub/actions/runs/28266036311/job/83752861952

Investigating the failure surfaced **two** real bugs that the test was meant to guard against but couldn't, because it never reached the code path it was testing.

## Root causes & fixes

**1. Ambiguous columns in the `FollowActivity` lookup**

`ActiveQueryActivity::init()` always left-joins `content` and `user`. Those tables share the column names `id`, `contentcontainer_id` and `created_by` with `activity`, so the unqualified `Activity::findAll([...])` in `Follow::beforeDelete()` (and the equivalent lookups in the test) produce an ambiguous-column SQL error — i.e. **unfollowing a user still crashed at runtime**, even after #8249. Columns are now qualified with the `activity.` prefix, matching the convention used throughout `ActiveQueryActivity`.

**2. Stale follow record in the runtime cache**

`Followable::getFollowRecord()` memoises the lookup in `runtimeCache`. `follow()` calls it (caching the still-missing record) *before* saving and never invalidates the entry, so a follow + unfollow within the same request reads the stale `null` and skips the deletion entirely — `unfollow()` returns `false` without ever running `beforeDelete()`. The cache is now invalidated after `follow()` saves and after `unfollow()` deletes.

With (1) alone the test still failed (`unfollow()` returned `false`); both fixes are required for the test to actually exercise — and verify — the `beforeDelete()` cleanup.

## Verification

All previously affected suites pass locally:

- `user` unit suite — 194 tests
- `activity` unit suite — 24 tests
- `space` `SpaceFollowTest`, `live` `LegitimationTest`, `dashboard` `DashboardMemberStreamQueryTest`

`FollowTest` now passes and genuinely covers follow → activity created → unfollow → follow record and activity removed.