### PR TITLE
Defer module update opcache_reset() to end of request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 HumHub Changelog
 ================
 
+1.18.5 (Unreleased)
+-------------------
+- Fix #8340: Defer module update `opcache_reset()` to the end of the request to avoid interrupting the update in worker runtimes (e.g. FrankenPHP)
+
 1.18.4 (July 21, 2026)
 ----------------------
 - Enh #8170: Handle controllers with using external modules

--- a/protected/humhub/modules/marketplace/components/OnlineModuleManager.php
+++ b/protected/humhub/modules/marketplace/components/OnlineModuleManager.php
@@ -16,6 +16,7 @@ use humhub\modules\marketplace\services\MarketplaceService;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use Yii;
+use yii\base\Application;
 use yii\base\Component;
 use yii\base\ErrorException;
 use yii\base\Exception;
@@ -79,8 +80,14 @@ class OnlineModuleManager extends Component
             );
         }
 
+        // Reset the OPcache so the updated module files are recompiled on the following requests.
+        // This is deferred to the end of the request: in worker runtimes (e.g. FrankenPHP) opcache_reset()
+        // restarts the worker, which would otherwise interrupt the still running update (cache flush,
+        // registration and database migrations) and leave the module in a half-updated state.
         if (function_exists('opcache_reset')) {
-            @opcache_reset();
+            Yii::$app->on(Application::EVENT_AFTER_REQUEST, static function () {
+                @opcache_reset();
+            });
         }
 
         Yii::$app->moduleManager->flushCache();


### PR DESCRIPTION
On a module install/update, `OnlineModuleManager::install()` calls `opcache_reset()` right after unzipping the new module files — i.e. **before** `moduleManager->flushCache()`, `register()` and, in the update flow, the database migrations run by `$module->update()`.

Since [php/frankenphp#2364](https://github.com/php/frankenphp/pull/2364), `opcache_reset()` triggers a **worker restart** in FrankenPHP worker mode. When it runs inline, that restart interrupts the still-running update and can leave the module in a half-updated state (new files on disk, migrations not applied). This is especially bad for a bulk *"update all modules"* run, where the first module’s reset aborts all remaining updates. ([FrankenPHP v1.12.5](https://github.com/php/frankenphp/releases/tag/v1.12.5) only fixes a hang in that restart path; the restart-on-`opcache_reset()` behavior itself remains.)

### Change

Register the reset on `Application::EVENT_AFTER_REQUEST` instead of calling it inline, so it runs only **after** the update work has fully completed (and the response is prepared). The effect on OPcache for the following requests is identical — the updated files are recompiled on the next request either way — but the worker restart can no longer interrupt the update.

Works the same in web and console runs, since both trigger `EVENT_AFTER_REQUEST` in `Application::run()`.

### Testing

- [x] `php -l` passes
- Manual: module install/update still registers the module and runs migrations; OPcache is reset for subsequent requests.