### PR TITLE
Classify gate request applicability by auth context, not the Accept header

### DIFF
--- a/protected/humhub/components/gates/GateFilter.php
+++ b/protected/humhub/components/gates/GateFilter.php
@@ -18,14 +18,15 @@ use yii\web\Response;
 /**
  * Enforces user gates on controller actions (see `docs/develop/user-gates.md`).
  *
- * Attached to [[\humhub\components\Controller]] after the access control behavior.
- * Classifies the request, asks the [[GateManager]] for an intercepting gate and answers
- * according to the request class:
+ * Attached to [[\humhub\components\Controller]] after the access control behavior. It
+ * classifies the request by its authentication context (see [[getRequestClass()]]), asks
+ * the [[GateManager]] for an intercepting gate and, if one intercepts, answers according
+ * to what the client can consume:
  *
- * - full page navigation: 302 to the gate route (the original URL is stored as returnUrl)
+ * - browser navigation: 302 to the gate route (a GET target is stored as returnUrl)
  * - AJAX/PJAX: 401 + JSON `{gate, url}`; the `X-Redirect` header lets `yii.js` redirect
  *   the top-level window
- * - API: 403 + JSON `{gate, message}`
+ * - anything else (JSON/API clients, sub-resource fetches): 403 + JSON `{gate, message}`
  *
  * At most one gate intercepts per request. When a gate intercepts, the event is marked
  * as handled so that legacy `EVENT_BEFORE_ACTION` interceptors do not overwrite the
@@ -69,66 +70,77 @@ class GateFilter extends ActionFilter
 
         $gate->onIntercept();
 
+        $request = Yii::$app->request;
         $response = Yii::$app->response;
         $gateUrl = Url::to($gate->getRoute());
 
-        switch ($requestClass) {
-            case RequestClass::FullPage:
-                if (Yii::$app->request->getIsGet()) {
-                    Yii::$app->user->setReturnUrl(Yii::$app->request->getUrl());
-                }
-                $response->redirect($gateUrl);
-                break;
-
-            case RequestClass::Ajax:
-                $response->setStatusCode(401);
-                $response->format = Response::FORMAT_JSON;
-                $response->data = ['gate' => $gate->getId(), 'url' => $gateUrl];
-                // yii.js redirects the top-level window on this header (ajaxComplete handler)
-                $response->headers->set('X-Redirect', $gateUrl);
-                break;
-
-            case RequestClass::Api:
-                $response->setStatusCode(403);
-                $response->format = Response::FORMAT_JSON;
-                $response->data = [
-                    'gate' => $gate->getId(),
-                    'message' => 'This action requires completing the "' . $gate->getId() . '" gate first.',
-                ];
-                break;
+        // The response shape follows what the client can consume (content negotiation),
+        // decided separately from whether the gate applies (getRequestClass()).
+        if ($request->getIsAjax() || $request->getIsPjax()) {
+            $response->setStatusCode(401);
+            $response->format = Response::FORMAT_JSON;
+            $response->data = ['gate' => $gate->getId(), 'url' => $gateUrl];
+            // yii.js redirects the top-level window on this header (ajaxComplete handler)
+            $response->headers->set('X-Redirect', $gateUrl);
+        } elseif ($this->acceptsHtml($request)) {
+            // Browser navigation — only a GET target is worth returning to afterwards
+            if ($request->getIsGet()) {
+                Yii::$app->user->setReturnUrl($request->getUrl());
+            }
+            $response->redirect($gateUrl);
+        } else {
+            $response->setStatusCode(403);
+            $response->format = Response::FORMAT_JSON;
+            $response->data = [
+                'gate' => $gate->getId(),
+                'url' => $gateUrl,
+                'message' => 'This action requires completing the "' . $gate->getId() . '" gate first.',
+            ];
         }
 
         return false;
     }
 
     /**
-     * Classifies the current request (see [[RequestClass]]).
+     * Classifies the current request by its authentication context — not by client-supplied
+     * content negotiation, so a gate cannot be escaped by spoofing request headers.
      *
-     * Only requests explicitly negotiating an HTML response are browser navigations —
-     * everything else (wildcard or JSON accept headers: service worker and manifest
-     * fetches, API clients, curl) must never be answered with a redirect, and especially
-     * must not poison the returnUrl that full-page interception stores.
+     * A token-/stateless-authenticated request (e.g. REST, CalDAV — the session is disabled
+     * server-side) is [[RequestClass::Api]]. A session-authenticated request is always
+     * [[RequestClass::Ajax]] or [[RequestClass::FullPage]] and stays subject to the gates,
+     * even when it sends, for example, `Accept: application/json`.
      */
     protected function getRequestClass(): RequestClass
     {
-        $request = Yii::$app->request;
+        if (!Yii::$app->user->enableSession) {
+            return RequestClass::Api;
+        }
 
-        if ($request->getIsAjax() || $request->getIsPjax()) {
+        if (Yii::$app->request->getIsAjax() || Yii::$app->request->getIsPjax()) {
             return RequestClass::Ajax;
         }
 
-        // No Accept header at all = no preference expressed; treat as navigation.
+        return RequestClass::FullPage;
+    }
+
+    /**
+     * Whether the client negotiates an HTML response (or expresses no preference) — a
+     * browser navigation that should be answered with a redirect rather than JSON.
+     */
+    protected function acceptsHtml($request): bool
+    {
         $acceptableContentTypes = $request->getAcceptableContentTypes();
         if (empty($acceptableContentTypes)) {
-            return RequestClass::FullPage;
+            // No preference expressed — treat as a browser navigation.
+            return true;
         }
 
         foreach ($acceptableContentTypes as $type => $params) {
             if (in_array($type, ['text/html', 'application/xhtml+xml'], true)) {
-                return RequestClass::FullPage;
+                return true;
             }
         }
 
-        return RequestClass::Api;
+        return false;
     }
 }

--- a/protected/humhub/components/gates/RequestClass.php
+++ b/protected/humhub/components/gates/RequestClass.php
@@ -9,13 +9,19 @@
 namespace humhub\components\gates;
 
 /**
- * Classification of an incoming request used to decide whether and how an open
- * user gate responds to it.
+ * Classification of an incoming request used to decide whether a user gate applies to it.
+ * It reflects the server-side authentication context, not client-supplied content
+ * negotiation, so a gate cannot be escaped by spoofing request headers
+ * (see [[GateFilter::getRequestClass()]]).
  *
- * - `FullPage`: regular browser navigation (GET, accepts `text/html`) — answered with a 302
- * - `Ajax`: XHR / fetch / PJAX / live polling — answered with 401 + JSON `{gate, url}`
- * - `Api`: token-authenticated machine request — answered with 403 + error code, if the
- *   gate applies to API requests at all
+ * - `FullPage`: session-authenticated request that is not an XHR (typically a browser
+ *   navigation)
+ * - `Ajax`: session-authenticated XHR / fetch / PJAX / live polling request
+ * - `Api`: token-/stateless-authenticated request (e.g. REST, CalDAV — the session is
+ *   disabled server-side)
+ *
+ * How an intercepted request is answered (302 / 401 / 403) is chosen separately, based on
+ * content negotiation; see [[GateFilter]].
  *
  * @see UserGateInterface::appliesTo()
  * @since 1.19

--- a/protected/humhub/tests/codeception/unit/components/gates/GateFilterRequestClassTest.php
+++ b/protected/humhub/tests/codeception/unit/components/gates/GateFilterRequestClassTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * @link https://www.humhub.org/
+ * @copyright Copyright (c) 2026 HumHub GmbH & Co. KG
+ * @license https://www.humhub.com/licences
+ */
+
+namespace humhub\tests\codeception\unit\components\gates;
+
+use humhub\components\gates\GateFilter;
+use humhub\components\gates\RequestClass;
+use tests\codeception\_support\HumHubDbTestCase;
+use Yii;
+use yii\web\Request;
+
+/**
+ * The request classification that decides gate applicability must depend on the server-side
+ * authentication context (stateless token vs. session), never on the client-supplied Accept
+ * header — otherwise a session could escape a gate by sending `Accept: application/json`.
+ */
+class GateFilterRequestClassTest extends HumHubDbTestCase
+{
+    private function classify(bool $enableSession, array $headers): RequestClass
+    {
+        Yii::$app->user->enableSession = $enableSession;
+
+        $request = new Request();
+        foreach ($headers as $name => $value) {
+            $request->headers->set($name, $value);
+        }
+        Yii::$app->set('request', $request);
+
+        $filter = new class () extends GateFilter {
+            public function classify(): RequestClass
+            {
+                return $this->getRequestClass();
+            }
+        };
+
+        return $filter->classify();
+    }
+
+    public function testStatelessRequestIsApiRegardlessOfAcceptHeader()
+    {
+        // REST/CalDAV set enableSession = false; whatever the client accepts, it is API
+        $this->assertSame(RequestClass::Api, $this->classify(false, ['Accept' => 'text/html']));
+        $this->assertSame(RequestClass::Api, $this->classify(false, ['Accept' => 'application/json']));
+    }
+
+    public function testSessionRequestIsNeverApiEvenWithJsonAccept()
+    {
+        // A cookie-authenticated request cannot downgrade itself to API via the Accept header
+        $this->assertSame(RequestClass::FullPage, $this->classify(true, ['Accept' => 'application/json']));
+        $this->assertSame(RequestClass::FullPage, $this->classify(true, ['Accept' => '*/*']));
+        $this->assertSame(RequestClass::FullPage, $this->classify(true, ['Accept' => 'text/html']));
+    }
+
+    public function testSessionXhrIsAjax()
+    {
+        $this->assertSame(RequestClass::Ajax, $this->classify(true, [
+            'Accept' => 'application/json',
+            'X-Requested-With' => 'XMLHttpRequest',
+        ]));
+    }
+}


### PR DESCRIPTION
Follow-up to #8291.

The gate dispatcher decided whether a request was an exempt API request from the client-supplied `Accept` header (`getRequestClass()` returned `RequestClass::Api` for any non-XHR request that did not accept `text/html`). Since the client controls that header, a session that had not yet passed a gate — e.g. a login that completed the password step but not the pending two-factor verification — could send `Accept: application/json` on a normal request and the gate that exempts API requests (twofa) would let it through.

## Change

`getRequestClass()` now derives the applicability class from the **server-side authentication context**, which the client cannot influence:

- stateless / token request (`Yii::$app->user->enableSession === false`, e.g. REST, CalDAV) → `RequestClass::Api`
- session-authenticated request → always `RequestClass::Ajax` (XHR/PJAX) or `RequestClass::FullPage`

A session request therefore stays subject to the gates whatever its `Accept` header says.

The response shape (302 / 401 / 403) is chosen separately, from content negotiation, and the `returnUrl` is only stored for genuine navigations — so sub-resource requests (service worker, `fetch`) neither receive a redirect nor poison the returnUrl (keeps the fix from #8291's follow-up intact).

## Tests

Adds `GateFilterRequestClassTest` (unit): a session request stays `FullPage` even with `Accept: application/json` / `*/*`, a stateless request is `Api` regardless of Accept, and a session XHR is `Ajax`. Full gate unit suite and the user module functional suite pass.
