### PR TITLE
Add CI database engine selector and weekly DB-compatibility sweep

### DIFF
--- a/.github/workflows/php-test-base.yml
+++ b/.github/workflows/php-test-base.yml
@@ -1,0 +1,156 @@
+name: PHP Codeception Tests (base)
+
+# Reusable base workflow. Runs the full Codeception suite once per
+# PHP x database matrix entry. Callers pass the PHP versions and the
+# databases to test. engine: mariadb | mysql.
+on:
+    workflow_call:
+        inputs:
+            php:
+                description: PHP versions to test, JSON list.
+                default: |-
+                    ["8.2", "8.3", "8.4"]
+                type: string
+            databases:
+                description: >-
+                    Databases to test, JSON list of {engine, version} objects.
+                    engine: mariadb | mysql. Default runs MariaDB 11.8 only;
+                    broader coverage lives in the weekly DB-compat sweep.
+                default: |-
+                    [{"engine": "mariadb", "version": "11.8"}]
+                type: string
+
+permissions:
+  contents: read
+
+jobs:
+    tests:
+        name: PHP ${{ matrix.php }}-${{ matrix.db.engine }}-${{ matrix.db.version }}
+        env:
+            extensions: curl, intl, pdo, pdo_mysql, zip, exif, fileinfo, mbstring, gd, ldap
+            key: cache-v2
+            LDAP_TEST_HOST: 127.0.0.1
+            LDAP_TEST_PORT: 389
+            LDAP_TEST_BASE_DN: dc=example,dc=org
+            LDAP_TEST_BIND_DN: cn=admin,dc=example,dc=org
+            LDAP_TEST_BIND_PASSWORD: adminpassword
+            LDAP_TEST_USER_FILTER: "(objectClass=inetOrgPerson)"
+            LDAP_TEST_USERNAME_ATTRIBUTE: uid
+
+        runs-on: ${{ matrix.os }}
+
+        strategy:
+            fail-fast: false
+            matrix:
+                os:
+                    - ubuntu-latest
+
+                php: ${{ fromJson(inputs.php) }}
+
+                db: ${{ fromJson(inputs.databases) }}
+
+        services:
+            db:
+                image: ${{ matrix.db.engine == 'mariadb' && format('mariadb:{0}', matrix.db.version) || format('mysql:{0}', matrix.db.version) }}
+                env:
+                    MYSQL_DATABASE: humhub_test
+                    MYSQL_ROOT_PASSWORD: root
+                ports:
+                    - 3306:3306
+                options: >-
+                    --health-cmd="${{ matrix.db.engine == 'mariadb' && 'healthcheck.sh --connect --innodb_initialized' || 'mysqladmin ping' }}"
+                    --health-interval=10s --health-timeout=5s --health-retries=3
+
+        steps:
+            - name: Start Selenium
+              run: |
+                docker run --detach --net=host --shm-size="2g" selenium/standalone-chrome:108.0-20250123
+
+            - name: Start OpenLDAP
+              run: |
+                docker run --detach \
+                  --name openldap \
+                  -p 389:389 \
+                  -e LDAP_ORGANISATION="HumHub Test" \
+                  -e LDAP_DOMAIN="example.org" \
+                  -e LDAP_ADMIN_PASSWORD="adminpassword" \
+                  -e LDAP_TLS=false \
+                  osixia/openldap:1.5.0 --copy-service
+
+            - uses: actions/checkout@v4
+            - uses: actions/setup-node@v4
+
+            - name: Install PHP with extensions
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: ${{ matrix.php }}
+                  extensions: ${{ env.extensions }}
+                  ini-values: date.timezone='UTC'
+
+            - name: Determine composer cache directory
+              if: matrix.os == 'ubuntu-latest'
+              run: echo "COMPOSER_CACHE_DIR=$(composer config cache-dir)" >> $GITHUB_ENV
+
+            - name: Validate composer.json and composer.lock
+              run: composer validate
+
+            - name: Cache dependencies installed with composer
+              uses: actions/cache@v4
+              with:
+                path: ${{ env.COMPOSER_CACHE_DIR }}
+                key: php${{ matrix.php }}-composer-${{ matrix.dependencies }}-${{ hashFiles('**/composer.json') }}
+                restore-keys: |
+                            php${{ matrix.php }}-composer-${{ matrix.dependencies }}-
+
+            - name: Install dependencies with composer
+              run: composer install --prefer-dist --no-interaction --no-progress --optimize-autoloader --ansi
+
+            - name: Install npm dependencies
+              run: npm install
+
+            - name: Build production assets
+              run: grunt build-assets
+
+            - name: Run migrations
+              run: php protected/humhub/tests/codeception/bin/yii migrate/up --includeModuleMigrations=1 --interactive=0
+
+            - name: Run installer
+              run: php protected/humhub/tests/codeception/bin/yii installer/auto
+
+            - name: Rebuild search index
+              run: php protected/humhub/tests/codeception/bin/yii content-search/rebuild
+
+            - name: Load LDAP test data
+              run: |
+                sudo apt-get install -y ldap-utils -q
+                echo "Waiting for OpenLDAP..."
+                for i in $(seq 1 30); do
+                  ldapsearch -x -H ldap://127.0.0.1:389 \
+                    -D "cn=admin,dc=example,dc=org" -w adminpassword \
+                    -b "dc=example,dc=org" "(objectClass=*)" dn &>/dev/null && break
+                  echo "  attempt $i/30 – retrying in 2s..."
+                  sleep 2
+                done
+                ldapadd -x -H ldap://127.0.0.1:389 \
+                  -D "cn=admin,dc=example,dc=org" -w adminpassword \
+                  -f protected/humhub/modules/ldap/tests/codeception/_data/init.ldif
+
+            - name: Run test server
+              run: php --server 127.0.0.1:8080 index-test.php &>/tmp/phpserver.log &
+
+            - name: Valdiate test server
+              run: sleep 5 && curl --fail --head http://127.0.0.1:8080/index-test.php
+
+            - name: Run test suite
+              run: grunt test -build -env=github
+
+            - name: Upload Codeception Output
+              if: failure()
+              uses: actions/upload-artifact@v4
+              with:
+                name: codeception-output-php${{ matrix.php }}-${{ matrix.db.engine }}-${{ matrix.db.version }}
+                path: |
+                  protected/humhub/tests/codeception/_output/*
+                  protected/humhub/modules/*/tests/codeception/_output/*
+                  protected/runtime/logs/*
+                  /tmp/phpserver.log

--- a/.github/workflows/php-test-db-compat.yml
+++ b/.github/workflows/php-test-db-compat.yml
@@ -1,0 +1,20 @@
+name: PHP Codeception Tests - DB compatibility
+
+# Weekly compatibility sweep across all supported database engines and
+# versions, pinned to a single PHP version for fast feedback. Catches DB
+# drift without slowing routine per-push CI. fail-fast is disabled so one
+# engine failing does not mask the others.
+on:
+    workflow_dispatch:
+    schedule:
+        - cron: "0 2 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+    tests:
+        uses: ./.github/workflows/php-test-base.yml
+        with:
+            php: '["8.4"]'
+            databases: '[{"engine": "mariadb", "version": "10.11"}, {"engine": "mariadb", "version": "11.8"}, {"engine": "mariadb", "version": "12.3"}, {"engine": "mysql", "version": "8.0"}, {"engine": "mysql", "version": "8.4"}, {"engine": "mysql", "version": "9.7"}]'

--- a/.github/workflows/php-test.yml
+++ b/.github/workflows/php-test.yml
@@ -1,5 +1,8 @@
 name: PHP Codeception Tests
 
+# Lean per-push / per-PR run: full PHP matrix against the recommended
+# database only (MariaDB 11.8). Broader engine/version coverage runs in
+# the weekly DB-compat sweep (php-test-db-compat.yml).
 on:
     workflow_dispatch:
     push:
@@ -26,156 +29,7 @@ permissions:
 
 jobs:
     tests:
-        name: PHP ${{ matrix.php-version }}-mysql-${{ matrix.mysql-version }}
-        env:
-            extensions: curl, intl, pdo, pdo_mysql, zip, exif, fileinfo, mbstring, gd, ldap
-            key: cache-v2
-            LDAP_TEST_HOST: 127.0.0.1
-            LDAP_TEST_PORT: 389
-            LDAP_TEST_BASE_DN: dc=example,dc=org
-            LDAP_TEST_BIND_DN: cn=admin,dc=example,dc=org
-            LDAP_TEST_BIND_PASSWORD: adminpassword
-            LDAP_TEST_USER_FILTER: "(objectClass=inetOrgPerson)"
-            LDAP_TEST_USERNAME_ATTRIBUTE: uid
-
-        runs-on: ${{ matrix.os }}
-
-        strategy:
-            matrix:
-                os:
-                    - ubuntu-latest
-
-                php-version:
-                    - "8.2"
-                    - "8.3"
-                    - "8.4"
-
-                mysql-version:
-                    - "5.7"
-
-        services:
-            mysql:
-                image: mysql:${{ matrix.mysql-version }}
-                env:
-                    MYSQL_DATABASE: humhub_test
-                    MYSQL_ROOT_PASSWORD: root
-                ports:
-                    - 3306:3306
-                options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
-
-        steps:
-            - name: Start Selenium
-              run: |
-                docker run --detach --net=host --shm-size="2g" selenium/standalone-chrome:108.0-20250123
-
-            - name: Start OpenLDAP
-              run: |
-                docker run --detach \
-                  --name openldap \
-                  -p 389:389 \
-                  -e LDAP_ORGANISATION="HumHub Test" \
-                  -e LDAP_DOMAIN="example.org" \
-                  -e LDAP_ADMIN_PASSWORD="adminpassword" \
-                  -e LDAP_TLS=false \
-                  osixia/openldap:1.5.0 --copy-service
-
-            - uses: actions/checkout@v4
-            - uses: actions/setup-node@v4
-
-#            - name: Setup cache environment
-#              id: cache-env
-#              uses: shivammathur/cache-extensions@v1
-#              with:
-#                php-version: ${{ matrix.php-version }}
-#                extensions: ${{ env.extensions }}
-#                key: ${{ env.key }}
-
-#            - name: Cache extensions
-#              uses: actions/cache@v4
-#              with:
-#                path: ${{ steps.cache-env.outputs.dir }}
-#                key: ${{ steps.cache-env.outputs.key }}
-#                restore-keys: ${{ steps.cache-env.outputs.key }}
-
-            - name: Install PHP with extensions
-              uses: shivammathur/setup-php@v2
-              with:
-                  php-version: ${{ matrix.php-version }}
-                  extensions: ${{ env.extensions }}
-                  ini-values: date.timezone='UTC'
-
-            - name: Determine composer cache directory
-              if: matrix.os == 'ubuntu-latest'
-              run: echo "COMPOSER_CACHE_DIR=$(composer config cache-dir)" >> $GITHUB_ENV
-
-            - name: Validate composer.json and composer.lock
-              run: composer validate
-
-            - name: Cache dependencies installed with composer
-              uses: actions/cache@v4
-              with:
-                path: ${{ env.COMPOSER_CACHE_DIR }}
-                key: php${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-${{ hashFiles('**/composer.json') }}
-                restore-keys: |
-                            php${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-
-
-            - name: Install dependencies with composer
-              run: composer install --prefer-dist --no-interaction --no-progress --optimize-autoloader --ansi
-
-#            - name: Verify MySQL connection from host
-#              run: |
-#                sudo apt-get update && sudo apt-get install -y mysql-client-8.0 mysql-common
-#                mysql --host 127.0.0.1 --port ${{ job.services.mysql.ports['3306'] }} -uroot -proot -e "SHOW DATABASES"
-
-            - name: Install npm dependencies
-              run: npm install
-
-            - name: Build production assets
-              run: grunt build-assets
-
-            - name: Run migrations
-              run: php protected/humhub/tests/codeception/bin/yii migrate/up --includeModuleMigrations=1 --interactive=0
-
-            - name: Run installer
-              run: php protected/humhub/tests/codeception/bin/yii installer/auto
-
-            - name: Rebuild search index
-              run: php protected/humhub/tests/codeception/bin/yii content-search/rebuild
-
-            - name: Load LDAP test data
-              run: |
-                sudo apt-get install -y ldap-utils -q
-                echo "Waiting for OpenLDAP..."
-                for i in $(seq 1 30); do
-                  ldapsearch -x -H ldap://127.0.0.1:389 \
-                    -D "cn=admin,dc=example,dc=org" -w adminpassword \
-                    -b "dc=example,dc=org" "(objectClass=*)" dn &>/dev/null && break
-                  echo "  attempt $i/30 – retrying in 2s..."
-                  sleep 2
-                done
-                ldapadd -x -H ldap://127.0.0.1:389 \
-                  -D "cn=admin,dc=example,dc=org" -w adminpassword \
-                  -f protected/humhub/modules/ldap/tests/codeception/_data/init.ldif
-
-            - name: Run test server
-              run: php --server 127.0.0.1:8080 index-test.php &>/tmp/phpserver.log &
-
-#            - name: Setup chromedriver
-#              run: chromedriver --url-base=/wd/hub &
-
-            - name: Valdiate test server
-              run: sleep 5 && curl --fail --head http://127.0.0.1:8080/index-test.php
-
-            - name: Run test suite
-              run: grunt test -build -env=github
-
-            - name: Upload Codeception Output
-              if: failure()
-              uses: actions/upload-artifact@v4
-              with:
-                name: codeception-output
-                path: |
-                  protected/humhub/tests/codeception/_output/*
-                  protected/humhub/modules/*/tests/codeception/_output/*
-                  protected/runtime/logs/*
-                  /tmp/phpserver.log
+        uses: ./.github/workflows/php-test-base.yml
+        with:
+            php: '["8.2", "8.3", "8.4"]'
+            databases: '[{"engine": "mariadb", "version": "11.8"}]'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ HumHub Changelog
 - Enh #8237: Allow symfony/mailer ^7.0 and widen all mailer bridge constraints to unblock symfony/event-dispatcher 7.x
 - Enh #8244: Log progress of the queued search index rebuild (`SearchRebuildIndex`) — start, interim item count, completion, and failures/skips, each prefixed with the worker process ID — via the `search-indexing` log category
 - Fix #8246: Add aria-label attribute for icon-only buttons
+- Enh: CI tests now support a database engine selector (MariaDB/MySQL); per-push runs use MariaDB 11.8, plus a weekly DB-compatibility sweep across MariaDB and MySQL versions
  
 1.18.4 (Unreleased)
 ---------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@ HumHub Changelog
 - Enh #8237: Allow symfony/mailer ^7.0 and widen all mailer bridge constraints to unblock symfony/event-dispatcher 7.x
 - Enh #8244: Log progress of the queued search index rebuild (`SearchRebuildIndex`) — start, interim item count, completion, and failures/skips, each prefixed with the worker process ID — via the `search-indexing` log category
 - Fix #8246: Add aria-label attribute for icon-only buttons
-- Enh: CI tests now support a database engine selector (MariaDB/MySQL); per-push runs use MariaDB 11.8, plus a weekly DB-compatibility sweep across MariaDB and MySQL versions
+- Enh #8255: CI tests now support a database engine selector (MariaDB/MySQL); per-push runs use MariaDB 11.8, plus a weekly DB-compatibility sweep across MariaDB and MySQL versions
  
 1.18.4 (Unreleased)
 ---------------------


### PR DESCRIPTION
## What

Adopts the database-engine-selector principle from [`module-coding-standards` #10](https://github.com/humhub/module-coding-standards/pull/10) for core CI.

Until now core was tested against a single, hardcoded, **EOL MySQL 5.7**. This restructures the test workflow so the database engine and version are matrix-driven, switches the default to a current engine, and adds broad engine/version coverage on a schedule.

## Changes

- **`php-test-base.yml`** (new, reusable `workflow_call`): the full Codeception job, parameterised by `php` and `databases` (JSON list of `{engine, version}`). The DB service image and health check are selected per engine — `mariadb:<v>` with `healthcheck.sh --connect --innodb_initialized`, otherwise `mysql:<v>` with `mysqladmin ping`. `fail-fast: false`, and failure artifacts are now named per matrix entry (the old fixed name collided under `upload-artifact@v4`).
- **`php-test.yml`** (now a lean caller): keeps the existing name and push/PR/dispatch triggers; runs PHP 8.2–8.4 against **MariaDB 11.8** only — fast per-push feedback, replacing MySQL 5.7.
- **`php-test-db-compat.yml`** (new, weekly): `cron 0 2 * * 1` + manual dispatch; PHP 8.4 across MariaDB 10.11/11.8/12.3 and MySQL 8.0/8.4/9.7. Same validated DB set as the module standard, so core and modules are tested against identical engines.

## Coverage

**Per push / PR** — `php-test.yml` (3 jobs)

| PHP | MariaDB 11.8 |
|-----|:---:|
| 8.2 | ✓ |
| 8.3 | ✓ |
| 8.4 | ✓ |

**Weekly sweep** — `php-test-db-compat.yml`, Mondays 02:00 UTC, PHP 8.4 (6 jobs)

| Engine | 1 | 2 | 3 |
|--------|:---:|:---:|:---:|
| MariaDB | 10.11 | 11.8 | 12.3 |
| MySQL | 8.0 | 8.4 | 9.7 |

**Combined matrix** — which PHP × DB combinations run, and on which trigger

| PHP | MariaDB 10.11 | MariaDB 11.8 | MariaDB 12.3 | MySQL 8.0 | MySQL 8.4 | MySQL 9.7 |
|-----|:---:|:---:|:---:|:---:|:---:|:---:|
| 8.2 | — | P | — | — | — | — |
| 8.3 | — | P | — | — | — | — |
| 8.4 | W | P + W | W | W | W | W |

Legend: **P** = every push/PR · **W** = weekly sweep · **—** = not tested

## Reviewer notes

- **Required status checks change name.** Going reusable renders checks as `tests / PHP <php>-<engine>-<version>` (e.g. `tests / PHP 8.2-mariadb-11.8`) instead of the old `PHP 8.2-mysql-5.7`. Branch-protection required-check rules need updating after merge.
- **Default DB floor changed.** Per-push CI no longer exercises MySQL 5.7; the minimum-version floor (MariaDB 10.11) is covered in the weekly sweep. Adjust the matrix if core still supports an older floor.
