### PR TITLE
Re-initialize eager widgets after async module registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ HumHub Changelog
 
 1.19.0-beta.2 (TBD)
 -------------------
+- Fix #8341: When the `assets` mount was served from a different origin than the HumHub site (an S3 bucket or CDN), module JavaScript loaded inside an ajax/pjax response (e.g. a modal) executed asynchronously — the browser cannot load cross-origin `<script src>` synchronously — so `[data-ui-init]` widgets in the response were processed before their module registered and silently failed on the first open (`Required a non initialized module: …`), only working from the second open on; eager widgets of an asynchronously registered module are now re-initialized right after registration (idempotent, covers modals, pjax and streams)
 - Enh #8337: Added a mail (SMTP) delivery configuration step to the web installer (after the basic step) reusing the admin mailing settings form, with an inline "Test" button that verifies the entered settings via AJAX; configuring mail never blocks completion, and the step is skipped on automated/managed-hosting installs (fixed mail config)
 - Enh #8337: The `php` mail transport (native mail()/sendmail) is no longer offered under Docker (`HUMHUB_DOCKER`) — hidden in the mailing settings form and rejected in validation, since containers ship no local MTA
 - Enh #8336: Unified the two near-identical `UserModule.auth` translation keys for the maintenance mode message that differed only by a trailing period — the maintenance page heading now reuses the punctuated key, so the sentence no longer has to be translated twice

--- a/docs/develop/ui-js-overview.md
+++ b/docs/develop/ui-js-overview.md
@@ -152,6 +152,8 @@ You will also need to specify the list of URLs for which the ajax page must call
     }
 ```
 
+> Info: When a module is registered **asynchronously** — its asset bundle is loaded inside an ajax response (e.g. a modal) or via [Pjax](ui-js-client.md) — HumHub re-applies the `ui.widget` addition to the module's own `[data-ui-init]` nodes right after registering it. This matters when assets are served from a **different origin** than the HumHub site (an S3 bucket or CDN via the `assets` mount): the browser executes cross-origin `<script src>` tags asynchronously — jQuery cannot load them synchronously — so the widget-initialization pass around the inserted content may run *before* the module's script executed. The late re-init makes eager `[data-ui-init]` widgets resilient to this ordering, so they no longer silently fail on the first modal/ajax open. Already initialized widgets are skipped, so it is idempotent.
+
 ### Module Unload
 
 For the purpose of cleaning up module related dom nodes etc. there is also an `unload` function which is called before each Pjax page load. This function is mainly used to remove obsolete dom nodes, prevent memory leaks, remove obsolete dom listeners or clear some module data.  

--- a/protected/humhub/resources/js/humhub/humhub.core.js
+++ b/protected/humhub/resources/js/humhub/humhub.core.js
@@ -200,6 +200,64 @@ var humhub = humhub || (function ($) {
         } else { // Init modules added asynchronously (ajax/pjax)
             addModuleLogger(instance);
             initModule(instance);
+            initPendingWidgets(instance);
+        }
+    };
+
+    /**
+     * Initializes [data-ui-init] widget nodes that belong to the just registered
+     * module but could not be initialized earlier.
+     *
+     * When a module's asset bundle is served from a different origin (e.g. an S3
+     * bucket or CDN via the `assets` mount), the `<script src>` injected with an
+     * ajax/pjax response (modal, stream, …) is executed *asynchronously* — jQuery
+     * silently ignores `async: false` for cross-domain scripts. The surrounding
+     * `applyAdditions()`/`applyTo()` pass that processes `[data-ui-init]` nodes
+     * therefore runs *before* this module registered, the widget namespace
+     * resolves to an empty stub ("Required a non initialized module: …") and the
+     * widget stays uninitialized until the next load.
+     *
+     * Now that the module is present we re-run the widget addition for the nodes
+     * that map to it. Nodes that were already initialized are skipped by the
+     * component instance guard (Component._getInstance), so this is idempotent.
+     *
+     * @param {object} instance the module instance that was just registered
+     * @returns {undefined}
+     */
+    var initPendingWidgets = function (instance) {
+        try {
+            // Resolve without init so a missing module never creates a stub or warns.
+            var additions = resolveNameSpace('ui.additions', false);
+            var action = resolveNameSpace('action', false);
+
+            if (!additions || !additions.applyTo || !action || !action.Component) {
+                return;
+            }
+
+            var moduleSuffix = _cutModulePrefix(instance.id);
+
+            var $nodes = $('[data-ui-init]').filter(function () {
+                var ns = action.Component.getNameSpace(this);
+                if (!ns) {
+                    return false;
+                }
+
+                // The node's widget class must be this module or live under it …
+                var nsSuffix = _cutModulePrefix(ns);
+                if (nsSuffix !== moduleSuffix && nsSuffix.indexOf(moduleSuffix + '.') !== 0) {
+                    return false;
+                }
+
+                // … and its namespace must actually resolve now (init = false does
+                // not create a stub or log a warning for still-missing modules).
+                return resolveNameSpace(ns, false) !== undefined;
+            });
+
+            if ($nodes.length) {
+                additions.applyTo($nodes, {include: ['ui.widget']});
+            }
+        } catch (e) {
+            require('log').error('Could not initialize pending widgets for module: ' + instance.id, e);
         }
     };
 


### PR DESCRIPTION
## Problem

When a module's asset bundle is served from a **different origin** than the HumHub site — an S3 bucket or CDN configured via the `assets` mount — module JavaScript loaded inside an ajax/pjax response (typically a modal) is executed **asynchronously**. As a result `[data-ui-init]` widgets in that response are initialized **before** their module registered, and silently fail on the first open (working only from the second open on):

```
Required a non initialized module: collabora.Editor
```

Affects any module that registers its asset bundle inside a modal view — e.g. **collabora**, **text-editor**, **drawio**. Not reproducible with same-origin (local) assets.

### Root cause

`Modal.setDialog()` does `this.$.empty().append(content); this.applyAdditions();`, assuming all `<script src>` of the response have executed by the time `.append()` returns. For **cross-origin** scripts jQuery's script transport appends a real `<script>` element and completes on its `load` event — `async: false` is silently ignored (documented jQuery behavior). So `applyAdditions()` runs before the module JS executed, `require(ns)` resolves an empty namespace stub, and the widget never initializes.

## Fix

In `humhub.core.js`, after a module is registered **asynchronously** (post `humhub:ready`), re-apply the `ui.widget` addition to the `[data-ui-init]` nodes that map to the just-registered module and whose namespace now resolves.

- **Path-agnostic** — triggers on module registration, covering modals, Pjax and stream inserts alike; no modal-specific timing hack.
- **Idempotent** — already-initialized widgets are skipped by the existing `Component._getInstance` guard (the same guard that keeps today's repeated `applyTo` calls safe).
- **No side effects / no noise** — lookups use `resolveNameSpace(ns, false)`, which never creates a stub or logs a warning; only runs after initial page load, so zero startup cost.
- **Handles multi-script responses** — each cross-origin script that lands re-scans for its own widgets, so ordering between several async bundles resolves naturally.

## Docs

- `docs/develop/ui-js-overview.md`: note on the async re-init behavior and the cross-origin assets caveat.

## Testing

- Reproduced with the collabora module and the S3 `assets` mount (cross-origin `baseUrl`): modal opened with title but empty body, iframe `src` never set, `Required a non initialized module: collabora.Editor` on first open. With this change the widget initializes on the first open.
- Same-origin assets: unchanged behavior; already-initialized widgets are not re-initialized.
- `node --check` passes.

Reported for the S3 assets mount in humhub/s3#2.