### PR TITLE
Fix: remove leftover codecept_debug() call in ActiveQueryActivity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ nbproject
 .php-cs-fixer.cache
 .php_cs.cache
 .DS_Store
+.playwright-mcp/
 
 themes/*
 !themes/HumHub

--- a/protected/humhub/modules/activity/components/ActiveQueryActivity.php
+++ b/protected/humhub/modules/activity/components/ActiveQueryActivity.php
@@ -148,8 +148,6 @@ class ActiveQueryActivity extends ActiveQuery
                 $user,
             ) == MailSummaryForm::LIMIT_MODE_INCLUDE) ? 'IN' : 'NOT IN';
             $this->andWhere([$mode, 'activity.contentcontainer_id', $limitContainer]);
-
-            codecept_debug($limitContainer);
         }
 
 


### PR DESCRIPTION
## Problem

`ActiveQueryActivity::mailLimitContentContainer()` contained a leftover
`codecept_debug($limitContainer);` debug statement (introduced by the activity
subsystem rebuild, #7933). `codecept_debug()` is defined only in the
`codeception/codeception` dev dependency, which is not installed in production
(`composer install --no-dev`).

Any user with a non-empty `mailSummaryLimitSpaces` setting therefore triggers a
fatal `Error: Call to undefined function codecept_debug()` when the mail-summary
cron runs, aborting the summary job.

## Fix

Remove the leftover debug statement. No behavioural change to the query.

Also adds `.playwright-mcp/` to `.gitignore`.

Ref: https://github.com/humhub/humhub-internal/issues/1266
