### PR TITLE
Fix TypeError for activities on global content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ HumHub Changelog
 
 1.19 (TBD)
 ----------
+- Fix #8308: Activities on global content (content without a container) crashed with a `TypeError` — e.g. commenting on a global content was impossible; `BaseActivity::$contentContainer` is now nullable, matching the nullable `activity.contentcontainer_id` column, and the activity layouts handle the missing container (regression from #7933)
 - Fix #8303: Pinned `npm-asset/intl-messageformat` (11.1.2) and `npm-asset/socket.io-client` (2.5.0) — the newer mirror packages ship an "iife" file that is actually an ES module (its top-level `export` broke the combined `humhub-app.js` entirely) resp. no longer contain the `dist/` files referenced by `SocketIoAsset`
 - Fix #8302: "Flush cache" deleted the `assets/.gitignore` shipped with the installation — `AssetManager::clear()` now skips dot files at the assets mount root, matching the pre-1.19 behavior
 - Fix #8294: Removed a leftover `codecept_debug()` call in `ActiveQueryActivity::mailLimitContentContainer()` — on production installs (without dev dependencies) the function does not exist, so the summary mail job crashed for every user with a space-limited mail summary; a new core test now guards against dev-only function calls in production code

--- a/protected/humhub/modules/activity/components/BaseActivity.php
+++ b/protected/humhub/modules/activity/components/BaseActivity.php
@@ -16,7 +16,7 @@ use yii\base\BaseObject;
 abstract class BaseActivity extends BaseObject
 {
     public readonly ActivityRecord $record;
-    public readonly ContentContainer $contentContainer;
+    public readonly ?ContentContainer $contentContainer;
     public readonly User $user;
     public readonly string $createdAt;
     public readonly int $groupCount;
@@ -57,7 +57,7 @@ abstract class BaseActivity extends BaseObject
 
     public function getUrl(bool $scheme = true): ?string
     {
-        return $this->contentContainer->polymorphicRelation->getUrl($scheme);
+        return $this->contentContainer?->polymorphicRelation?->getUrl($scheme);
     }
 
     protected function getMessageParamsMailText(): array

--- a/protected/humhub/modules/activity/models/Activity.php
+++ b/protected/humhub/modules/activity/models/Activity.php
@@ -14,15 +14,15 @@ use yii\db\ActiveQuery;
  *
  * @property int $id
  * @property string $class
- * @property int $contentcontainer_id
+ * @property int|null $contentcontainer_id
  * @property int $content_id
  * @property int $content_addon_record_id
  * @property string $grouping_key
  * @property int $created_by
  * @property string $created_at
  *
- * @property-read Content $content
- * @property-read ContentContainer $contentContainer
+ * @property-read Content|null $content
+ * @property-read ContentContainer|null $contentContainer
  */
 class Activity extends \humhub\components\ActiveRecord
 {

--- a/protected/humhub/modules/activity/tests/codeception/unit/ActivityTest.php
+++ b/protected/humhub/modules/activity/tests/codeception/unit/ActivityTest.php
@@ -5,7 +5,10 @@ namespace humhub\modules\activity\tests\codeception\unit;
 use Codeception\Specify;
 use humhub\modules\activity\models\Activity;
 use humhub\modules\activity\services\ActivityManager;
+use humhub\modules\activity\services\RenderService;
 use humhub\modules\activity\tests\codeception\activities\TestActivity;
+use humhub\modules\comment\activities\NewCommentActivity;
+use humhub\modules\comment\models\Comment;
 use humhub\modules\post\models\Post;
 use tests\codeception\_support\HumHubDbTestCase;
 use Yii;
@@ -30,6 +33,34 @@ class ActivityTest extends HumHubDbTestCase
         $this->assertEquals(TestActivity::class, $testActivity::class);
         $this->assertEquals($record->content->polymorphicRelation->id, $post->id);
         $this->assertEquals($record->contentcontainer_id, $post->content->contentcontainer_id);
+    }
+
+    public function testCreateActivityOnGlobalContent()
+    {
+        $this->becomeUser('User2');
+
+        $post = new Post(['message' => 'Global content']);
+        $this->assertTrue($post->save());
+        $this->assertNull($post->content->contentcontainer_id);
+
+        // Commenting on global content dispatches NewCommentActivity without a container
+        $comment = new Comment([
+            'message' => 'Comment on global content',
+            'content_id' => $post->content->id,
+        ]);
+        $this->assertTrue($comment->save());
+
+        $record = Activity::findOne(['class' => NewCommentActivity::class]);
+        $this->assertNotNull($record, 'Activity record persisted');
+        $this->assertNull($record->contentcontainer_id);
+
+        $activity = ActivityManager::load($record);
+        $this->assertNull($activity->contentContainer);
+
+        $renderService = new RenderService($record);
+        $this->assertNotEmpty($renderService->getWeb());
+        $this->assertNotEmpty($renderService->getMailText());
+        $this->assertNotEmpty($renderService->getMailHtml());
     }
 
     public function testDeleteRecord()

--- a/protected/humhub/modules/activity/views/layouts/mail.php
+++ b/protected/humhub/modules/activity/views/layouts/mail.php
@@ -77,7 +77,7 @@ use humhub\helpers\MailStyleHelper;
                                                                         <?= $message ?>
 
                                                                         <!-- check if activity object has a space -->
-                                                                        <?php if ($contentContainer->polymorphicRelation instanceof Space): ?>
+                                                                        <?php if ($contentContainer?->polymorphicRelation instanceof Space): ?>
                                                                             <?= Html::a(
                                                                                 $contentContainer->polymorphicRelation->displayName,
                                                                                 $contentContainer->polymorphicRelation->createUrl(null, [], true),

--- a/protected/humhub/modules/activity/views/layouts/mail_plaintext.php
+++ b/protected/humhub/modules/activity/views/layouts/mail_plaintext.php
@@ -16,7 +16,7 @@ use humhub\modules\space\models\Space;
 ---
 
 <?= $message ?>
-<?php if ($contentContainer->polymorphicRelation instanceof Space) : ?>
+<?php if ($contentContainer?->polymorphicRelation instanceof Space) : ?>
     (<?= Yii::t('ActivityModule.base', 'via') ?> <?= $contentContainer->polymorphicRelation->displayName ?>)
 <?php endif; ?>
 

--- a/protected/humhub/modules/activity/views/layouts/web.php
+++ b/protected/humhub/modules/activity/views/layouts/web.php
@@ -25,7 +25,7 @@ use yii\helpers\Url;
             <?= $user->getProfileImage()->render(32, ['link' => false]) ?>
 
             <!-- Show space image, if you are outside from a space -->
-            <?php if (!Yii::$app->controller instanceof ContentContainerController && $contentContainer->polymorphicRelation instanceof Space) : ?>
+            <?php if (!Yii::$app->controller instanceof ContentContainerController && $contentContainer?->polymorphicRelation instanceof Space) : ?>
                 <?= Image::widget([
                     'space' => $contentContainer->polymorphicRelation,
                     'width' => 20,

--- a/protected/humhub/modules/content/activities/ContentCreatedActivity.php
+++ b/protected/humhub/modules/content/activities/ContentCreatedActivity.php
@@ -68,7 +68,7 @@ final class ContentCreatedActivity extends BaseContentActivity implements Config
     {
         return Activity::find()
             ->andWhere(['activity.class' => self::class])
-            ->andWhere(['activity.contentcontainer_id' => $this->contentContainer->id])
+            ->andWhere(['activity.contentcontainer_id' => $this->contentContainer?->id])
             ->andWhere(['activity.created_by' => $this->user->id])
             ->andWhere(['content.object_model' => $this->record->content->object_model])
             ->andWhere(['content.visibility' => $this->record->content->visibility])

--- a/protected/humhub/modules/space/components/BaseSpaceActivity.php
+++ b/protected/humhub/modules/space/components/BaseSpaceActivity.php
@@ -18,7 +18,7 @@ abstract class BaseSpaceActivity extends BaseActivity
     {
         parent::__construct($record, $config);
 
-        if (!$record->contentContainer->polymorphicRelation instanceof Space) {
+        if (!$record->contentContainer?->polymorphicRelation instanceof Space) {
             throw new InvalidValueException('Space activity content container must implement space');
         }
 

--- a/protected/humhub/modules/user/activities/FollowActivity.php
+++ b/protected/humhub/modules/user/activities/FollowActivity.php
@@ -19,7 +19,7 @@ final class FollowActivity extends BaseActivity implements ConfigurableActivityI
     {
         parent::__construct($record, $config);
 
-        if (!$this->contentContainer->polymorphicRelation instanceof User) {
+        if (!$this->contentContainer?->polymorphicRelation instanceof User) {
             throw new InvalidValueException('Invalid user record!');
         }
 


### PR DESCRIPTION
## What

Activities on global content (content without a container) crashed with

```
TypeError: Cannot assign null to property humhub\modules\activity\components\BaseActivity::$contentContainer of type humhub\modules\content\models\ContentContainer
```

e.g. commenting on a global content was impossible (see humhub/humhub-internal#1278). Regression from the activity refactoring #7933.

## Why

`content.contentcontainer_id` — and therefore `activity.contentcontainer_id` (nullable by migration) — is `null` for global content, but the new readonly property was typed non-nullable.

## How

- `BaseActivity::$contentContainer` is now `?ContentContainer`, `getUrl()` is null-safe
- `ContentCreatedActivity::getGroupingQuery()` uses `$this->contentContainer?->id` (Yii turns `null` into `IS NULL`, so global contents group among themselves)
- The activity layouts (`web.php`, `mail.php`, `mail_plaintext.php`) handle a missing container
- `BaseSpaceActivity`/`FollowActivity` no longer dereference the container before their guard — a missing container now raises the intended `InvalidValueException` instead of a fatal (`MemberAdded`/`MemberRemovedActivity` stay unchanged, their base class guard guarantees the container)
- Regression test: `ActivityTest::testCreateActivityOnGlobalContent` creates a global post, comments on it (the exact path from the report) and renders the activity as web, mail text and mail HTML

No module impact: no external module uses the new readonly property yet (all module activity classes are still on the 1.18 `SocialActivity` API).