### PR TITLE
Harden theme loading against incomplete/stale theme directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 HumHub Changelog
 ================
 
+1.19 (TBD)
+----------
+- Fix #8335: An update that moves the theme out of the webroot (the 1.19 move of `static`/`themes` into `protected/humhub`, #8102) could leave an empty `themes/HumHub` skeleton behind while the stored active theme still pointed at it — every request then failed with a fatal SCSS build error ("Can't find stylesheet to import") and the fallback looped forever because the empty skeleton shadowed the real core theme by name; a theme directory without its `scss/variables.scss` is now ignored when resolving themes (so the stale path no longer loads and no longer shadows the core theme and affected installations self-heal), the theme CSS fallback only switches to and refreshes for a different, buildable core theme instead of risking an endless redirect loop, and a theme's `variables` import is skipped when the file is missing
+
 1.19.0-beta.1 (July 21, 2026)
 --------------------
 - Fix #8334: The module administration showed a "Configure" button on disabled modules to users holding `ManageSettings` but not `ManageModules` — a disabled module now only offers the "Enable" action; the `ManageSettings` permission description now also mentions module settings, since module config controllers are guarded by this permission

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ HumHub Changelog
 
 1.19 (TBD)
 ----------
+- Fix #8335: The mailer view theme pointed at `@humhub/themes/Humhub` (lowercase `h`), a dead path on case-sensitive filesystems since the directory is `HumHub` — it now uses the `Theme::CORE_THEME_NAME` constant like the main view theme
 - Fix #8335: An update that moves the theme out of the webroot (the 1.19 move of `static`/`themes` into `protected/humhub`, #8102) could leave an empty `themes/HumHub` skeleton behind while the stored active theme still pointed at it — every request then failed with a fatal SCSS build error ("Can't find stylesheet to import") and the fallback looped forever because the empty skeleton shadowed the real core theme by name; a theme directory without its `scss/variables.scss` is now ignored when resolving themes (so the stale path no longer loads and no longer shadows the core theme and affected installations self-heal), the theme CSS fallback only switches to and refreshes for a different, buildable core theme instead of risking an endless redirect loop, and a theme's `variables` import is skipped when the file is missing
 
 1.19.0-beta.1 (July 21, 2026)

--- a/protected/humhub/components/Theme.php
+++ b/protected/humhub/components/Theme.php
@@ -131,11 +131,19 @@ class Theme extends BaseTheme
             $buildResult = ThemeHelper::buildCss();
             // If SCSS error in a Child Theme or Custom SCSS
             if ($buildResult !== true) {
-                // Fallback to HumHub theme with no Custom SCSS for a minimal working styling
+                // Fallback to the core HumHub theme with no Custom SCSS for a minimal
+                // working styling. Only switch and refresh when the core theme is a
+                // different, buildable theme - otherwise (e.g. the core theme itself
+                // fails to build, or is already active) refreshing would loop forever.
                 $coreTheme = ThemeHelper::getThemeByName(self::CORE_THEME_NAME);
-                ThemeHelper::buildCss($coreTheme, false);
-                $coreTheme->activate();
-                Yii::$app->response->refresh();
+                if (
+                    $coreTheme !== null
+                    && $coreTheme->getBasePath() !== $this->getBasePath()
+                    && ThemeHelper::buildCss($coreTheme, false) === true
+                ) {
+                    $coreTheme->activate();
+                    Yii::$app->response->refresh();
+                }
             }
         }
 

--- a/protected/humhub/config/common.php
+++ b/protected/humhub/config/common.php
@@ -168,8 +168,8 @@ $config = [
                 'class' => \yii\web\View::class,
                 'theme' => [
                     'class' => \humhub\components\Theme::class,
-                    'name' => 'HumHub',
-                    'basePath' => '@humhub/themes/Humhub',
+                    'name' => \humhub\components\Theme::CORE_THEME_NAME,
+                    'basePath' => '@humhub/themes/' . \humhub\components\Theme::CORE_THEME_NAME,
                 ],
             ],
         ],

--- a/protected/humhub/helpers/ThemeHelper.php
+++ b/protected/humhub/helpers/ThemeHelper.php
@@ -120,6 +120,15 @@ class ThemeHelper
             return null;
         }
 
+        // A theme directory without its SCSS variables file is not a usable theme
+        // (e.g. an empty `themes/HumHub` skeleton left behind by an update that moved
+        // the theme into `protected/humhub`). Loading it would break the SCSS build and,
+        // worse, shadow the real core theme in getThemes() since both share the name.
+        if (!is_file(ScssHelper::getVariableFile($theme))) {
+            Yii::warning('Ignoring invalid theme without SCSS variables file: ' . $path, 'ui');
+            return null;
+        }
+
         return $theme;
     }
 
@@ -271,7 +280,10 @@ class ThemeHelper
 
         // Import variables child theme first, because they have the !default flag
         foreach ($treeThemes as $treeTheme) {
-            $imports[] = $treeTheme->getBasePath() . DIRECTORY_SEPARATOR . 'scss' . DIRECTORY_SEPARATOR . 'variables';
+            $variablesFile = $treeTheme->getBasePath() . DIRECTORY_SEPARATOR . 'scss' . DIRECTORY_SEPARATOR . 'variables';
+            if (file_exists($variablesFile . '.scss')) {
+                $imports[] = $variablesFile;
+            }
         }
         $imports[] = Yii::getAlias('@humhub/resources/scss/variables');
         $imports[] = Yii::getAlias('@vendor/twbs/bootstrap/scss/variables');

--- a/protected/humhub/modules/ui/tests/codeception/unit/ThemeHelperTest.php
+++ b/protected/humhub/modules/ui/tests/codeception/unit/ThemeHelperTest.php
@@ -28,6 +28,32 @@ class ThemeHelperTest extends HumHubDbTestCase
         $this->testTheme($this->createTheme('Test'));
     }
 
+    public function testGetThemeByPathIgnoresThemeWithoutVariablesFile()
+    {
+        // An empty/incomplete theme directory (e.g. a `themes/HumHub` skeleton left
+        // behind by an update) must not be loaded as a theme.
+        $incompleteThemeDir = Yii::getAlias('@runtime') . '/tests/themes/Incomplete';
+        FileHelper::removeDirectory($incompleteThemeDir);
+        FileHelper::createDirectory($incompleteThemeDir . '/scss');
+
+        $this->assertNull(ThemeHelper::getThemeByPath($incompleteThemeDir));
+
+        FileHelper::removeDirectory($incompleteThemeDir);
+    }
+
+    public function testGetThemesByPathSkipsIncompleteTheme()
+    {
+        // A leftover `HumHub` skeleton (no scss/variables.scss) in the themes directory
+        // must not be listed as a theme - otherwise it would shadow the real core theme.
+        $themesDir = Yii::getAlias('@runtime') . '/tests/themes-scan';
+        FileHelper::removeDirectory($themesDir);
+        FileHelper::createDirectory($themesDir . '/HumHub/scss');
+
+        $this->assertArrayNotHasKey('HumHub', ThemeHelper::getThemesByPath($themesDir));
+
+        FileHelper::removeDirectory($themesDir);
+    }
+
     private function testTheme(?Theme $theme)
     {
         $this->assertInstanceOf(Theme::class, $theme);


### PR DESCRIPTION
## Problem

After an update that moves the theme out of the webroot — most recently the 1.19 move of `static`/`themes` into `protected/humhub` ([#8102](https://github.com/humhub/humhub/pull/8102)) — an installation can be left with an **empty `themes/HumHub` skeleton** (an update deletes the files but the old updater leaves the now-empty directories behind), while the stored active `theme` setting still points at that absolute path.

The result is a hard failure on every request:

```
Error while building the CSS from theme SCSS. Saas compiler error: Can't find stylesheet to import.
5 | @import "…/themes/HumHub/scss/variables", …
```

The failure chain:

1. `ThemeLoader::bootstrap()` only checks `is_dir($themePath)` — the empty skeleton passes, so the stale theme is loaded.
2. `ThemeHelper::buildCss()` imports `<basePath>/scss/variables` **unguarded** (unlike the `build` import right below it, which already has a `file_exists` guard) → the deleted file makes the Sass compile throw.
3. The fallback in `Theme::register()` calls `getThemeByName('HumHub')`, but `getThemes()` merges `@themes` (webroot) over `@humhub/themes` — so the empty skeleton **shadows the real core theme by name**. The fallback build fails identically, re-activates the stale path and calls `response->refresh()` → **endless redirect loop**.

## Changes

- **`ThemeHelper::getThemeByPath()`** returns `null` for a directory without `scss/variables.scss`. This is the root-cause fix: the stale path is no longer loaded by `ThemeLoader` (it falls through to the statically configured default theme), and the skeleton can no longer shadow the real core theme in `getThemes()`. Affected installations self-heal on the next request.
- **`Theme::register()`** only switches to and refreshes for the core-theme fallback when it is a *different, buildable* theme — preventing the endless redirect loop for any `buildCss` failure (e.g. broken custom SCSS in a child theme), not just this scenario.
- **`ThemeHelper::buildCss()`** skips a theme's `variables` import when the file is missing, mirroring the existing guard on the `build` import (defense in depth).

## Tests

Added two unit tests to `ThemeHelperTest`:
- `getThemeByPath()` ignores a directory without `scss/variables.scss`
- `getThemesByPath()` does not list an incomplete `HumHub` skeleton (anti-shadowing)

Full `ThemeHelperTest` suite passes locally (4 tests, incl. the existing default/child-theme build tests), php-cs-fixer clean.

## Note

The complementary updater fix — removing the empty directories in the first place — shipped in the Updater module ([humhub/updater#67](https://github.com/humhub/updater/pull/67), released as 2.4.2). This core change makes already-affected installations recover gracefully regardless of the updater version.
---

### Also in this PR: mailer view theme path casing

While reviewing the theme config, spotted that the **mailer** view theme pointed at `@humhub/themes/Humhub` (lowercase `h`) — a dead path on case-sensitive filesystems (Linux prod), since the directory is `HumHub`. The main view theme right below it already uses `Theme::CORE_THEME_NAME`. Fixed the mailer block to use the same constant so the casing can't drift again. Thematically the same class of issue (a theme `basePath` pointing at a non-existent directory).
