### PR TITLE
Enh: Display a success toast when a module is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ HumHub Changelog
 - Fix #8268: Fix dropdown menu hidden behind topbar when flipped upward
 - Fix #8273: Fix confirm modal getting stuck open forever when closed while still transitioning in
 - Fix #8282: Fix confirm modal closing itself on next open after being closed during its hide transition
+- Enh: Display a success toast when a module is enabled
 
 1.18.3 (May 18, 2026)
 ---------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ HumHub Changelog
 - Fix #8268: Fix dropdown menu hidden behind topbar when flipped upward
 - Fix #8273: Fix confirm modal getting stuck open forever when closed while still transitioning in
 - Fix #8282: Fix confirm modal closing itself on next open after being closed during its hide transition
-- Enh: Display a success toast when a module is enabled
+- Enh #8286: Display a success toast when a module is enabled
 
 1.18.3 (May 18, 2026)
 ---------------------

--- a/protected/humhub/modules/admin/controllers/ModuleController.php
+++ b/protected/humhub/modules/admin/controllers/ModuleController.php
@@ -85,8 +85,10 @@ class ModuleController extends Controller
             $this->view->error(Yii::t('AdminModule.modules', 'Deactivation of this module has not been completed yet. Please retry in a few minutes.'));
         } elseif (QueueHelper::isQueued(new RemoveModuleJob(['moduleId' => $moduleId]))) {
             $this->view->error(Yii::t('AdminModule.modules', 'Uninstallation of this module has not been completed yet. It will be removed in a few minutes.'));
+        } elseif ($module->enable() === false) {
+            $this->view->error('Could not enable module!');
         } else {
-            $module->enable();
+            $this->view->saved();
         }
 
         return $this->redirectToModules();


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included
- [x] Changelog was modified

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

I didn't add translations to 'Could not enable module!' because it is very rare for that to happen.