### PR TITLE
Add test coverage for the unencoded short text converter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ HumHub Changelog
 
 1.19 (TBD)
 ----------
+- Enh #8332: Add test coverage for the unencoded short text converter (`FORMAT_SHORT_TEXT`) — the existing test exercises the encoded legacy `FORMAT_SHORTTEXT` path only
 - Fix #8326: Deleting a user or running the `PurgeDeletedContents` job crashed with a fatal error when hitting a content entry whose underlying record no longer exists — orphaned entries are now removed directly, matching the integrity check (#8312)
 - Fix #8327: The 1.19 upgrade aborted with a foreign key violation in the comment `content_id` migration when the database contained a reply whose parent comment (or a comment whose content) was already gone — such orphaned comments are now deleted before the RESTRICT foreign keys are created
 - Fix #8329: `LikeService` crashed with a fatal error when a user was explicitly passed to the constructor — the typed property was only assigned in the fallback branch

--- a/protected/humhub/modules/content/tests/codeception/unit/widgets/RichTextToShortTextConverterTest.php
+++ b/protected/humhub/modules/content/tests/codeception/unit/widgets/RichTextToShortTextConverterTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * @link https://www.humhub.org/
+ * @copyright Copyright (c) 2026 HumHub GmbH & Co. KG
+ * @license https://www.humhub.com/licences
+ */
+
+namespace tests\codeception\unit\modules\content\widgets;
+
+use humhub\modules\content\widgets\richtext\RichText;
+use tests\codeception\_support\HumHubDbTestCase;
+use yii\base\InvalidConfigException;
+
+/**
+ * Tests the genuinely unencoded short text conversion (FORMAT_SHORT_TEXT /
+ * RichTextToShortTextConverter). The result must not be HTML encoded — for the
+ * encoded preview (FORMAT_SHORT_HTML, legacy FORMAT_SHORTTEXT) see
+ * RichTextShortTextConverterTest.
+ */
+class RichTextToShortTextConverterTest extends HumHubDbTestCase
+{
+    /**
+     * @throws InvalidConfigException
+     */
+    public function testSpecialCharsRemainUnencoded()
+    {
+        $this->assertConversionResult(
+            "Test special chars like & or <test>>",
+            "Test special chars like & or <test>>",
+        );
+    }
+
+    /**
+     * @throws InvalidConfigException
+     */
+    public function testConvertLinkWithSpecialCharRemainsUnencoded()
+    {
+        $this->assertConversionResult(
+            'Test [Link &< Link](https://www.humhub.com/de)',
+            "Test Link &< Link",
+        );
+    }
+
+    /**
+     * @throws InvalidConfigException
+     */
+    public function testConvertTextWithMaxLength()
+    {
+        $this->assertConversionResult(
+            'Test **text** truncation',
+            "Test...",
+            ['maxLength' => 5],
+        );
+    }
+
+    /**
+     * @throws InvalidConfigException
+     */
+    public function testShortHtmlFormatStaysEncoded()
+    {
+        static::assertEquals(
+            "Test Link &amp;&lt; Link",
+            RichText::convert('Test [Link &< Link](https://www.humhub.com/de)', RichText::FORMAT_SHORT_HTML),
+        );
+    }
+
+    /**
+     * @throws InvalidConfigException
+     */
+    private function assertConversionResult($markdown, $expected = null, $options = [])
+    {
+        $result = RichText::convert($markdown, RichText::FORMAT_SHORT_TEXT, $options);
+
+        static::assertEquals($expected ?? $markdown, $result);
+    }
+}


### PR DESCRIPTION
## What

The 1.19 RichText converter split made `RichTextToShortTextConverter` (`FORMAT_SHORT_TEXT`) return **unencoded** plain text. No test asserted that: despite its name, `RichTextShortTextConverterTest` exercises the *encoded* path — the legacy `FORMAT_SHORTTEXT` it uses maps to `convertToShortHtml()` for backward compatibility. A future regression re-encoding the short-text output (breaking mail subjects etc. with entities) would have passed CI.

## How

New `RichTextToShortTextConverterTest` covering `FORMAT_SHORT_TEXT`: special characters and link labels stay unencoded, truncation works, and one contrast case pins `FORMAT_SHORT_HTML` as encoded.

Verified the tests discriminate: pointed at the encoded converter they fail (2 failures), against `FORMAT_SHORT_TEXT` they pass.

Part of the 1.19 before-stable items from the release assessment (P1 / test gap).