### PR TITLE
Restore full delete cascade for deprecated Content::hardDelete()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ HumHub Changelog
 
 1.19 (TBD)
 ----------
+- Fix #8331: The deprecated `Content::hardDelete()` left the underlying record and its files orphaned — it now delegates to the record's `hardDelete()` and runs the complete deletion path as in 1.18
 - Fix #8326: Deleting a user or running the `PurgeDeletedContents` job crashed with a fatal error when hitting a content entry whose underlying record no longer exists — orphaned entries are now removed directly, matching the integrity check (#8312)
 - Fix #8327: The 1.19 upgrade aborted with a foreign key violation in the comment `content_id` migration when the database contained a reply whose parent comment (or a comment whose content) was already gone — such orphaned comments are now deleted before the RESTRICT foreign keys are created
 - Fix #8329: `LikeService` crashed with a fatal error when a user was explicitly passed to the constructor — the typed property was only assigned in the fallback branch

--- a/protected/humhub/modules/content/models/Content.php
+++ b/protected/humhub/modules/content/models/Content.php
@@ -461,6 +461,7 @@ class Content extends ActiveRecord implements Movable, ContentOwner, Archiveable
 
     /**
      * Deletes this content immediately and permanently
+     * including the underlying record and its files.
      *
      * @return bool
      * @throws Throwable
@@ -470,7 +471,9 @@ class Content extends ActiveRecord implements Movable, ContentOwner, Archiveable
      */
     public function hardDelete(): bool
     {
-        return $this->hardDeleteInternal();
+        $record = $this->getPolymorphicRelation();
+
+        return $record === null ? $this->hardDeleteInternal() : $record->hardDelete();
     }
 
     /**

--- a/protected/humhub/modules/content/tests/codeception/unit/ContentHardDeleteTest.php
+++ b/protected/humhub/modules/content/tests/codeception/unit/ContentHardDeleteTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace tests\codeception\unit\modules\content;
+
+use humhub\modules\content\models\Content;
+use humhub\modules\post\models\Post;
+use humhub\modules\space\models\Space;
+use tests\codeception\_support\HumHubDbTestCase;
+
+class ContentHardDeleteTest extends HumHubDbTestCase
+{
+    public function testDeprecatedContentHardDeleteDeletesRecord()
+    {
+        $post = $this->createPost();
+
+        $this->assertTrue($post->content->hardDelete());
+
+        $this->assertNull(Post::findOne(['id' => $post->id]));
+        $this->assertNull(Content::findOne(['id' => $post->content->id]));
+    }
+
+    public function testDeprecatedContentHardDeleteOnOrphanedContent()
+    {
+        $post = $this->createPost();
+        $content = $post->content;
+        Post::deleteAll(['id' => $post->id]);
+
+        $this->assertTrue(Content::findOne(['id' => $content->id])->hardDelete());
+
+        $this->assertNull(Content::findOne(['id' => $content->id]));
+    }
+
+    private function createPost(): Post
+    {
+        $this->becomeUser('User2');
+
+        $post = new Post(['message' => 'Content hardDelete test post']);
+        $post->content->setContainer(Space::findOne(['id' => 2]));
+        $post->save();
+
+        return $post;
+    }
+}


### PR DESCRIPTION
## What

`Content::hardDelete()` is deprecated but still a common external-module call. Since the deletion flow was inverted to be driven from `ContentActiveRecord` (#7917), the method only deleted the content row (plus activities/comments/likes via `EVENT_BEFORE_HARD_DELETE`) — the underlying record (Post, …) and its files were left orphaned.

## How

Delegate to `getPolymorphicRelation()->hardDelete()`, which runs the complete deletion path (record → files → content row via `afterDelete()`), matching what the deprecated call did in 1.18. Orphaned content entries without an underlying record are still removed directly via `hardDeleteInternal()`.

## Test

New `ContentHardDeleteTest` — the record-orphaning case failed before the fix (Post row survived), now both the record and the content entry are gone; the orphaned-content case keeps working.

Part of the 1.19 before-stable items from the release assessment (P1).