### PR TITLE
Fix "Flush cache" deleting assets/.gitignore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ HumHub Changelog
 
 1.19 (TBD)
 ----------
+- Fix: "Flush cache" deleted the `assets/.gitignore` shipped with the installation — `AssetManager::clear()` now skips dot files at the assets mount root, matching the pre-1.19 behavior
 - Fix #8294: Removed a leftover `codecept_debug()` call in `ActiveQueryActivity::mailLimitContentContainer()` — on production installs (without dev dependencies) the function does not exist, so the summary mail job crashed for every user with a space-limited mail summary; a new core test now guards against dev-only function calls in production code
 - Fix #8294: `BaseNotification::html()` still called `getAsHtml()`, which was removed in #7980 — any notification not overriding `html()` (typical for module-provided notifications) crashed on rendering; the obsolete override was removed so the `SocialActivity` default (`null`, the pre-1.19 behaviour) applies again
 - Fix #8294: Likes on top-level content were never deleted when the content was hard-deleted — the `fk_like_content` constraint (`ON DELETE RESTRICT`) then aborted the deletion with an integrity error and the `PurgeDeletedContents` job could never purge liked content; the like module now deletes a content's likes on `ContentActiveRecord::EVENT_BEFORE_DELETE` (matching the comment module)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ HumHub Changelog
 
 1.19 (TBD)
 ----------
-- Fix: "Flush cache" deleted the `assets/.gitignore` shipped with the installation — `AssetManager::clear()` now skips dot files at the assets mount root, matching the pre-1.19 behavior
+- Fix #8302: "Flush cache" deleted the `assets/.gitignore` shipped with the installation — `AssetManager::clear()` now skips dot files at the assets mount root, matching the pre-1.19 behavior
 - Fix #8294: Removed a leftover `codecept_debug()` call in `ActiveQueryActivity::mailLimitContentContainer()` — on production installs (without dev dependencies) the function does not exist, so the summary mail job crashed for every user with a space-limited mail summary; a new core test now guards against dev-only function calls in production code
 - Fix #8294: `BaseNotification::html()` still called `getAsHtml()`, which was removed in #7980 — any notification not overriding `html()` (typical for module-provided notifications) crashed on rendering; the obsolete override was removed so the `SocialActivity` default (`null`, the pre-1.19 behaviour) applies again
 - Fix #8294: Likes on top-level content were never deleted when the content was hard-deleted — the `fk_like_content` constraint (`ON DELETE RESTRICT`) then aborted the deletion with an integrity error and the `PurgeDeletedContents` job could never purge liked content; the like module now deletes a content's likes on `ContentActiveRecord::EVENT_BEFORE_DELETE` (matching the comment module)

--- a/protected/humhub/components/assets/AssetManager.php
+++ b/protected/humhub/components/assets/AssetManager.php
@@ -220,6 +220,11 @@ class AssetManager extends \yii\web\AssetManager
         // on its parent directory - not granted in some setups (e.g. Docker), causing the
         // clear cache action to fail with a "Permission denied" error.
         foreach ($this->fs->listContents('.')->toArray() as $item) {
+            // Keep dot files such as the shipped `assets/.gitignore` - published assets never start with a dot.
+            if (str_starts_with(basename($item->path()), '.')) {
+                continue;
+            }
+
             if ($item->isDir()) {
                 $this->fs->deleteDirectory($item->path());
             } else {

--- a/protected/humhub/tests/codeception/unit/components/assets/AssetManagerClearTest.php
+++ b/protected/humhub/tests/codeception/unit/components/assets/AssetManagerClearTest.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * @link      https://www.humhub.org/
+ * @copyright Copyright (c) 2026 HumHub GmbH & Co. KG
+ * @license   https://www.humhub.com/licences
+ */
+
+namespace humhub\tests\codeception\unit\components\assets;
+
+use tests\codeception\_support\HumHubDbTestCase;
+use Yii;
+
+class AssetManagerClearTest extends HumHubDbTestCase
+{
+    /**
+     * `clear()` must only remove published assets. Dot files at the mount root,
+     * such as the `assets/.gitignore` shipped with the installation, have to
+     * survive a cache flush.
+     */
+    public function testClearRemovesPublishedContentButKeepsDotFiles()
+    {
+        $fs = Yii::$app->fs->getAssetsMount();
+
+        $fs->write('.gitignore', "*\n!.gitignore\n");
+        $fs->write('a1b2c3d4/test.js', 'test');
+
+        Yii::$app->assetManager->clear();
+
+        $this->assertFalse($fs->directoryExists('a1b2c3d4'));
+        $this->assertTrue($fs->fileExists('.gitignore'));
+    }
+}


### PR DESCRIPTION
## What

On 1.19, clicking **Flush Caches** in the administration deleted the `assets/.gitignore` shipped with the installation.

Fixes humhub/humhub-internal#1273

## Why

The Flysystem-based `AssetManager::clear()` removes every entry of the assets mount. The pre-1.19 implementation skipped everything starting with a dot, so `.gitignore` survived. Published assets never start with a dot (hashed directory names, `_/` for asset images), so `clear()` now skips dot files at the mount root again.

## How tested

- New regression test `AssetManagerClearTest` (fails on develop, passes with the fix); all asset unit tests green.
- Manually verified through the admin UI: clicking **Flush Caches** wipes published assets but keeps `assets/.gitignore`, twice in a row.