### PR TITLE
Revert missed `MobileAppHelper::registerHideOpenerScript()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ HumHub Changelog
 - Fix #8282: Fix confirm modal closing itself on next open after being closed during its hide transition
 - Enh #8286: Display a success toast when a module is enabled
 - Enh #8300: Update composer package web-token/jwt-library to 4.1.7 (GHSA-3prj-6hqw-cm82, GHSA-jc38-x7x8-2xc8)
+- Fix #8301: Revert missed `MobileAppHelper::registerHideOpenerScript()`
 
 1.18.3 (May 18, 2026)
 ---------------------

--- a/protected/humhub/helpers/MobileAppHelper.php
+++ b/protected/humhub/helpers/MobileAppHelper.php
@@ -33,6 +33,18 @@ class MobileAppHelper
         self::sendFlutterMessage($message);
     }
 
+    public static function registerHideOpenerScript(): void
+    {
+        if (!DeviceDetectorHelper::isAppRequest()) {
+            return;
+        }
+
+        $json = ['type' => 'hideOpener'];
+        $message = Json::encode($json);
+
+        self::sendFlutterMessage($message);
+    }
+
     /**
      * @deprecated Remove in 1.19
      */

--- a/protected/humhub/widgets/LayoutAddons.php
+++ b/protected/humhub/widgets/LayoutAddons.php
@@ -9,6 +9,7 @@
 namespace humhub\widgets;
 
 use humhub\components\InstallationState;
+use humhub\helpers\DeviceDetectorHelper;
 use humhub\helpers\MobileAppHelper;
 use humhub\modules\admin\widgets\TrackingWidget;
 use humhub\modules\tour\widgets\Tour;
@@ -52,6 +53,11 @@ class LayoutAddons extends BaseStack
         parent::init();
 
         if (Yii::$app->installationState->hasState(InstallationState::STATE_INSTALLED)) {
+            // If the mobile app Opener page is open (after login and switching instance)
+            if (DeviceDetectorHelper::appOpenerState()) {
+                MobileAppHelper::registerHideOpenerScript();
+            }
+
             if (Yii::$app->session->has(MobileAppHelper::SESSION_VAR_SHOW_OPENER)) {
                 MobileAppHelper::registerShowOpenerScript();
                 Yii::$app->session->remove(MobileAppHelper::SESSION_VAR_SHOW_OPENER);


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

**The PR fulfills these requirements:**

- [ ] All tests are passing
- [x] Changelog was modified

**Other information:**
https://github.com/humhub/app-internal/issues/152#issuecomment-4980575536