### PR TITLE
Handle orphaned content when hard deleting user content and purging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ HumHub Changelog
 
 1.19 (TBD)
 ----------
+- Fix #8326: Deleting a user or running the `PurgeDeletedContents` job crashed with a fatal error when hitting a content entry whose underlying record no longer exists — orphaned entries are now removed directly, matching the integrity check (#8312)
 - Enh #8321: Add the `UnreadCountChangedEvent`, triggered whenever a user's unseen notification count changes or by modules such as Messenger
 - Fix: JS console warning `Required a non initialized module: i18n` on every full page load — `humhub.i18n.js` was registered last in `CoreApiAsset`, after core modules (`ui.additions`, `action`, `ui.widget`, `client`, `ui.modal`, ...) that `require('i18n')` at definition time, so the first of them created an empty namespace stub; it is now loaded directly after `humhub.core.js` (regression from #8078)
 - Fix #8322: On iOS (Safari & Chrome), programmatically focusing a field (e.g. opening a comment reply form) only showed the keyboard without scrolling the field into view until the first keystroke — a just-focused input, textarea or richtext editor that ends up hidden behind the keyboard is now scrolled into view once the keyboard has settled, network-wide

--- a/protected/humhub/modules/content/Events.php
+++ b/protected/humhub/modules/content/Events.php
@@ -41,7 +41,8 @@ class Events extends BaseObject
 
         // Delete user profile content on soft delete
         foreach (Content::findAll(['contentcontainer_id' => $event->user->contentcontainer_id]) as $content) {
-            $content->getPolymorphicRelation()->hardDelete();
+            $record = $content->getPolymorphicRelation();
+            $record === null ? $content->hardDeleteInternal() : $record->hardDelete();
         }
     }
 
@@ -54,7 +55,8 @@ class Events extends BaseObject
     {
         $user = $event->sender;
         foreach (Content::findAll(['created_by' => $user->id]) as $content) {
-            $content->getPolymorphicRelation()->hardDelete();
+            $record = $content->getPolymorphicRelation();
+            $record === null ? $content->hardDeleteInternal() : $record->hardDelete();
         }
     }
 

--- a/protected/humhub/modules/content/jobs/PurgeDeletedContents.php
+++ b/protected/humhub/modules/content/jobs/PurgeDeletedContents.php
@@ -20,7 +20,8 @@ class PurgeDeletedContents extends LongRunningActiveJob
     public function run()
     {
         foreach (Content::findAll(['content.state' => Content::STATE_DELETED]) as $content) {
-            if (!$content->getPolymorphicRelation()->hardDelete()) {
+            $record = $content->getPolymorphicRelation();
+            if (!($record === null ? $content->hardDeleteInternal() : $record->hardDelete())) {
                 Yii::error('Purge deleted contents job: Unable to delete content ID ' . $content->id . '. Error: ' . implode(' ', $content->getErrorSummary(true)), 'content');
             }
         }

--- a/protected/humhub/modules/content/tests/codeception/unit/OrphanedContentDeletionTest.php
+++ b/protected/humhub/modules/content/tests/codeception/unit/OrphanedContentDeletionTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace tests\codeception\unit\modules\content;
+
+use humhub\modules\content\Events;
+use humhub\modules\content\jobs\PurgeDeletedContents;
+use humhub\modules\content\models\Content;
+use humhub\modules\post\models\Post;
+use humhub\modules\space\models\Space;
+use humhub\modules\user\events\UserEvent;
+use tests\codeception\_support\HumHubDbTestCase;
+use Yii;
+use yii\base\Event;
+
+class OrphanedContentDeletionTest extends HumHubDbTestCase
+{
+    public function testPurgeDeletedContentsHandlesOrphanedContent()
+    {
+        $content = $this->createOrphanedContent();
+        $content->updateAttributes(['state' => Content::STATE_DELETED]);
+
+        (new PurgeDeletedContents())->run();
+
+        $this->assertNull(Content::findOne(['id' => $content->id]));
+    }
+
+    public function testUserDeleteHandlesOrphanedContent()
+    {
+        $content = $this->createOrphanedContent();
+
+        Events::onUserDelete(new Event(['sender' => Yii::$app->user->getIdentity()]));
+
+        $this->assertNull(Content::findOne(['id' => $content->id]));
+    }
+
+    public function testUserSoftDeleteHandlesOrphanedContent()
+    {
+        $content = $this->createOrphanedContent(true);
+
+        Events::onUserSoftDelete(new UserEvent(['user' => Yii::$app->user->getIdentity()]));
+
+        $this->assertNull(Content::findOne(['id' => $content->id]));
+    }
+
+    private function createOrphanedContent(bool $onOwnProfile = false): Content
+    {
+        $this->becomeUser('User2');
+
+        $post = new Post(['message' => 'Orphaned content test post']);
+        $post->content->setContainer($onOwnProfile ? Yii::$app->user->getIdentity() : Space::findOne(['id' => 2]));
+        $post->save();
+
+        // Simulate an inconsistent state: the underlying record is gone
+        // while its content entry was left behind
+        Post::deleteAll(['id' => $post->id]);
+
+        return Content::findOne(['id' => $post->content->id]);
+    }
+}


### PR DESCRIPTION
## What

`Events::onUserSoftDelete()`, `Events::onUserDelete()` and the `PurgeDeletedContents` job called `$content->getPolymorphicRelation()->hardDelete()` unguarded. On a content entry whose underlying record no longer exists (inconsistent/orphaned data that 1.18 handled null-safely) this fatals with `Call to a member function hardDelete() on null` — aborting user deletion or the whole purge cron run.

## How

When the polymorphic relation resolves to `null`, the orphaned content entry is now removed directly via `Content::hardDeleteInternal()` — the same approach the integrity check uses since #8312 (which fixed the fourth affected call site).

## Test

New `OrphanedContentDeletionTest` covering all three call sites — each reproduced the fatal before the fix and now asserts the orphaned content entry is cleaned up.

Part of the 1.19 before-stable items from the release assessment (P1).