### PR TITLE
Allow changing container Profile and Banner image via Event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@ HumHub Changelog
 - Enh #8261: In the mobile app settings, change Whitelist domains to URLs, and also send auth client (SSO) URLs to the mobile app to open all of them in the in-app browser instead of the external one
 - Enh #8254: Allow reading content in State mode for owner
 - Fix #8267: Delete `\humhub\widgets\PageAddonStack` unused class
-- Enh #8287: Add `ContentContainerActiveRecord::EVENT_CREATE_PROFILE_IMAGE` and `EVENT_CREATE_BANNER_IMAGE`
+- Enh #8287: Add `ContentContainerActiveRecord::EVENT_INIT_PROFILE_IMAGE` and `EVENT_INIT_BANNER_IMAGE`
 - Fix #8287: `AssetImage::getUrl()` for a source file without an extension (e.g. a HumHub `File`, stored as `file`)
  
 1.18.4 (Unreleased)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,8 +64,8 @@ HumHub Changelog
 - Enh #8261: In the mobile app settings, change Whitelist domains to URLs, and also send auth client (SSO) URLs to the mobile app to open all of them in the in-app browser instead of the external one
 - Enh #8254: Allow reading content in State mode for owner
 - Fix #8267: Delete `\humhub\widgets\PageAddonStack` unused class
-- Enh: Add`ContentContainerActiveRecord::EVENT_CREATE_PROFILE_IMAGE` and `EVENT_CREATE_BANNER_IMAGE`
-- Fix: `AssetImage::getUrl()` for a source file without an extension (e.g. a HumHub `File`, stored as `file`)
+- Enh #8287: Add`ContentContainerActiveRecord::EVENT_CREATE_PROFILE_IMAGE` and `EVENT_CREATE_BANNER_IMAGE`
+- Fix #8287: `AssetImage::getUrl()` for a source file without an extension (e.g. a HumHub `File`, stored as `file`)
  
 1.18.4 (Unreleased)
 ---------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@ HumHub Changelog
 - Enh #8261: In the mobile app settings, change Whitelist domains to URLs, and also send auth client (SSO) URLs to the mobile app to open all of them in the in-app browser instead of the external one
 - Enh #8254: Allow reading content in State mode for owner
 - Fix #8267: Delete `\humhub\widgets\PageAddonStack` unused class
-- Enh #8287: Add`ContentContainerActiveRecord::EVENT_CREATE_PROFILE_IMAGE` and `EVENT_CREATE_BANNER_IMAGE`
+- Enh #8287: Add `ContentContainerActiveRecord::EVENT_CREATE_PROFILE_IMAGE` and `EVENT_CREATE_BANNER_IMAGE`
 - Fix #8287: `AssetImage::getUrl()` for a source file without an extension (e.g. a HumHub `File`, stored as `file`)
  
 1.18.4 (Unreleased)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@ HumHub Changelog
 - Enh #8261: In the mobile app settings, change Whitelist domains to URLs, and also send auth client (SSO) URLs to the mobile app to open all of them in the in-app browser instead of the external one
 - Enh #8254: Allow reading content in State mode for owner
 - Fix #8267: Delete `\humhub\widgets\PageAddonStack` unused class
+- Enh: Add`ContentContainerActiveRecord::EVENT_CREATE_PROFILE_IMAGE` and `EVENT_CREATE_BANNER_IMAGE`
+- Fix: `AssetImage::getUrl()` for a source file without an extension (e.g. a HumHub `File`, stored as `file`)
  
 1.18.4 (Unreleased)
 ---------------------

--- a/docs/develop/module-migrate.md
+++ b/docs/develop/module-migrate.md
@@ -238,7 +238,9 @@ Each minor release line has its own file with the breaking changes, new APIs and
 - Removed `AssetManager::$preventDefer` option
 - New Flysystem Filesystem Wrapper - Migrate all file access for assets and uploads to the Flysystem wrapper (`Yii::$app->fs->getDataMount()` or `Yii::$app->fs->getAssetsMount()`). Read more: https://flysystem.thephpleague.com/docs/usage/filesystem-api/
 - Added `humhub\modules\content\components\ContentContainerActiveRecord::EVENT_CREATE_PROFILE_IMAGE`
-  and `EVENT_CREATE_BANNER_IMAGE`.
+  and `EVENT_CREATE_BANNER_IMAGE` (`humhub\modules\content\events\ContentContainerImageEvent`) to customize
+  or replace a container's profile/banner `AssetImage`. Use these instead of overriding `$profileImageClass`,
+  which only affects the deprecated `ProfileImage` path.
 
 ## Released versions
 

--- a/docs/develop/module-migrate.md
+++ b/docs/develop/module-migrate.md
@@ -237,8 +237,8 @@ Each minor release line has its own file with the breaking changes, new APIs and
 - Removed `@filestore` Alias
 - Removed `AssetManager::$preventDefer` option
 - New Flysystem Filesystem Wrapper - Migrate all file access for assets and uploads to the Flysystem wrapper (`Yii::$app->fs->getDataMount()` or `Yii::$app->fs->getAssetsMount()`). Read more: https://flysystem.thephpleague.com/docs/usage/filesystem-api/
-- Added `humhub\modules\content\components\ContentContainerActiveRecord::EVENT_CREATE_PROFILE_IMAGE`
-  and `EVENT_CREATE_BANNER_IMAGE` (`humhub\modules\content\events\ContentContainerImageEvent`) to customize
+- Added `humhub\modules\content\components\ContentContainerActiveRecord::EVENT_INIT_PROFILE_IMAGE`
+  and `EVENT_INIT_BANNER_IMAGE` (`humhub\modules\content\events\ContentContainerImageEvent`) to customize
   or replace a container's profile/banner `AssetImage`. Use these instead of overriding `$profileImageClass`,
   which only affects the deprecated `ProfileImage` path.
 

--- a/docs/develop/module-migrate.md
+++ b/docs/develop/module-migrate.md
@@ -237,6 +237,8 @@ Each minor release line has its own file with the breaking changes, new APIs and
 - Removed `@filestore` Alias
 - Removed `AssetManager::$preventDefer` option
 - New Flysystem Filesystem Wrapper - Migrate all file access for assets and uploads to the Flysystem wrapper (`Yii::$app->fs->getDataMount()` or `Yii::$app->fs->getAssetsMount()`). Read more: https://flysystem.thephpleague.com/docs/usage/filesystem-api/
+- Added `humhub\modules\content\components\ContentContainerActiveRecord::EVENT_CREATE_PROFILE_IMAGE`
+  and `EVENT_CREATE_BANNER_IMAGE`.
 
 ## Released versions
 

--- a/protected/humhub/components/assets/AssetImage.php
+++ b/protected/humhub/components/assets/AssetImage.php
@@ -137,7 +137,10 @@ class AssetImage extends Component implements \Stringable
         $checksum = hash('xxh32', json_encode($options));
 
         $info = pathinfo($fileName);
-        return $info['filename'] . '_' . $checksum . '.' . $info['extension'];
+        // The source file may have no extension (e.g. a HumHub File is stored as `file`);
+        // fall back to the resolved image format so the variant still gets a valid extension.
+        $extension = $info['extension'] ?? $this->getFileFormat();
+        return $info['filename'] . '_' . $checksum . '.' . $extension;
     }
 
     private function convert(string $newFileName, array $options = []): bool

--- a/protected/humhub/modules/content/components/ContentContainerActiveRecord.php
+++ b/protected/humhub/modules/content/components/ContentContainerActiveRecord.php
@@ -11,6 +11,7 @@ namespace humhub\modules\content\components;
 use humhub\components\ActiveRecord;
 use humhub\components\assets\AssetImage;
 use humhub\libs\BasePermission;
+use humhub\components\Event;
 use humhub\libs\ProfileImage;
 use humhub\modules\content\models\Content;
 use humhub\modules\content\models\ContentContainer;
@@ -55,6 +56,20 @@ use yii\web\IdentityInterface;
  */
 abstract class ContentContainerActiveRecord extends ActiveRecord
 {
+    /**
+     * @event Event triggered when the profile image ({@see getImage()}) of the container is created.
+     * A handler may replace `$event->result` (the {@see AssetImage}) with a different image,
+     * @since 1.19
+     */
+    public const EVENT_CREATE_PROFILE_IMAGE = 'createProfileImage';
+
+    /**
+     * @event Event triggered when the banner image ({@see getBannerImage()}) of the container is created.
+     * A handler may replace `$event->result` (the {@see AssetImage}) with a different image,
+     * @since 1.19
+     */
+    public const EVENT_CREATE_BANNER_IMAGE = 'createBannerImage';
+
     /**
      * @var ContentContainerPermissionManager
      */
@@ -116,7 +131,7 @@ abstract class ContentContainerActiveRecord extends ActiveRecord
     public function getImage(): AssetImage
     {
         if ($this->_image === null) {
-            $this->_image = new AssetImage([
+            $image = new AssetImage([
                 'file' => '/profile_image/' . $this->guid . '.jpg',
                 'defaultOptions' => [
                     'width' => 150,
@@ -130,6 +145,7 @@ abstract class ContentContainerActiveRecord extends ActiveRecord
                     ? '@humhub/resources/img/default_space.jpg'
                     : '@humhub/resources/img/default_user.jpg',
             ]);
+            $this->_image = $this->triggerCreateImageEvent($image, self::EVENT_CREATE_PROFILE_IMAGE);
         }
         return $this->_image;
     }
@@ -137,7 +153,7 @@ abstract class ContentContainerActiveRecord extends ActiveRecord
     public function getBannerImage(): AssetImage
     {
         if ($this->_bannerImage === null) {
-            $this->_bannerImage = new AssetImage([
+            $image = new AssetImage([
                 'file' => '/profile_image/banner/' . $this->guid . '.jpg',
                 'defaultOptions' => [
                     'width' => 1134,
@@ -149,8 +165,23 @@ abstract class ContentContainerActiveRecord extends ActiveRecord
                 ],
                 'defaultFile' => '@humhub/resources/img/default_banner.jpg',
             ]);
+            $this->_bannerImage = $this->triggerCreateImageEvent($image, self::EVENT_CREATE_BANNER_IMAGE);
         }
         return $this->_bannerImage;
+    }
+
+    /**
+     * Triggers the given create-image event ({@see EVENT_CREATE_PROFILE_IMAGE} or
+     * {@see EVENT_CREATE_BANNER_IMAGE}), letting modules replace the container's {@see AssetImage}
+     * via `$event->result`, and returns the resulting image.
+     *
+     * @since 1.19
+     */
+    protected function triggerCreateImageEvent(AssetImage $image, string $eventName): AssetImage
+    {
+        $event = new Event(['result' => $image]);
+        $this->trigger($eventName, $event);
+        return $event->result;
     }
 
 

--- a/protected/humhub/modules/content/components/ContentContainerActiveRecord.php
+++ b/protected/humhub/modules/content/components/ContentContainerActiveRecord.php
@@ -11,8 +11,8 @@ namespace humhub\modules\content\components;
 use humhub\components\ActiveRecord;
 use humhub\components\assets\AssetImage;
 use humhub\libs\BasePermission;
-use humhub\components\Event;
 use humhub\libs\ProfileImage;
+use humhub\modules\content\events\ContentContainerImageEvent;
 use humhub\modules\content\models\Content;
 use humhub\modules\content\models\ContentContainer;
 use humhub\modules\content\models\ContentContainerBlockedUsers;
@@ -57,15 +57,21 @@ use yii\web\IdentityInterface;
 abstract class ContentContainerActiveRecord extends ActiveRecord
 {
     /**
-     * @event Event triggered when the profile image ({@see getImage()}) of the container is created.
-     * A handler may replace `$event->result` (the {@see AssetImage}) with a different image,
+     * @event ContentContainerImageEvent triggered when the profile image ({@see getImage()}) of the
+     * container is created. This happens once per record instance, on first access; the result is
+     * cached afterwards. A handler may modify `$event->image` (e.g. set another `defaultFile`) or
+     * replace it with a different {@see AssetImage} — `$event->config` holds the configuration the
+     * image was created with.
      * @since 1.19
      */
     public const EVENT_CREATE_PROFILE_IMAGE = 'createProfileImage';
 
     /**
-     * @event Event triggered when the banner image ({@see getBannerImage()}) of the container is created.
-     * A handler may replace `$event->result` (the {@see AssetImage}) with a different image,
+     * @event ContentContainerImageEvent triggered when the banner image ({@see getBannerImage()}) of the
+     * container is created. This happens once per record instance, on first access; the result is
+     * cached afterwards. A handler may modify `$event->image` (e.g. set another `defaultFile`) or
+     * replace it with a different {@see AssetImage} — `$event->config` holds the configuration the
+     * image was created with.
      * @since 1.19
      */
     public const EVENT_CREATE_BANNER_IMAGE = 'createBannerImage';
@@ -131,7 +137,7 @@ abstract class ContentContainerActiveRecord extends ActiveRecord
     public function getImage(): AssetImage
     {
         if ($this->_image === null) {
-            $image = new AssetImage([
+            $this->_image = $this->triggerCreateImageEvent(self::EVENT_CREATE_PROFILE_IMAGE, [
                 'file' => '/profile_image/' . $this->guid . '.jpg',
                 'defaultOptions' => [
                     'width' => 150,
@@ -145,7 +151,6 @@ abstract class ContentContainerActiveRecord extends ActiveRecord
                     ? '@humhub/resources/img/default_space.jpg'
                     : '@humhub/resources/img/default_user.jpg',
             ]);
-            $this->_image = $this->triggerCreateImageEvent($image, self::EVENT_CREATE_PROFILE_IMAGE);
         }
         return $this->_image;
     }
@@ -153,7 +158,7 @@ abstract class ContentContainerActiveRecord extends ActiveRecord
     public function getBannerImage(): AssetImage
     {
         if ($this->_bannerImage === null) {
-            $image = new AssetImage([
+            $this->_bannerImage = $this->triggerCreateImageEvent(self::EVENT_CREATE_BANNER_IMAGE, [
                 'file' => '/profile_image/banner/' . $this->guid . '.jpg',
                 'defaultOptions' => [
                     'width' => 1134,
@@ -165,25 +170,27 @@ abstract class ContentContainerActiveRecord extends ActiveRecord
                 ],
                 'defaultFile' => '@humhub/resources/img/default_banner.jpg',
             ]);
-            $this->_bannerImage = $this->triggerCreateImageEvent($image, self::EVENT_CREATE_BANNER_IMAGE);
         }
         return $this->_bannerImage;
     }
 
     /**
      * Triggers the given create-image event ({@see EVENT_CREATE_PROFILE_IMAGE} or
-     * {@see EVENT_CREATE_BANNER_IMAGE}), letting modules replace the container's {@see AssetImage}
-     * via `$event->result`, and returns the resulting image.
+     * {@see EVENT_CREATE_BANNER_IMAGE}), letting modules customize or replace the container's
+     * {@see AssetImage}, and returns the resulting image.
      *
      * @since 1.19
      */
-    protected function triggerCreateImageEvent(AssetImage $image, string $eventName): AssetImage
+    protected function triggerCreateImageEvent(string $eventName, array $config): AssetImage
     {
-        $event = new Event(['result' => $image]);
+        $event = new ContentContainerImageEvent([
+            'image' => new AssetImage($config),
+            'config' => $config,
+        ]);
         $this->trigger($eventName, $event);
-        return $event->result;
-    }
 
+        return $event->image;
+    }
 
     /**
      * @return ProfileImage

--- a/protected/humhub/modules/content/components/ContentContainerActiveRecord.php
+++ b/protected/humhub/modules/content/components/ContentContainerActiveRecord.php
@@ -58,23 +58,23 @@ abstract class ContentContainerActiveRecord extends ActiveRecord
 {
     /**
      * @event ContentContainerImageEvent triggered when the profile image ({@see getImage()}) of the
-     * container is created. This happens once per record instance, on first access; the result is
+     * container is initialized. This happens once per record instance, on first access; the result is
      * cached afterwards. A handler may modify `$event->image` (e.g. set another `defaultFile`) or
      * replace it with a different {@see AssetImage} — `$event->config` holds the configuration the
      * image was created with.
      * @since 1.19
      */
-    public const EVENT_CREATE_PROFILE_IMAGE = 'createProfileImage';
+    public const EVENT_INIT_PROFILE_IMAGE = 'initProfileImage';
 
     /**
      * @event ContentContainerImageEvent triggered when the banner image ({@see getBannerImage()}) of the
-     * container is created. This happens once per record instance, on first access; the result is
+     * container is initialized. This happens once per record instance, on first access; the result is
      * cached afterwards. A handler may modify `$event->image` (e.g. set another `defaultFile`) or
      * replace it with a different {@see AssetImage} — `$event->config` holds the configuration the
      * image was created with.
      * @since 1.19
      */
-    public const EVENT_CREATE_BANNER_IMAGE = 'createBannerImage';
+    public const EVENT_INIT_BANNER_IMAGE = 'initBannerImage';
 
     /**
      * @var ContentContainerPermissionManager
@@ -137,7 +137,7 @@ abstract class ContentContainerActiveRecord extends ActiveRecord
     public function getImage(): AssetImage
     {
         if ($this->_image === null) {
-            $this->_image = $this->triggerCreateImageEvent(self::EVENT_CREATE_PROFILE_IMAGE, [
+            $this->_image = $this->triggerInitImageEvent(self::EVENT_INIT_PROFILE_IMAGE, [
                 'file' => '/profile_image/' . $this->guid . '.jpg',
                 'defaultOptions' => [
                     'width' => 150,
@@ -158,7 +158,7 @@ abstract class ContentContainerActiveRecord extends ActiveRecord
     public function getBannerImage(): AssetImage
     {
         if ($this->_bannerImage === null) {
-            $this->_bannerImage = $this->triggerCreateImageEvent(self::EVENT_CREATE_BANNER_IMAGE, [
+            $this->_bannerImage = $this->triggerInitImageEvent(self::EVENT_INIT_BANNER_IMAGE, [
                 'file' => '/profile_image/banner/' . $this->guid . '.jpg',
                 'defaultOptions' => [
                     'width' => 1134,
@@ -175,13 +175,13 @@ abstract class ContentContainerActiveRecord extends ActiveRecord
     }
 
     /**
-     * Triggers the given create-image event ({@see EVENT_CREATE_PROFILE_IMAGE} or
-     * {@see EVENT_CREATE_BANNER_IMAGE}), letting modules customize or replace the container's
+     * Triggers the given init-image event ({@see EVENT_INIT_PROFILE_IMAGE} or
+     * {@see EVENT_INIT_BANNER_IMAGE}), letting modules customize or replace the container's
      * {@see AssetImage}, and returns the resulting image.
      *
      * @since 1.19
      */
-    protected function triggerCreateImageEvent(string $eventName, array $config): AssetImage
+    private function triggerInitImageEvent(string $eventName, array $config): AssetImage
     {
         $event = new ContentContainerImageEvent([
             'image' => new AssetImage($config),

--- a/protected/humhub/modules/content/events/ContentContainerImageEvent.php
+++ b/protected/humhub/modules/content/events/ContentContainerImageEvent.php
@@ -14,10 +14,10 @@ use yii\base\Event;
 
 /**
  * ContentContainerImageEvent is triggered when the profile or banner image of a
- * container is created, letting modules customize or replace the {@see AssetImage}.
+ * container is initialized, letting modules customize or replace the {@see AssetImage}.
  *
- * @see \humhub\modules\content\components\ContentContainerActiveRecord::EVENT_CREATE_PROFILE_IMAGE
- * @see \humhub\modules\content\components\ContentContainerActiveRecord::EVENT_CREATE_BANNER_IMAGE
+ * @see \humhub\modules\content\components\ContentContainerActiveRecord::EVENT_INIT_PROFILE_IMAGE
+ * @see \humhub\modules\content\components\ContentContainerActiveRecord::EVENT_INIT_BANNER_IMAGE
  * @since 1.19
  */
 class ContentContainerImageEvent extends Event

--- a/protected/humhub/modules/content/events/ContentContainerImageEvent.php
+++ b/protected/humhub/modules/content/events/ContentContainerImageEvent.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @link https://www.humhub.org/
+ * @copyright Copyright (c) 2026 HumHub GmbH & Co. KG
+ * @license https://www.humhub.com/licences
+ *
+ */
+
+namespace humhub\modules\content\events;
+
+use humhub\components\assets\AssetImage;
+use yii\base\Event;
+
+/**
+ * ContentContainerImageEvent is triggered when the profile or banner image of a
+ * container is created, letting modules customize or replace the {@see AssetImage}.
+ *
+ * @see \humhub\modules\content\components\ContentContainerActiveRecord::EVENT_CREATE_PROFILE_IMAGE
+ * @see \humhub\modules\content\components\ContentContainerActiveRecord::EVENT_CREATE_BANNER_IMAGE
+ * @since 1.19
+ */
+class ContentContainerImageEvent extends Event
+{
+    /**
+     * @var AssetImage the image the container will use. A handler may modify this instance
+     * (e.g. set another `defaultFile`) or replace it with a different image, typically
+     * reusing {@see $config}: `$event->image = new MyAssetImage($event->config);`
+     */
+    public AssetImage $image;
+
+    /**
+     * @var array the configuration the image was created with, allowing handlers to build
+     * a replacement without duplicating the core defaults
+     */
+    public array $config = [];
+}

--- a/protected/humhub/modules/content/tests/codeception/unit/ContentContainerImageEventTest.php
+++ b/protected/humhub/modules/content/tests/codeception/unit/ContentContainerImageEventTest.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * @link https://www.humhub.org/
+ * @copyright Copyright (c) 2026 HumHub GmbH & Co. KG
+ * @license https://www.humhub.com/licences
+ *
+ */
+
+namespace tests\codeception\unit\modules\content;
+
+use humhub\components\assets\AssetImage;
+use humhub\modules\content\components\ContentContainerActiveRecord;
+use humhub\modules\content\events\ContentContainerImageEvent;
+use humhub\modules\space\models\Space;
+use humhub\modules\user\models\User;
+use tests\codeception\_support\HumHubDbTestCase;
+use Yii;
+use yii\base\Event;
+
+class ContentContainerImageEventTest extends HumHubDbTestCase
+{
+    protected function _after()
+    {
+        Event::off(Space::class, ContentContainerActiveRecord::EVENT_CREATE_PROFILE_IMAGE);
+        Event::off(Space::class, ContentContainerActiveRecord::EVENT_CREATE_BANNER_IMAGE);
+        parent::_after();
+    }
+
+    public function testProfileImageCanBeReplacedByEvent()
+    {
+        Event::on(Space::class, ContentContainerActiveRecord::EVENT_CREATE_PROFILE_IMAGE, function (ContentContainerImageEvent $event) {
+            $event->image = new AssetImage(['file' => '/tests/custom-profile.png'] + $event->config);
+        });
+
+        $space = Space::findOne(['id' => 1]);
+        $this->assertSame('/tests/custom-profile.png', $space->getImage()->file);
+        // `$event->config` lets handlers reuse the core defaults for their replacement
+        $this->assertSame(150, $space->getImage()->defaultOptions['width']);
+
+        // The banner image and other container classes are unaffected
+        $this->assertSame('/profile_image/banner/' . $space->guid . '.jpg', $space->getBannerImage()->file);
+        $user = User::findOne(['id' => 1]);
+        $this->assertSame('/profile_image/' . $user->guid . '.jpg', $user->getImage()->file);
+    }
+
+    public function testBannerImageCanBeCustomizedByEvent()
+    {
+        Event::on(Space::class, ContentContainerActiveRecord::EVENT_CREATE_BANNER_IMAGE, function (ContentContainerImageEvent $event) {
+            $event->image->defaultFile = Yii::getAlias('@humhub/resources/img/default_space.jpg');
+        });
+
+        $space = Space::findOne(['id' => 1]);
+        $this->assertStringEndsWith('default_space.jpg', $space->getBannerImage()->defaultFile);
+    }
+
+    public function testCreateImageEventIsTriggeredOncePerRecord()
+    {
+        $calls = 0;
+        Event::on(Space::class, ContentContainerActiveRecord::EVENT_CREATE_PROFILE_IMAGE, function () use (&$calls) {
+            $calls++;
+        });
+
+        $space = Space::findOne(['id' => 1]);
+        $this->assertSame($space->getImage(), $space->getImage());
+        $this->assertSame(1, $calls);
+    }
+}

--- a/protected/humhub/modules/content/tests/codeception/unit/ContentContainerImageEventTest.php
+++ b/protected/humhub/modules/content/tests/codeception/unit/ContentContainerImageEventTest.php
@@ -22,14 +22,14 @@ class ContentContainerImageEventTest extends HumHubDbTestCase
 {
     protected function _after()
     {
-        Event::off(Space::class, ContentContainerActiveRecord::EVENT_CREATE_PROFILE_IMAGE);
-        Event::off(Space::class, ContentContainerActiveRecord::EVENT_CREATE_BANNER_IMAGE);
+        Event::off(Space::class, ContentContainerActiveRecord::EVENT_INIT_PROFILE_IMAGE);
+        Event::off(Space::class, ContentContainerActiveRecord::EVENT_INIT_BANNER_IMAGE);
         parent::_after();
     }
 
     public function testProfileImageCanBeReplacedByEvent()
     {
-        Event::on(Space::class, ContentContainerActiveRecord::EVENT_CREATE_PROFILE_IMAGE, function (ContentContainerImageEvent $event) {
+        Event::on(Space::class, ContentContainerActiveRecord::EVENT_INIT_PROFILE_IMAGE, function (ContentContainerImageEvent $event) {
             $event->image = new AssetImage(['file' => '/tests/custom-profile.png'] + $event->config);
         });
 
@@ -46,7 +46,7 @@ class ContentContainerImageEventTest extends HumHubDbTestCase
 
     public function testBannerImageCanBeCustomizedByEvent()
     {
-        Event::on(Space::class, ContentContainerActiveRecord::EVENT_CREATE_BANNER_IMAGE, function (ContentContainerImageEvent $event) {
+        Event::on(Space::class, ContentContainerActiveRecord::EVENT_INIT_BANNER_IMAGE, function (ContentContainerImageEvent $event) {
             $event->image->defaultFile = Yii::getAlias('@humhub/resources/img/default_space.jpg');
         });
 
@@ -54,10 +54,10 @@ class ContentContainerImageEventTest extends HumHubDbTestCase
         $this->assertStringEndsWith('default_space.jpg', $space->getBannerImage()->defaultFile);
     }
 
-    public function testCreateImageEventIsTriggeredOncePerRecord()
+    public function testInitImageEventIsTriggeredOncePerRecord()
     {
         $calls = 0;
-        Event::on(Space::class, ContentContainerActiveRecord::EVENT_CREATE_PROFILE_IMAGE, function () use (&$calls) {
+        Event::on(Space::class, ContentContainerActiveRecord::EVENT_INIT_PROFILE_IMAGE, function () use (&$calls) {
             $calls++;
         });
 

--- a/protected/humhub/tests/codeception/unit/components/assets/AssetImagePublishTest.php
+++ b/protected/humhub/tests/codeception/unit/components/assets/AssetImagePublishTest.php
@@ -142,6 +142,20 @@ class AssetImagePublishTest extends HumHubDbTestCase
         $this->assertSame('', $withoutDefault->getUrl());
     }
 
+    public function testUrlForSourceFileWithoutExtension()
+    {
+        // e.g. a HumHub `File` record's stored file, saved without an extension as `file`
+        $image = new AssetImage([
+            'file' => '/tests/asset-image/file',
+            'defaultOptions' => self::OPTIONS,
+        ]);
+        $image->delete(); // remove leftovers of previous runs
+        $image->setByFile($this->createTempImage('default_user.jpg'));
+
+        // The variant falls back to the resolved image format for its extension
+        $this->assertStringContainsString('.png', $image->getUrl());
+    }
+
     private function createAssetImage(): AssetImage
     {
         return new AssetImage([


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included
- [ ] Changelog was modified

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

- Enh: Add`ContentContainerActiveRecord::EVENT_CREATE_PROFILE_IMAGE` and `EVENT_CREATE_BANNER_IMAGE`
- Fix: `AssetImage::getUrl()` for a source file without an extension (e.g. a HumHub `File`, stored as `file`)