### PR TITLE
Fix Select2 dropdown flickering/closing when it doesn't fit the viewport at browser zoom > 100%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ HumHub Changelog
 - Enh #8238: Reset OPcache after update a module
 - Enh #8248: Fix updating of space notification state per user after reset for all users
 - Enh #8260: Make form fieldset focusable and expanded via keyboard
+- Fix #8253: Fix Select2 dropdown flickering/closing when it doesn't fit the viewport at browser zoom > 100%
 
 1.18.3 (May 18, 2026)
 ---------------------

--- a/static/js/humhub/humhub.ui.additions.js
+++ b/static/js/humhub/humhub.ui.additions.js
@@ -196,6 +196,7 @@ humhub.module('ui.additions', function (module, require, $) {
                     templateResult: templateItem,
                     templateSelection: templateItem,
                     dropdownAutoWidth: true,
+                    scrollAfterSelect: true,
                 });
             });
         });

--- a/static/scss/_select2.scss
+++ b/static/scss/_select2.scss
@@ -278,10 +278,18 @@
 
         /**
          * Limit the dropdown height.
+         *
+         * Fix for browser zoom > 100%:
+         * The height is also capped relative to the viewport (vh) so the
+         * options list always fits above or below the field - even when
+         * the browser zoom level is above 100%, which shrinks the
+         * effective viewport height in CSS pixels. Without this, Select2
+         * can end up unable to find enough room in either direction and
+         * flip its position back and forth on every scroll/resize event,
+         * making the dropdown flicker open and immediately close.
          */
-
         .select2-results > .select2-results__options {
-            max-height: 400px;
+            max-height: min(400px, 40vh);
             overflow-y: auto;
         }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

**The PR fulfills these requirements:**

- [ ] All tests are passing
- [x] Changelog was modified

**Other information:**
https://github.com/humhub/humhub/issues/8253