### PR TITLE
Add public and standalone file flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ HumHub Changelog
 - Enh #8286: Display a success toast when a module is enabled
 - Enh #8300: Update composer package web-token/jwt-library to 4.1.7 (GHSA-3prj-6hqw-cm82, GHSA-jc38-x7x8-2xc8)
 - Fix #8301: Revert missed `MobileAppHelper::registerHideOpenerScript()`
+- Enh #8307: Add `public` and `standalone` file flags for module-managed files (e.g. config images) with explicit access semantics
 
 1.18.3 (May 18, 2026)
 ---------------------

--- a/protected/humhub/modules/file/Events.php
+++ b/protected/humhub/modules/file/Events.php
@@ -48,7 +48,7 @@ class Events extends BaseObject
 
         // Delete unused files
         $deleteTime = time() - (60 * 60 * 24 * 1); // Older than 1 day
-        foreach (File::find()->andWhere(['<', 'created_at', date('Y-m-d', $deleteTime)])->andWhere('(object_model IS NULL or object_model = "")')->all() as $file) {
+        foreach (File::find()->andWhere(['<', 'created_at', date('Y-m-d', $deleteTime)])->andWhere('(object_model IS NULL or object_model = "")')->andWhere(['standalone' => 0])->all() as $file) {
             $file->delete();
         }
 

--- a/protected/humhub/modules/file/actions/DownloadAction.php
+++ b/protected/humhub/modules/file/actions/DownloadAction.php
@@ -132,21 +132,28 @@ class DownloadAction extends Action
             throw new HttpException(404, Yii::t('FileModule.base', 'Could not find requested file!'));
         }
 
-        $user = null;
-        if ($token !== null) {
-            $user = static::getUserByDownloadToken($token, $file);
-        }
+        $user = $token !== null
+            ? static::getUserByDownloadToken($token, $file)
+            : Yii::$app->user->identity;
 
-        // File is not assigned to any database record (yet)
-        if (empty($file->object_model) && (Yii::$app->user->isGuest || $file->created_by != Yii::$app->user->id)) {
-            throw new HttpException(401, Yii::t('FileModule.base', 'Insufficient permissions!'));
-        }
-
-        if (!$file->canView($user)) {
+        if (!$this->checkAccess($file, $user)) {
             throw new HttpException(401, Yii::t('FileModule.base', 'Insufficient permissions!'));
         }
 
         $this->file = $file;
+    }
+
+    /**
+     * Checks if the given user may download the file.
+     *
+     * Modules serving standalone files with custom access rules can subclass
+     * this action and override this method.
+     *
+     * @since 1.18.4
+     */
+    protected function checkAccess(File $file, ?User $user): bool
+    {
+        return $file->canView($user);
     }
 
 

--- a/protected/humhub/modules/file/migrations/m260716_100000_file_add_public_standalone_columns.php
+++ b/protected/humhub/modules/file/migrations/m260716_100000_file_add_public_standalone_columns.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * @link      https://www.humhub.org/
+ * @copyright Copyright (c) 2026 HumHub GmbH & Co. KG
+ * @license   https://www.humhub.com/licences
+ */
+
+use humhub\components\Migration;
+use humhub\modules\file\models\File;
+
+/**
+ * Add `public` and `standalone` flags to the file table
+ */
+class m260716_100000_file_add_public_standalone_columns extends Migration
+{
+    // protected properties
+    protected string $table;
+
+    public function __construct($config = [])
+    {
+        $this->table = File::tableName();
+        parent::__construct($config);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function safeUp()
+    {
+        $this->safeAddColumn(
+            $this->table,
+            'public',
+            $this->boolean()
+                ->defaultValue(false)
+                ->notNull()
+                ->after('state'),
+        );
+
+        $this->safeAddColumn(
+            $this->table,
+            'standalone',
+            $this->boolean()
+                ->defaultValue(false)
+                ->notNull()
+                ->after('public'),
+        );
+    }
+}

--- a/protected/humhub/modules/file/models/File.php
+++ b/protected/humhub/modules/file/models/File.php
@@ -40,6 +40,9 @@ use yii\web\UploadedFile;
  * @property int $id
  * @property string $guid
  * @property int $state
+ * @property int $public whether the file is viewable by everyone, including guests (since 1.18.4)
+ * @property int $standalone whether the file may exist without an attached record; the owning code
+ *      holds the reference (e.g. by file id or guid), keeps it alive and is responsible for deleting it (since 1.18.4)
  * @property int|null $category Note, categories are still experimental. Expect changes in v1.16 (ToDo)
  * @property string $file_name
  * @property string $title
@@ -298,6 +301,16 @@ class File extends FileCompat implements ViewableInterface
      */
     public function canView($user = null): bool
     {
+        if ($this->public) {
+            return true;
+        }
+
+        // File is not attached to any record: only viewable by its creator
+        if (empty($this->object_model)) {
+            $user = UserHelper::getUserByParam($user);
+            return $user !== null && $this->created_by == $user->id;
+        }
+
         $object = $this->getPolymorphicRelation();
 
         if ($object instanceof ViewableInterface) {
@@ -327,6 +340,12 @@ class File extends FileCompat implements ViewableInterface
      */
     public function canDelete($user = null): bool
     {
+        // Standalone files are managed by the code that created them and cannot
+        // be deleted through the generic file API
+        if ($this->standalone) {
+            return false;
+        }
+
         $user = UserHelper::getUserByParam($user);
 
         $object = $this->getPolymorphicRelation();

--- a/protected/humhub/modules/file/tests/codeception/unit/FileAccessTest.php
+++ b/protected/humhub/modules/file/tests/codeception/unit/FileAccessTest.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * @link https://www.humhub.org/
+ * @copyright Copyright (c) 2026 HumHub GmbH & Co. KG
+ * @license https://www.humhub.com/licences
+ */
+
+namespace tests\codeception\unit\modules\file;
+
+use humhub\modules\content\models\Content;
+use humhub\modules\file\Events;
+use humhub\modules\file\models\File;
+use humhub\modules\post\models\Post;
+use humhub\modules\space\models\Space;
+use humhub\modules\user\models\User;
+use tests\codeception\_support\HumHubDbTestCase;
+use yii\base\Event;
+use yii\helpers\Console;
+
+class FileAccessTest extends HumHubDbTestCase
+{
+    public function testUnassignedFileIsOnlyViewableByCreator()
+    {
+        $file = $this->createFile(['created_by' => 2]);
+
+        $this->assertTrue($file->canView(User::findOne(2)));
+        $this->assertFalse($file->canView(User::findOne(3)));
+        $this->assertFalse($file->canView());
+    }
+
+    public function testPublicFileIsViewableByEveryone()
+    {
+        $file = $this->createFile(['created_by' => 2, 'public' => 1]);
+
+        $this->assertTrue($file->canView(User::findOne(2)));
+        $this->assertTrue($file->canView(User::findOne(3)));
+        $this->assertTrue($file->canView());
+    }
+
+    public function testPublicFlagOverridesObjectPermissions()
+    {
+        self::becomeUser('Admin');
+
+        $post = new Post(Space::findOne(5), Content::VISIBILITY_PRIVATE, ['message' => 'Private space post']);
+        $this->assertTrue($post->save());
+
+        $file = $this->createFile();
+        $post->fileManager->attach($file);
+        $file->refresh();
+
+        self::logout();
+
+        // User2 is no member of the private Space 5
+        $this->assertFalse($file->canView(User::findOne(3)));
+
+        $file->updateAttributes(['public' => 1]);
+        $this->assertTrue($file->canView(User::findOne(3)));
+    }
+
+    public function testStandaloneFileCannotBeDeletedViaGenericApi()
+    {
+        $file = $this->createFile(['created_by' => 2, 'standalone' => 1, 'public' => 1]);
+
+        $this->assertFalse($file->canDelete(User::findOne(2)));
+        $this->assertFalse($file->canDelete(User::findOne(1)));
+    }
+
+    public function testUnassignedFileCanBeDeleted()
+    {
+        $file = $this->createFile(['created_by' => 2]);
+
+        $this->assertTrue($file->canDelete(User::findOne(2)));
+    }
+
+    public function testCronCleanupKeepsStandaloneFiles()
+    {
+        $standalone = $this->createFile(['standalone' => 1]);
+        $unassigned = $this->createFile();
+
+        $outdated = date('Y-m-d H:i:s', time() - 60 * 60 * 24 * 3);
+        $standalone->updateAttributes(['created_at' => $outdated]);
+        $unassigned->updateAttributes(['created_at' => $outdated]);
+
+        Events::onCronDailyRun(new Event(['sender' => new class {
+            public function stdout($string, ...$args)
+            {
+            }
+        }]));
+
+        $this->assertNotNull(File::findOne(['id' => $standalone->id]));
+        $this->assertNull(File::findOne(['id' => $unassigned->id]));
+    }
+
+    private function createFile(array $attributes = []): File
+    {
+        $file = new File();
+        $file->file_name = 'test.txt';
+        $this->assertTrue($file->save());
+
+        if ($attributes !== []) {
+            $file->updateAttributes($attributes);
+        }
+
+        return $file;
+    }
+}


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Enhancement

**The PR fulfills these requirements:**

- [x] All tests are passing
- [x] Changelog was modified

**Other information:**

Introduces two flags on the `file` record for files that are module configuration rather than user content (e.g. default cover images):

- `public` — viewable by everyone including guests; an explicit declaration that wins over record-based access rules
- `standalone` — may exist without an attached record; the owning code holds the reference, the daily cleanup cron skips it, and `file/file/delete` refuses it (deleting is the owning module's job)

Additionally:
- Unassigned files are now only viewable by their creator. This was previously only enforced inline in `DownloadAction` and did not apply to token-based (e-mail) downloads — the token fix from #8306 is included here.
- The access decision is centralized in `File::canView()`; `DownloadAction` delegates via an overridable `checkAccess()` hook so modules can serve standalone files with custom access rules without rebuilding variant/caching/delivery handling.

Alternative to the `Setting`-linking approach of #8306, see humhub/humhub-internal#1275.