### PR TITLE
Delete orphaned comments before adding RESTRICT foreign keys in the content_id migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ HumHub Changelog
 
 1.19 (TBD)
 ----------
+- Fix #8327: The 1.19 upgrade aborted with a foreign key violation in the comment `content_id` migration when the database contained a reply whose parent comment (or a comment whose content) was already gone — such orphaned comments are now deleted before the RESTRICT foreign keys are created
 - Enh #8321: Add the `UnreadCountChangedEvent`, triggered whenever a user's unseen notification count changes or by modules such as Messenger
 - Fix: JS console warning `Required a non initialized module: i18n` on every full page load — `humhub.i18n.js` was registered last in `CoreApiAsset`, after core modules (`ui.additions`, `action`, `ui.widget`, `client`, `ui.modal`, ...) that `require('i18n')` at definition time, so the first of them created an empty namespace stub; it is now loaded directly after `humhub.core.js` (regression from #8078)
 - Fix #8322: On iOS (Safari & Chrome), programmatically focusing a field (e.g. opening a comment reply form) only showed the keyboard without scrolling the field into view until the first keystroke — a just-focused input, textarea or richtext editor that ends up hidden behind the keyboard is now scrolled into view once the keyboard has settled, network-wide

--- a/protected/humhub/modules/comment/migrations/m251230_140508_content_id.php
+++ b/protected/humhub/modules/comment/migrations/m251230_140508_content_id.php
@@ -37,6 +37,13 @@ class m251230_140508_content_id extends Migration
          WHERE comment.parent_comment_id IS NOT NULL AND comment.content_id IS NULL AND parent.id IS NOT NULL',
         );
 
+        // Comments that could not be linked above — the commented content or
+        // the parent comment was already gone — would abort the RESTRICT
+        // foreign key creation below, so delete these orphaned records
+        $orphaned = $this->db->createCommand('DELETE FROM `comment` WHERE `content_id` IS NULL')->execute();
+        if ($orphaned > 0) {
+            echo "    > deleted $orphaned orphaned comment records without an existing content or parent comment\n";
+        }
 
         $this->safeAddForeignKey('fk_comment_content', 'comment', 'content_id', 'content', 'id', 'RESTRICT', 'CASCADE');
         $this->safeAddForeignKey(


### PR DESCRIPTION
## What

`m251230_140508_content_id` adds `fk_comment_comment` (RESTRICT) without first cleaning up rows that could not be linked during the backfill. On a database containing a reply whose parent comment was already hard-deleted (or a comment whose content row is gone — both possible states in ≤1.18 data), `ADD FOREIGN KEY` fails with error 1452 and **the whole 1.19 upgrade aborts**.

## How

After the backfill UPDATEs, comments with `content_id IS NULL` are exactly the unlinkable orphans (direct comments on vanished content, replies to vanished parents, and replies inheriting `NULL` from an orphaned parent). They are now deleted before the foreign keys are created, with an echo of the affected row count — same policy as the activity restructure migration uses for unresolvable orphans.

The migration stays restartable: an upgrade that already aborted on `fk_comment_comment` resumes cleanly on re-run (guarded column/FK helpers, idempotent UPDATEs and DELETE).

## Verification

Reproduced against a scratch database with the pre-1.19 schema and seeded orphans (dangling reply + comment on missing content), replaying the migration statements in order:

- without the guard: `ERROR 1452 ... CONSTRAINT fk_comment_comment` — upgrade aborts
- with the guard: migration completes; the valid comment and its valid reply survive correctly linked, both orphans are removed

(No Codeception test — the test database has this migration already applied, so the pre-migration schema cannot be exercised there.)

Part of the 1.19 before-stable items from the release assessment (P1).