### PR TITLE
Unify duplicate "Maintenance mode is active" message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ HumHub Changelog
 
 1.19 (TBD)
 ----------
+- Enh #8336: Unified the two near-identical `UserModule.auth` translation keys for the maintenance mode message that differed only by a trailing period — the maintenance page heading now reuses the punctuated key, so the sentence no longer has to be translated twice
 - Fix #8335: The mailer view theme pointed at `@humhub/themes/Humhub` (lowercase `h`), a dead path on case-sensitive filesystems since the directory is `HumHub` — it now uses the `Theme::CORE_THEME_NAME` constant like the main view theme
 - Fix #8335: An update that moves the theme out of the webroot (the 1.19 move of `static`/`themes` into `protected/humhub`, #8102) could leave an empty `themes/HumHub` skeleton behind while the stored active theme still pointed at it — every request then failed with a fatal SCSS build error ("Can't find stylesheet to import") and the fallback looped forever because the empty skeleton shadowed the real core theme by name; a theme directory without its `scss/variables.scss` is now ignored when resolving themes (so the stale path no longer loads and no longer shadows the core theme and affected installations self-heal), the theme CSS fallback only switches to and refreshes for a different, buildable core theme instead of risking an endless redirect loop, and a theme's `variables` import is skipped when the file is missing
 

--- a/protected/humhub/modules/user/views/auth/maintenance.php
+++ b/protected/humhub/modules/user/views/auth/maintenance.php
@@ -19,7 +19,7 @@ $customInfo = trim((string)Yii::$app->settings->get('maintenanceModeInfo', ''));
 
     <div class="panel panel-default animated bounceIn">
         <div class="panel-heading">
-            <?= Yii::t('UserModule.auth', 'Maintenance mode is active') ?>
+            <?= Yii::t('UserModule.auth', 'Maintenance mode is active.') ?>
         </div>
         <div class="panel-body">
 


### PR DESCRIPTION
The maintenance mode feature (1.19) introduced two near-identical `UserModule.auth` translation keys that differ only by a trailing period:

- `Maintenance mode is active` — maintenance page heading (`views/auth/maintenance.php`)
- `Maintenance mode is active.` — login flash message (`controllers/AuthController.php`)

Both existed in all 49 language files, so translators had to translate the same sentence twice.

This unifies the maintenance page heading onto the punctuated key. The orphaned key is removed automatically on the next message extraction run (`removeUnused => true` in `config/i18n.php`), so no message files are touched here.

The functional test `MaintenanceModeCest` still passes — `$I->see(...)` matches on substring.