### PR TITLE
Fix rendering of comments from blocked authors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ HumHub Changelog
 
 1.19 (TBD)
 ----------
+- Fix #8325: Rendering a comment written by a blocked author crashed the whole wall entry — the blocked-comment fallback still read the dropped `object_model`/`object_id` columns and the removed `user` relation (regression from #7917)
 - Enh #8321: Add the `UnreadCountChangedEvent`, triggered whenever a user's unseen notification count changes or by modules such as Messenger
 - Fix: JS console warning `Required a non initialized module: i18n` on every full page load — `humhub.i18n.js` was registered last in `CoreApiAsset`, after core modules (`ui.additions`, `action`, `ui.widget`, `client`, `ui.modal`, ...) that `require('i18n')` at definition time, so the first of them created an empty namespace stub; it is now loaded directly after `humhub.core.js` (regression from #8078)
 - Fix #8322: On iOS (Safari & Chrome), programmatically focusing a field (e.g. opening a comment reply form) only showed the keyboard without scrolling the field into view until the first keystroke — a just-focused input, textarea or richtext editor that ends up hidden behind the keyboard is now scrolled into view once the keyboard has settled, network-wide

--- a/protected/humhub/modules/comment/tests/codeception/unit/CommentWidgetTest.php
+++ b/protected/humhub/modules/comment/tests/codeception/unit/CommentWidgetTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace tests\codeception\unit\modules\comment;
+
+use humhub\modules\comment\models\Comment;
+use humhub\modules\comment\widgets\Comment as CommentWidget;
+use tests\codeception\_support\HumHubDbTestCase;
+use Yii;
+
+class CommentWidgetTest extends HumHubDbTestCase
+{
+    public function testRenderCommentOfBlockedAuthor()
+    {
+        $this->becomeUser('User1');
+        ($comment = new Comment(['message' => 'Message of blocked author', 'content_id' => 11]))->save();
+
+        $this->becomeUser('User2');
+        $comment->createdBy->blockForUser(Yii::$app->user->getIdentity());
+
+        $html = CommentWidget::widget(['comment' => $comment]);
+
+        $this->assertStringContainsString('comment-blocked-user', $html);
+        $this->assertStringNotContainsString('Message of blocked author', $html);
+    }
+}

--- a/protected/humhub/modules/comment/widgets/Comment.php
+++ b/protected/humhub/modules/comment/widgets/Comment.php
@@ -59,8 +59,6 @@ class Comment extends Widget
     private function renderBlockedComment(): string
     {
         $loadBlockedCommentUrl = Url::to(['/comment/comment/load',
-            'objectModel' => $this->comment->object_model,
-            'objectId' => $this->comment->object_id,
             'id' => $this->comment->id,
             'showBlocked' => true,
         ]);

--- a/protected/humhub/modules/comment/widgets/views/commentBlockedUser.php
+++ b/protected/humhub/modules/comment/widgets/views/commentBlockedUser.php
@@ -19,7 +19,7 @@ use humhub\widgets\bootstrap\Link;
      data-action-component="comment.Comment">
 
     <div class="flex-shrink-0 me-2">
-        <?= UserImage::widget(['user' => $comment->user, 'width' => 25, 'htmlOptions' => ['data-contentcontainer-id' => $comment->user->contentcontainer_id]]); ?>
+        <?= UserImage::widget(['user' => $comment->createdBy, 'width' => 25, 'htmlOptions' => ['data-contentcontainer-id' => $comment->createdBy->contentcontainer_id]]); ?>
     </div>
 
     <div class="flex-grow-1 overflow-hidden">


### PR DESCRIPTION
## What

Rendering a comment written by an author the viewing user has blocked crashed with an `UnknownPropertyException`, taking down the whole wall entry (500).

Two leftovers from the comment FK migration (#7917):

- `Comment` widget (`renderBlockedComment()`) still built the *Show* link with the dropped `object_model` / `object_id` columns — `CommentController::actionLoad()` resolves the comment via `id` only, so the parameters were dead anyway.
- The `commentBlockedUser` view still used the removed `user` relation instead of `createdBy`.

## How

- Build the load URL with `id` + `showBlocked` only.
- Use `$comment->createdBy` in the view.

## Test

- New `CommentWidgetTest::testRenderCommentOfBlockedAuthor` — reproduced both crashes before the fix (`UnknownPropertyException: object_model`, then `::user`), now asserts the blocked-comment placeholder is rendered and the message is hidden.

Part of the 1.19 before-stable items from the release assessment (P1).