### PR TITLE
Fix ActiveFileUpload remove button for standalone files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ HumHub Changelog
 - Enh #8300: Update composer package web-token/jwt-library to 4.1.7 (GHSA-3prj-6hqw-cm82, GHSA-jc38-x7x8-2xc8)
 - Fix #8301: Revert missed `MobileAppHelper::registerHideOpenerScript()`
 - Enh #8307: Add `public` and `standalone` file flags for module-managed files (e.g. config images) with explicit access semantics
+- Fix #8324: Fix `ActiveFileUpload` remove button for standalone files (new `standalone` widget option)
 
 1.18.3 (May 18, 2026)
 ---------------------

--- a/protected/humhub/modules/file/resources/js/humhub.ActiveFileUpload.js
+++ b/protected/humhub/modules/file/resources/js/humhub.ActiveFileUpload.js
@@ -39,6 +39,16 @@ humhub.module('ActiveFileUpload', function (module, require, $) {
     Upload.prototype.delete = function (event) {
         event.preventDefault()
 
+        if (this.options.standalone) {
+            // Standalone files are refused by the generic file/delete endpoint —
+            // only clear the input, the owning form deletes the record on submit.
+            const name = this.uploadWidget.options.uploadSubmitName || 'fileList[]';
+            this.uploadWidget.$form.find('input[name="' + name + '"]').val('');
+            this.$.find('.img-uploader-remove').hide();
+            this.previewWidget.reset();
+            return;
+        }
+
         this.uploadWidget.delete({guid: this.previewWidget.$.find('.file-preview-item').first().attr('data-guid')});
         this.previewWidget.reset();
     };

--- a/protected/humhub/modules/file/widgets/ActiveFileUpload.php
+++ b/protected/humhub/modules/file/widgets/ActiveFileUpload.php
@@ -36,6 +36,16 @@ class ActiveFileUpload extends InputWidget
 {
     public string $accept = '*';
     public bool $hideInStream = true;
+
+    /**
+     * Whether the managed file is a standalone file owned by the form's model (see File::$standalone).
+     * The generic file delete endpoint refuses standalone files, so the remove button only clears
+     * the input — deleting the old file record is up to the owning form on submit.
+     *
+     * @since 1.18.4
+     */
+    public bool $standalone = false;
+
     public array $inputOptions = [];
     public array $previewOptions = [];
     public array $progressOptions = [];
@@ -52,6 +62,9 @@ class ActiveFileUpload extends InputWidget
             'ui-widget' => 'ActiveFileUpload.Upload',
             'ui-init' => true,
         ];
+        if ($this->standalone) {
+            $this->field->options['data']['standalone'] = 1;
+        }
         $this->field->template = '{label}{hint}{input}{error}';
 
         $previewHeight = ArrayHelper::remove($this->previewOptions, 'height');


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

**The PR fulfills these requirements:**

- [x] Changelog was modified

**Other information:**

Follow-up to #8307, see humhub/humhub-internal#1275.

The remove button of `ActiveFileUpload` posts to the generic `file/delete` endpoint. Since #8307 that endpoint refuses standalone files (`File::canDelete()` returns `false`), so removing an already saved module-managed image (e.g. the News default cover) fails with "Insufficient permissions!".

This adds a `standalone` option to `ActiveFileUpload`:

```php
<?= $form->field($settings, 'coverImageGuid')->widget(ActiveFileUpload::class, [
    'accept' => 'image/*',
    'standalone' => true,
]) ?>
```

With the option set, the remove button only clears the input client-side — the actual deletion of the old file record is up to the owning form on submit (which is the whole point of the standalone concept: file operations go through the owner, so the stored reference and the file record cannot get out of sync). Removal therefore also becomes transactional with the form: pressing ✕ and leaving without saving no longer destroys the file.

Freshly uploaded but never submitted files stay unassigned and are removed by the existing daily cleanup cron, like any abandoned form upload.

Used by humhub/news#151.