### PR TITLE
Redirect invite links to the external single auth client instead of the local registration form when local registration is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ HumHub Changelog
 - Fix #8264: Update Twig to 3.28.0 (GHSA-529h-vh3j-85hq / CVE-2026-46636 - sandbox allow-list bypass on cached templates)
 - Fix #8268: Fix dropdown menu hidden behind topbar when flipped upward
 - Fix #8273: Fix confirm modal getting stuck open forever when closed while still transitioning in
+- Fix #8275: Redirect invite links to the external single auth client instead of the local registration form when local registration is disabled
 
 1.18.3 (May 18, 2026)
 ---------------------

--- a/protected/humhub/modules/user/controllers/RegistrationController.php
+++ b/protected/humhub/modules/user/controllers/RegistrationController.php
@@ -158,9 +158,9 @@ class RegistrationController extends Controller
 
     /**
      * Invitation by link
-     * @param null $token
-     * @param null $spaceId
-     * @return string
+     *
+     * @param string|null $token
+     * @param int|null $spaceId
      * @throws HttpException
      * @throws Throwable
      * @throws StaleObjectException
@@ -178,6 +178,15 @@ class RegistrationController extends Controller
         }
 
         $linkRegistrationService->storeInSession();
+
+        // If local login/registration is disabled and exactly one external auth
+        // client (e.g. SAML) remains, send the user directly into that auth client's
+        // flow instead of showing the "invite by link" landing page. The space
+        // invite itself survives the round trip via LinkRegistrationService's
+        // session state (see storeInSession() above).
+        if (($response = $this->redirectToForcedAuthClient()) !== null) {
+            return $response;
+        }
 
         $form = new Invite([
             'source' => Invite::SOURCE_INVITE_BY_LINK,
@@ -201,17 +210,21 @@ class RegistrationController extends Controller
 
     /**
      * When the local registration/login form is disabled (e.g. "Force SAML" setups
-     * with only an SSO provider enabled), an invite link should not fall back to the
-     * local password registration form. Instead, redirect straight into the sole
-     * remaining external auth client's flow, mirroring what happens for direct logins.
+     * with only an SSO provider enabled), invite links (by e-mail token or by shared
+     * link) should not fall back to the local password registration form. Instead,
+     * redirect straight into the sole remaining external auth client's flow,
+     * mirroring what happens for direct logins.
      *
      * Returns `null` if the local form should still be rendered (e.g. because it is
-     * not disabled, or there isn't exactly one unambiguous external auth client).
+     * not disabled, the request has `?showRegistrationForm=1`, or there isn't exactly
+     * one unambiguous external auth client).
      *
-     * @param string $token the invite token, kept in session so it can be restored
-     *  once the auth client flow redirects back to this controller
+     * @param string|null $inviteToken the e-mail invite token (from actionIndex()), kept
+     *  in session so it can be restored once the auth client flow redirects back to this
+     *  controller. Not needed for the "invite by link" flow (actionByLink()), since that
+     *  already persists its own state via LinkRegistrationService::storeInSession().
      */
-    private function redirectToForcedAuthClient(string $token): ?Response
+    private function redirectToForcedAuthClient(?string $inviteToken = null): ?Response
     {
         if ($this->module->showRegistrationForm) {
             return null;
@@ -229,7 +242,9 @@ class RegistrationController extends Controller
         /** @var BaseClient $externalClient */
         $externalClient = reset($externalClients);
 
-        Yii::$app->session->set(self::SESSION_INVITE_TOKEN, $token);
+        if ($inviteToken !== null) {
+            Yii::$app->session->set(self::SESSION_INVITE_TOKEN, $inviteToken);
+        }
 
         return $this->redirect(['/user/auth/external', 'authclient' => $externalClient->getId()]);
     }

--- a/protected/humhub/modules/user/controllers/RegistrationController.php
+++ b/protected/humhub/modules/user/controllers/RegistrationController.php
@@ -10,7 +10,9 @@ namespace humhub\modules\user\controllers;
 
 use humhub\components\access\ControllerAccess;
 use humhub\components\Controller;
+use humhub\components\Response;
 use humhub\modules\space\models\Space;
+use humhub\modules\user\authclient\BaseFormAuth;
 use humhub\modules\user\authclient\interfaces\ApprovalBypass;
 use humhub\modules\user\models\forms\Registration;
 use humhub\modules\user\models\Invite;
@@ -37,9 +39,17 @@ use yii\web\HttpException;
 class RegistrationController extends Controller
 {
     /**
+     * Session key used to carry an invite token across an enforced external
+     * auth client login round trip triggered from an invite link.
+     *
+     * @see redirectToForcedAuthClient()
+     */
+    private const SESSION_INVITE_TOKEN = self::class . '::inviteToken';
+
+    /**
      * @inheritdoc
      */
-    public $layout = "@humhub/modules/user/views/layouts/main";
+    public $layout = '@humhub/modules/user/views/layouts/main';
 
     /**
      * Allow guest access independently from guest mode setting.
@@ -84,15 +94,34 @@ class RegistrationController extends Controller
          */
         $authClient = null;
 
-        if (Yii::$app->request->get('token')) {
-            $inviteRegistrationService = new InviteRegistrationService(Yii::$app->request->get('token'));
+        $token = Yii::$app->request->get('token');
+        if ($token) {
+            $inviteRegistrationService = new InviteRegistrationService($token);
             if (!$inviteRegistrationService->isValid()) {
                 throw new HttpException(404, 'Invalid registration token!');
             }
+
+            // If local login/registration is disabled and exactly one external auth
+            // client remains, send invited users directly into that
+            // auth client's flow instead of showing the local password form.
+            if (($response = $this->redirectToForcedAuthClient($token)) !== null) {
+                return $response;
+            }
+
             $inviteRegistrationService->populateRegistration($registration);
         } elseif (Yii::$app->session->has('authClient')) {
             $authClient = Yii::$app->session->get('authClient');
             $registration = $this->createRegistrationByAuthClient($authClient);
+
+            // Restore invite data (e.g. e-mail/language) after the user was redirected
+            // through an enforced external auth client login triggered by an invite link.
+            if ($pendingInviteToken = Yii::$app->session->get(self::SESSION_INVITE_TOKEN)) {
+                Yii::$app->session->remove(self::SESSION_INVITE_TOKEN);
+                $pendingInviteRegistrationService = new InviteRegistrationService($pendingInviteToken);
+                if ($pendingInviteRegistrationService->isValid()) {
+                    $pendingInviteRegistrationService->populateRegistration($registration);
+                }
+            }
         } else {
             Yii::warning('Registration failed: No token (query) or authclient (session) found!', 'user');
             Yii::$app->session->setFlash('error', 'Registration failed.');
@@ -168,6 +197,41 @@ class RegistrationController extends Controller
             'showRegistrationForm' => $this->module->showRegistrationForm,
             'showAuthClients' => true,
         ]);
+    }
+
+    /**
+     * When the local registration/login form is disabled (e.g. "Force SAML" setups
+     * with only an SSO provider enabled), an invite link should not fall back to the
+     * local password registration form. Instead, redirect straight into the sole
+     * remaining external auth client's flow, mirroring what happens for direct logins.
+     *
+     * Returns `null` if the local form should still be rendered (e.g. because it is
+     * not disabled, or there isn't exactly one unambiguous external auth client).
+     *
+     * @param string $token the invite token, kept in session so it can be restored
+     *  once the auth client flow redirects back to this controller
+     */
+    private function redirectToForcedAuthClient(string $token): ?Response
+    {
+        if ($this->module->showRegistrationForm) {
+            return null;
+        }
+
+        $externalClients = array_filter(
+            Yii::$app->get('authClientCollection')->getClients(),
+            static fn ($client) => !$client instanceof BaseFormAuth,
+        );
+
+        if (count($externalClients) !== 1) {
+            return null;
+        }
+
+        /** @var BaseClient $externalClient */
+        $externalClient = reset($externalClients);
+
+        Yii::$app->session->set(self::SESSION_INVITE_TOKEN, $token);
+
+        return $this->redirect(['/user/auth/external', 'authclient' => $externalClient->getId()]);
     }
 
     /**


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

**The PR fulfills these requirements:**

- [ ] All tests are passing
- [x] Changelog was modified

**Other information:**
https://github.com/humhub/humhub-internal/issues/1258