### PR TITLE
Fix confirm modal getting stuck open forever when closed while still transitioning in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ HumHub Changelog
 - Fix #8253: Fix Select2 dropdown flickering/closing when it doesn't fit the viewport at browser zoom > 100%
 - Fix #8264: Update Twig to 3.28.0 (GHSA-529h-vh3j-85hq / CVE-2026-46636 - sandbox allow-list bypass on cached templates)
 - Fix #8268: Fix dropdown menu hidden behind topbar when flipped upward
+- Fix #8273: Fix confirm modal getting stuck open forever when closed while still transitioning in
 
 1.18.3 (May 18, 2026)
 ---------------------

--- a/static/js/humhub/humhub.ui.modal.js
+++ b/static/js/humhub/humhub.ui.modal.js
@@ -123,7 +123,18 @@ humhub.module('ui.modal', function (module, require, $) {
      * @returns {undefined}
      */
     Modal.prototype.close = function (reset) {
-        this.getModalInstance().hide();
+        var instance = this.getModalInstance();
+
+        // Bootstrap silently ignores hide() while the show transition is still
+        // running, which leaves the modal stuck open forever. Defer the hide
+        // until the transition finishes in that case.
+        if (instance._isTransitioning) {
+            this.$.one('shown.bs.modal', function () {
+                instance.hide();
+            });
+        } else {
+            instance.hide();
+        }
 
         if (reset) {
             this.reset();


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

**The PR fulfills these requirements:**

- [ ] All tests are passing
- [x] Changelog was modified

**Other information:**
https://github.com/humhub/humhub-internal/issues/1257