### PR TITLE
Remove the unused doNotInterceptActionIds flag and isNotInterceptedAction()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ HumHub Changelog
 
 1.19 (TBD)
 ----------
+- Enh: Removed the now-unused `Controller::$doNotInterceptActionIds` flag and `Controller::isNotInterceptedAction()` — action interception is handled by the user gate system (see `docs/develop/user-gates.md`); see the migration guide
 - Enh: When Step 1 of the two-step login form redirects to an external auth client, the resolved user's e-mail address is now stored as a one-shot login hint (`LoginHintService`) — external auth clients (SAML, OIDC) can consume it and forward it to the IdP so its login mask is pre-filled with the identity the user already typed
 - Enh #8292: The installer "Modules" step no longer downloads a recommended module from the marketplace when it is already available locally (e.g. via `moduleAutoloadPaths`) — the local module is enabled instead
 - Enh: Added the central user gate system (`humhub\components\gates`) for modules that intercept requests to route the user through a mandatory flow (2FA check, terms acceptance, wizards) — gates register via `GateManager::EVENT_INIT_GATES`, are evaluated in a deterministic order with at most one redirect per request, answer AJAX/API requests with machine-readable responses instead of HTML redirects, and cache the all-closed state per session; the must-change-password and maintenance-mode enforcement were migrated from `ControllerAccess` fixed rules to the first core gates, and the unused legacy `codeCallback` mechanism was removed (see `docs/develop/user-gates.md` and the migration guide)

--- a/docs/develop/module-migrate.md
+++ b/docs/develop/module-migrate.md
@@ -25,7 +25,15 @@ Each minor release line has its own file with the breaking changes, new APIs and
     during maintenance now happens in the gate's `onIntercept()` hook.
   - Requests classified as AJAX/PJAX now receive `401` + JSON `{gate, url}` (plus an
     `X-Redirect` header handled by `yii.js`) instead of a `302` to an HTML page when a gate
-    intercepts; API requests (content negotiation without `text/html`) receive `403` + JSON.
+    intercepts; token-authenticated API requests (server-side, `enableSession = false`)
+    receive `403` + JSON.
+  - **Removed** `Controller::$doNotInterceptActionIds` and `Controller::isNotInterceptedAction()`
+    (`@since 1.9`, unused by the gate system and uncalled by any known module). The flag was a
+    controller's way to opt individual actions out of interception; that is now handled by the
+    gates themselves (`UserGateInterface::appliesTo()` / `getAllowedRoutes()`), and stateless
+    API endpoints are exempt via the request classification. A module controller that still
+    declares the property keeps working (it becomes an unused own property) but the declaration
+    can be removed.
 - `humhub\modules\content\components\ActiveQueryContent::readable()` and `::userRelated()` no
   longer accept a `$user` parameter. The user is now resolved once, in the constructor — either
   the current session user (`Yii::$app->user->getIdentity()`) or an explicit user passed as the

--- a/protected/humhub/components/Controller.php
+++ b/protected/humhub/components/Controller.php
@@ -61,12 +61,6 @@ class Controller extends \yii\web\Controller
     protected $access = StrictAccess::class;
 
     /**
-     * @var string[] List of action ids which should not be intercepted by another actions. Use '*' for all action ids.
-     * @since 1.9
-     */
-    protected $doNotInterceptActionIds = [];
-
-    /**
      * Returns access rules for the standard access control behavior.
      *
      * @return array the access permissions
@@ -310,32 +304,5 @@ class Controller extends \yii\web\Controller
     {
         $moduleId = (Yii::$app->controller->module) ? Yii::$app->controller->module->id : '';
         $this->view->registerJs('humhub.modules.ui.view.setState("' . $moduleId . '", "' . Yii::$app->controller->id . '", "' . Yii::$app->controller->action->id . '");', \yii\web\View::POS_BEGIN);
-    }
-
-    /**
-     * Check if action cannot be intercepted
-     *
-     * @param string|null $actionId , NULL - to use current action
-     *
-     * @return bool
-     * @since 1.9
-     */
-    public function isNotInterceptedAction(?string $actionId = null): bool
-    {
-        if ($actionId === null) {
-            if (isset($this->action->id)) {
-                $actionId = $this->action->id;
-            } else {
-                return false;
-            }
-        }
-
-        foreach ($this->doNotInterceptActionIds as $doNotInterceptActionId) {
-            if ($doNotInterceptActionId === '*' || $doNotInterceptActionId === $actionId) {
-                return true;
-            }
-        }
-
-        return false;
     }
 }

--- a/protected/humhub/modules/live/controllers/PollController.php
+++ b/protected/humhub/modules/live/controllers/PollController.php
@@ -29,11 +29,6 @@ use yii\db\Expression;
 class PollController extends Controller
 {
     /**
-     * @inheritdoc
-     */
-    protected $doNotInterceptActionIds = ['*'];
-
-    /**
      * @var int maximum events by query
      */
     public $maxEventsByQuery = 500;

--- a/protected/humhub/modules/user/controllers/AccountController.php
+++ b/protected/humhub/modules/user/controllers/AccountController.php
@@ -41,11 +41,6 @@ class AccountController extends BaseAccountController
     /**
      * @inheritdoc
      */
-    protected $doNotInterceptActionIds = ['delete'];
-
-    /**
-     * @inheritdoc
-     */
     public function init()
     {
         $this->setActionTitles([

--- a/protected/humhub/modules/user/controllers/AuthController.php
+++ b/protected/humhub/modules/user/controllers/AuthController.php
@@ -78,11 +78,6 @@ class AuthController extends Controller
     public $access = ControllerAccess::class;
 
     /**
-     * @inheritdoc
-     */
-    protected $doNotInterceptActionIds = ['*'];
-
-    /**
      * Whether self-registration is currently permitted at all — false in
      * maintenance mode or when the admin has disabled anonymous registration.
      * Covers the back-end gate: blocks AuthClient-driven auto-registration and


### PR DESCRIPTION
Cleanup follow-up to the user gate system (#8291).

`Controller::$doNotInterceptActionIds` (`@since 1.9`) and `Controller::isNotInterceptedAction()` let a controller opt individual actions out of being intercepted by another module. Since 1.19 that concern is owned by the user gate system: a gate decides applicability through `UserGateInterface::appliesTo()` / `getAllowedRoutes()`, and stateless API endpoints are exempt via the request classification (#8295). The flag is no longer read anywhere in core and is not called by any known module (verified across the humhub/* and humhub-contrib/* orgs — the method has zero callers).

## Change

- Removes the base `$doNotInterceptActionIds` property and the `isNotInterceptedAction()` method from `humhub\components\Controller`.
- Removes the now-dead declarations in `live` `PollController`, `user` `AuthController` and `AccountController`.

A module controller that still declares `protected $doNotInterceptActionIds = [...]` keeps working — it simply becomes an unused own property (PHP allows redeclaring a property the parent no longer defines) — and can drop it at its convenience. Recorded under "Removed" in the migration guide.

No behavior change: nothing consumed the flag after the gate migration.
