### PR TITLE
Fix confirm modal self-closing on next open after close during hide transition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ HumHub Changelog
 - Fix #8264: Update Twig to 3.28.0 (GHSA-529h-vh3j-85hq / CVE-2026-46636 - sandbox allow-list bypass on cached templates)
 - Fix #8268: Fix dropdown menu hidden behind topbar when flipped upward
 - Fix #8273: Fix confirm modal getting stuck open forever when closed while still transitioning in
+- Fix #8282: Fix confirm modal closing itself on next open after being closed during its hide transition
 
 1.18.3 (May 18, 2026)
 ---------------------

--- a/static/js/humhub/humhub.ui.modal.js
+++ b/static/js/humhub/humhub.ui.modal.js
@@ -127,8 +127,11 @@ humhub.module('ui.modal', function (module, require, $) {
 
         // Bootstrap silently ignores hide() while the show transition is still
         // running, which leaves the modal stuck open forever. Defer the hide
-        // until the transition finishes in that case.
-        if (instance._isTransitioning) {
+        // until the transition finishes in that case. Only do this while
+        // transitioning in (_isShown is true) — while transitioning out the
+        // modal is already closing, and a deferred hide would close the modal
+        // the next time it is shown again.
+        if (instance._isTransitioning && instance._isShown) {
             this.$.one('shown.bs.modal', function () {
                 instance.hide();
             });


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

**The PR fulfills these requirements:**

- [x] Changelog was modified

**Other information:**

Regression from #8273. The deferred hide checks `_isTransitioning` only, but Bootstrap sets that flag while transitioning **out** as well. When `close()` is called redundantly during the hide transition — e.g. `ui.modal` `unload()` on `pjax:beforeSend` right after a confirm button click triggered a redirect — the deferred `shown.bs.modal` handler never fires for that cycle and stays bound. The next time the modal is opened, the stale handler hides it immediately, so the next confirm dialog closes itself without the user being able to confirm.

This is what broke the `SendMailCest` acceptance test on all mail module PRs against core master since Jul 8 (see https://github.com/humhub/mail/pull/504#issuecomment-4936037687 — the confirm flow there is: `Leave` button click → `data-modal-close` starts the hide transition while the leave POST responds with a redirect → `pjax:beforeSend` → `unload()` closes the still-transitioning modal → next `Leave` confirm self-closes → `ElementNotInteractableException`). Control run on unchanged mail `master` fails the same way, so the failure is unrelated to the module PRs: https://github.com/humhub/mail/actions/runs/29101382356

The fix defers the hide only while the modal is actually transitioning **in** (`_isShown` is true). While transitioning out the modal is already closing, so `hide()` remains a no-op as before #8273. Verified both directions against vendored Bootstrap 5: close during show-transition still ends hidden (the #8273 scenario), and a redundant close during hide-transition no longer breaks the next open.