### PR TITLE
Hide module Configure button for disabled modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ HumHub Changelog
 
 1.19 (TBD)
 ----------
+- Fix #8334: The module administration showed a "Configure" button on disabled modules to users holding `ManageSettings` but not `ManageModules` — a disabled module now only offers the "Enable" action; the `ManageSettings` permission description now also mentions module settings, since module config controllers are guarded by this permission
 - Enh #8332: Add test coverage for the unencoded short text converter (`FORMAT_SHORT_TEXT`) — the existing test exercises the encoded legacy `FORMAT_SHORTTEXT` path only
 - Fix #8331: The deprecated `Content::hardDelete()` left the underlying record and its files orphaned — it now delegates to the record's `hardDelete()` and runs the complete deletion path as in 1.18
 - Fix #8326: Deleting a user or running the `PurgeDeletedContents` job crashed with a fatal error when hitting a content entry whose underlying record no longer exists — orphaned entries are now removed directly, matching the integrity check (#8312)

--- a/protected/humhub/modules/admin/permissions/ManageSettings.php
+++ b/protected/humhub/modules/admin/permissions/ManageSettings.php
@@ -28,7 +28,7 @@ class ManageSettings extends BaseAdminPermission
         parent::__construct($config);
 
         $this->title = Yii::t('AdminModule.permissions', 'Manage Settings');
-        $this->description = Yii::t('AdminModule.permissions', 'Can manage general settings.');
+        $this->description = Yii::t('AdminModule.permissions', 'Can manage general settings and module settings.');
     }
 
 }

--- a/protected/humhub/modules/admin/widgets/InstalledModuleActionButtons.php
+++ b/protected/humhub/modules/admin/widgets/InstalledModuleActionButtons.php
@@ -32,11 +32,15 @@ class InstalledModuleActionButtons extends Widget
      */
     public function run()
     {
-        if (!$this->module->getIsEnabled() && Yii::$app->user->can(ManageModules::class)) {
-            return ModalButton::accent(Yii::t('AdminModule.base', 'Enable'))
-                ->sm()
-                ->post(['/admin/module/enable', 'moduleId' => $this->module->id])
-                ->options(['data-message' => Yii::t('AdminModule.base', 'Enable module...')]);
+        if (!$this->module->getIsEnabled()) {
+            if (Yii::$app->user->can(ManageModules::class)) {
+                return ModalButton::accent(Yii::t('AdminModule.base', 'Enable'))
+                    ->sm()
+                    ->post(['/admin/module/enable', 'moduleId' => $this->module->id])
+                    ->options(['data-message' => Yii::t('AdminModule.base', 'Enable module...')]);
+            }
+
+            return '';
         }
 
         if ($this->module->getConfigUrl() !== '' && Yii::$app->user->can(ManageSettings::class)) {


### PR DESCRIPTION
See humhub/humhub-internal#1290 (follow-up to humhub/news#154).

In the module administration, the "Configure" button of an installed module only checked the config URL and the `ManageSettings` permission — the enabled state was only considered implicitly via the preceding "Enable" branch, which additionally requires `ManageModules`. A user holding `ManageSettings` but not `ManageModules` therefore saw a "Configure" button on **disabled** modules. A disabled module now only offers the "Enable" action (with `ManageModules`) and no action otherwise.

Additionally, the `ManageSettings` permission description now mentions module settings ("Can manage general settings and module settings."), since module config controllers (`admin\components\Controller::getAccessRules()` default) are guarded by this permission. Translation files are intentionally untouched so the reworded string shows up as untranslated for the translation workflow.