### PR TITLE
Do not skip the installer mail step on enableAutoSetup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ HumHub Changelog
 
 1.19.0-beta.2 (TBD)
 -------------------
-- Enh #8337: Added a mail (SMTP) delivery configuration step to the web installer (after the basic step) reusing the admin mailing settings form, with an inline "Test" button that verifies the entered settings via AJAX; configuring mail never blocks completion, and the step is skipped on automated/managed-hosting installs (fixed mail config)
+- Fix #8343: The new installer mail step (#8337) did not appear under Docker, where the auto-setup flag only automates the technical setup while the config wizard still runs interactively — the step is now only skipped when the mail transport is pinned via static config
+- Enh #8337: Added a mail (SMTP) delivery configuration step to the web installer (after the basic step) reusing the admin mailing settings form, with an inline "Test" button that verifies the entered settings via AJAX; configuring mail never blocks completion, and the step is skipped on managed-hosting installs (fixed mail config)
 - Enh #8337: The `php` mail transport (native mail()/sendmail) is no longer offered under Docker (`HUMHUB_DOCKER`) — hidden in the mailing settings form and rejected in validation, since containers ship no local MTA
 - Enh #8336: Unified the two near-identical `UserModule.auth` translation keys for the maintenance mode message that differed only by a trailing period — the maintenance page heading now reuses the punctuated key, so the sentence no longer has to be translated twice
 - Enh #8339: The tour navigation buttons (Next/Previous/Done) and progress text are now translatable

--- a/protected/humhub/modules/installer/controllers/ConfigController.php
+++ b/protected/humhub/modules/installer/controllers/ConfigController.php
@@ -137,13 +137,14 @@ class ConfigController extends Controller
      */
     public function actionMail()
     {
-        // Skip the interactive step when there is nothing for the admin to
-        // decide: during automated / CLI installs (mirroring actionDatabase()
-        // and actionCron() in SetupController), or when the mail transport is
-        // pinned via static config. The latter is the managed-hosting case
-        // (HUMHUB_FIXED_SETTINGS__BASE__MAILER_*), where SetupController is
-        // likewise skipped and mail delivery is provided centrally.
-        if ($this->module->enableAutoSetup || Yii::$app->settings->isFixed('mailerTransportType')) {
+        // Skip the interactive step only when the mail transport is pinned via
+        // static config (HUMHUB_FIXED_SETTINGS__BASE__MAILER_*) — the
+        // managed-hosting case where mail delivery is provided centrally.
+        // Deliberately not gated on enableAutoSetup: that flag only automates
+        // the technical setup phase (SetupController); the config wizard still
+        // runs interactively, e.g. under Docker where the entrypoint enables
+        // it whenever DB credentials are passed via environment.
+        if (Yii::$app->settings->isFixed('mailerTransportType')) {
             return $this->redirect(Yii::$app->getModule('installer')->getNextConfigStepUrl());
         }
 


### PR DESCRIPTION
## Problem

The new mail configuration step (#8337) never appeared under Docker.

`actionMail()` skipped itself on `enableAutoSetup`, treating the flag as "unattended install". In reality the flag only automates the **technical setup phase** — `SetupController` skips prerequisites, database form, cron and pretty URLs — while the config wizard (`ConfigController`) still runs interactively afterwards (`actionFinalize()` redirects into it).

Docker deployments effectively always run with `enableAutoSetup=true`:
- the production image entrypoint sets `AUTO_SETUP=true` whenever DB DSN + username are passed via environment (the standard compose setup)
- `docker-dev` hardcodes `HUMHUB_CONFIG__MODULES__INSTALLER__ENABLE_AUTO_SETUP=true`

So the mail step was the only wizard step that silently disappeared under Docker, while basic, localisation, use case, security, admin and sample data all showed.

## Fix

Drop the `enableAutoSetup` half of the condition. The step is now only skipped when the mail transport is pinned via static config (`HUMHUB_FIXED_SETTINGS__BASE__MAILER_*`) — the managed-hosting case where mail is provided centrally, which was the actually intended skip.