### PR TITLE
Fix LikeService constructor ignoring an explicitly passed user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ HumHub Changelog
 
 1.19 (TBD)
 ----------
+- Fix #8329: `LikeService` crashed with a fatal error when a user was explicitly passed to the constructor — the typed property was only assigned in the fallback branch
 - Enh #8321: Add the `UnreadCountChangedEvent`, triggered whenever a user's unseen notification count changes or by modules such as Messenger
 - Fix: JS console warning `Required a non initialized module: i18n` on every full page load — `humhub.i18n.js` was registered last in `CoreApiAsset`, after core modules (`ui.additions`, `action`, `ui.widget`, `client`, `ui.modal`, ...) that `require('i18n')` at definition time, so the first of them created an empty namespace stub; it is now loaded directly after `humhub.core.js` (regression from #8078)
 - Fix #8322: On iOS (Safari & Chrome), programmatically focusing a field (e.g. opening a comment reply form) only showed the keyboard without scrolling the field into view until the first keystroke — a just-focused input, textarea or richtext editor that ends up hidden behind the keyboard is now scrolled into view once the keyboard has settled, network-wide

--- a/protected/humhub/modules/like/services/LikeService.php
+++ b/protected/humhub/modules/like/services/LikeService.php
@@ -35,9 +35,7 @@ class LikeService
             $this->contentAddon = $object;
         }
 
-        if ($user === null) {
-            $this->user = Yii::$app->getUser()->identity ?? null;
-        }
+        $this->user = $user ?? Yii::$app->getUser()->identity ?? null;
     }
 
     public function canLike(): bool

--- a/protected/humhub/modules/like/tests/codeception/unit/LikeServiceTest.php
+++ b/protected/humhub/modules/like/tests/codeception/unit/LikeServiceTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace tests\codeception\unit\modules\like;
+
+use humhub\modules\like\services\LikeService;
+use humhub\modules\post\models\Post;
+use humhub\modules\user\models\User;
+use tests\codeception\_support\HumHubDbTestCase;
+
+class LikeServiceTest extends HumHubDbTestCase
+{
+    public function testConstructWithExplicitUser()
+    {
+        $this->becomeUser('User1');
+        $post = Post::findOne(['id' => 1]);
+        $this->assertTrue((new LikeService($post))->like());
+
+        // A service for another, explicitly passed user must not report the
+        // session user's like
+        $serviceForOther = new LikeService($post, User::findOne(['username' => 'User2']));
+        $this->assertFalse($serviceForOther->hasLiked());
+
+        $serviceForLiker = new LikeService($post, User::findOne(['username' => 'User1']));
+        $this->assertTrue($serviceForLiker->hasLiked());
+    }
+}


### PR DESCRIPTION
## What

`LikeService::__construct(ContentProvider $object, ?User $user = null)` only assigned the typed `$user` property when no user was passed. Passing a non-null `User` left the property uninitialized, so the first access (`canLike()`, `hasLiked()`, `like()`, …) crashed with `Typed property ... $user must not be accessed before initialization` — the second constructor argument was unusable.

## How

Assign the passed user, falling back to the session identity as before.

Note: the passed user scopes the read side (`hasLiked()`, current-like lookup, title text). Creating a like still stamps `created_by` from the session via the blameable behavior — unchanged by this fix.

## Test

New `LikeServiceTest::testConstructWithExplicitUser` — fataled before the fix, now asserts a service constructed for another user does not report the session user's like (and vice versa).

Part of the 1.19 before-stable items from the release assessment (P1).