### PR TITLE
Restore database-level like uniqueness for content likes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ HumHub Changelog
 
 1.19 (TBD)
 ----------
+- Fix #8328: Duplicate likes on the same content were possible via concurrent requests — the unique index contained the nullable `content_addon_record_id` and therefore never applied to likes on the content itself; uniqueness is now enforced via a generated key column
 - Enh #8321: Add the `UnreadCountChangedEvent`, triggered whenever a user's unseen notification count changes or by modules such as Messenger
 - Fix: JS console warning `Required a non initialized module: i18n` on every full page load — `humhub.i18n.js` was registered last in `CoreApiAsset`, after core modules (`ui.additions`, `action`, `ui.widget`, `client`, `ui.modal`, ...) that `require('i18n')` at definition time, so the first of them created an empty namespace stub; it is now loaded directly after `humhub.core.js` (regression from #8078)
 - Fix #8322: On iOS (Safari & Chrome), programmatically focusing a field (e.g. opening a comment reply form) only showed the keyboard without scrolling the field into view until the first keystroke — a just-focused input, textarea or richtext editor that ends up hidden behind the keyboard is now scrolled into view once the keyboard has settled, network-wide

--- a/protected/humhub/modules/like/migrations/m260720_120000_like_unique_index.php
+++ b/protected/humhub/modules/like/migrations/m260720_120000_like_unique_index.php
@@ -1,0 +1,52 @@
+<?php
+
+use humhub\components\Migration;
+
+class m260720_120000_like_unique_index extends Migration
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function safeUp()
+    {
+        // idx_unique_user contains the nullable content_addon_record_id, so it
+        // never applied to likes on the content itself (NULL values are distinct
+        // in unique indexes). Enforce uniqueness over a generated column that
+        // maps NULL to 0 instead.
+
+        // Remove duplicate content likes created while the index did not apply
+        $this->execute(
+            'DELETE l1 FROM `like` l1
+                 JOIN `like` l2 ON l1.content_id = l2.content_id AND l1.created_by = l2.created_by AND l1.id > l2.id
+             WHERE l1.content_addon_record_id IS NULL AND l2.content_addon_record_id IS NULL',
+        );
+
+        if (!$this->columnExists('content_addon_record_key', 'like')) {
+            // A generated column cannot be based on a column with an
+            // ON UPDATE CASCADE foreign key; record_map ids never change, so the
+            // foreign key is re-created with ON UPDATE RESTRICT below
+            $this->safeDropForeignKey('fk_like_content_addon', 'like');
+
+            // MariaDB (min version 10.1) only knows PERSISTENT, MySQL only STORED
+            $keyword = stripos($this->db->getServerVersion(), 'mariadb') !== false ? 'PERSISTENT' : 'STORED';
+            $this->execute(
+                'ALTER TABLE `like` ADD COLUMN `content_addon_record_key` INT GENERATED ALWAYS AS (IFNULL(`content_addon_record_id`, 0)) ' . $keyword,
+            );
+        }
+
+        $this->safeAddForeignKey('fk_like_content_addon', 'like', 'content_addon_record_id', 'record_map', 'id', 'CASCADE', 'RESTRICT');
+
+        $this->safeCreateIndex('idx_unique_like', 'like', ['content_id', 'content_addon_record_key', 'created_by'], true);
+        $this->safeDropIndex('idx_unique_user', 'like');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function safeDown()
+    {
+        echo "m260720_120000_like_unique_index cannot be reverted.\n";
+
+        return false;
+    }
+}

--- a/protected/humhub/modules/like/tests/codeception/unit/LikeUniquenessTest.php
+++ b/protected/humhub/modules/like/tests/codeception/unit/LikeUniquenessTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace tests\codeception\unit\modules\like;
+
+use humhub\modules\like\models\Like;
+use humhub\modules\like\services\LikeService;
+use humhub\modules\post\models\Post;
+use tests\codeception\_support\HumHubDbTestCase;
+use yii\db\Expression;
+use yii\db\IntegrityException;
+
+class LikeUniquenessTest extends HumHubDbTestCase
+{
+    public function testDuplicateContentLikeIsRejectedByDatabase()
+    {
+        $this->becomeUser('User2');
+
+        $post = Post::findOne(['id' => 1]);
+        $this->assertTrue((new LikeService($post))->like());
+
+        $duplicate = new Like([
+            'content_id' => $post->content->id,
+            'content_addon_record_id' => new Expression('NULL'),
+        ]);
+
+        $this->expectException(IntegrityException::class);
+        $duplicate->save(false);
+    }
+}


### PR DESCRIPTION
## What

`idx_unique_user` (`content_id`, `content_addon_record_id`, `created_by`) contains the nullable `content_addon_record_id` — and NULL values are distinct in MySQL/MariaDB unique indexes. Likes on the content itself always store `NULL` there, so the database never enforced one-like-per-user for them: concurrent double-clicks / parallel requests could create duplicate likes (1.18 enforced this via the old `unique-object-user` index).

## How

New `like` migration that

- deduplicates existing content likes (keeps the oldest row),
- adds a generated column `content_addon_record_key` = `IFNULL(content_addon_record_id, 0)` — `PERSISTENT` on MariaDB (min version 10.1 does not know `STORED`), `STORED` on MySQL,
- creates `idx_unique_like` (`content_id`, `content_addon_record_key`, `created_by`) and drops `idx_unique_user`.

Because MariaDB/MySQL refuse a generated column based on a column carrying an `ON UPDATE CASCADE` foreign key (error 1901), `fk_like_content_addon` is re-created with `ON UPDATE RESTRICT` — no behavioural change, `record_map` ids are never updated. `ON DELETE CASCADE` stays as is (verified: deleting a `record_map` row still cascades).

An addon like and a content like of the same user on the same content still coexist (`0` vs. the record-map id in the key column).

## Test

- New `LikeUniquenessTest::testDuplicateContentLikeIsRejectedByDatabase` — inserted a duplicate content like without error before the migration, now fails with an `IntegrityException` on `idx_unique_like`.
- Migration sequence additionally replayed on a scratch database (dedupe, coexistence, cascade) on MariaDB.

Part of the 1.19 before-stable items from the release assessment (P1).