### PR TITLE
Fix ProfileImage::getUrl() fatal for GUID-constructed instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ HumHub Changelog
 
 1.19 (TBD)
 ----------
+- Fix #8330: `ProfileImage::getUrl()` (deprecated shim) crashed with a fatal error for GUID-constructed instances — the container is now resolved lazily and unknown GUIDs return an empty string, consistent with `render()`
 - Enh #8321: Add the `UnreadCountChangedEvent`, triggered whenever a user's unseen notification count changes or by modules such as Messenger
 - Fix: JS console warning `Required a non initialized module: i18n` on every full page load — `humhub.i18n.js` was registered last in `CoreApiAsset`, after core modules (`ui.additions`, `action`, `ui.widget`, `client`, `ui.modal`, ...) that `require('i18n')` at definition time, so the first of them created an empty namespace stub; it is now loaded directly after `humhub.core.js` (regression from #8078)
 - Fix #8322: On iOS (Safari & Chrome), programmatically focusing a field (e.g. opening a comment reply form) only showed the keyboard without scrolling the field into view until the first keystroke — a just-focused input, textarea or richtext editor that ends up hidden behind the keyboard is now scrolled into view once the keyboard has settled, network-wide

--- a/protected/humhub/libs/ProfileImage.php
+++ b/protected/humhub/libs/ProfileImage.php
@@ -37,7 +37,7 @@ class ProfileImage
 
     public function getUrl(?string $compat = null, bool $scheme = false)
     {
-        return $this->container->image->getUrl(null, $scheme);
+        return $this->getContainer()?->image->getUrl(null, $scheme) ?? '';
     }
 
     public function render($width = 32, $cfg = [])

--- a/protected/humhub/tests/codeception/unit/libs/ProfileImageTest.php
+++ b/protected/humhub/tests/codeception/unit/libs/ProfileImageTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * @link https://www.humhub.org/
+ * @copyright Copyright (c) 2026 HumHub GmbH & Co. KG
+ * @license https://www.humhub.com/licences
+ */
+
+namespace humhub\tests\codeception\unit\libs;
+
+use humhub\libs\ProfileImage;
+use humhub\modules\user\models\User;
+use tests\codeception\_support\HumHubDbTestCase;
+
+class ProfileImageTest extends HumHubDbTestCase
+{
+    protected $fixtureConfig = ['default'];
+
+    public function testGetUrlForGuidConstructedInstance()
+    {
+        $url = (new ProfileImage(User::findOne(['username' => 'User1'])->guid))->getUrl();
+
+        $this->assertNotEmpty($url);
+    }
+
+    public function testGetUrlForUnknownGuid()
+    {
+        $this->assertSame('', (new ProfileImage('00000000-0000-0000-0000-000000000000'))->getUrl());
+    }
+}


### PR DESCRIPTION
## What

The deprecated `humhub\libs\ProfileImage` shim (kept for external modules) dereferenced `$this->container` in `getUrl()` without resolving it first. The property is only set when the instance was constructed with a container object — or lazily by `getContainer()`/`render()`. So the classic module pattern

```php
(new ProfileImage($guid))->getUrl()
```

always crashed (`Attempt to read property "image" on null`), which makes the `@deprecated` label overstate what the shim still delivers.

## How

`getUrl()` now resolves the container via `getContainer()` and returns `''` for unknown GUIDs — consistent with `render()`.

## Test

New `ProfileImageTest` — both cases fataled before the fix; now a GUID-constructed instance returns the profile image URL and an unknown GUID returns `''`.

Part of the 1.19 before-stable items from the release assessment (P1).