### PR TITLE
Force Select2 dropdowns to always open below the field instead of flipping above when there's not enough space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ HumHub Changelog
 1.18.5 (Unreleased)
 -------------------
 - Fix #8340: Defer module update `opcache_reset()` to the end of the request to avoid interrupting the update in worker runtimes (e.g. FrankenPHP)
+- Enh #8346: Force Select2 dropdowns to always open below the field instead of flipping above when there's not enough space
 
 1.18.4 (July 21, 2026)
 ----------------------

--- a/static/js/humhub/humhub.ui.additions.js
+++ b/static/js/humhub/humhub.ui.additions.js
@@ -175,6 +175,80 @@ humhub.module('ui.additions', function (module, require, $) {
             $match.timeago();
         });
 
+        // Forces the Select2 dropdown to always open below the field, regardless of
+        // available viewport space (Select2's default auto up/down detection is disabled).
+        //
+        // Mirrors the exact decorator chain Select2's own Defaults.prototype.apply builds
+        // (select2/defaults, dropdownAdapter block) - Dropdown [+ Search when single-select]
+        // -> CloseOnSelect (HumHub doesn't override closeOnSelect, default true) -> AttachBody -
+        // just swapping in a variant of AttachBody whose _positionDropdown() hardcodes the
+        // "below" direction instead of computing it from available viewport space. All other
+        // positioning math (offsets, parent offset, left/top) is kept identical to Select2's
+        // original implementation so width/scroll/attach-to-body behaviour is unaffected.
+        var forceDropdownBelowAdapter = function ($element) {
+            var Utils = $.fn.select2.amd.require('select2/utils');
+            var Dropdown = $.fn.select2.amd.require('select2/dropdown');
+            var DropdownSearch = $.fn.select2.amd.require('select2/dropdown/search');
+            var CloseOnSelect = $.fn.select2.amd.require('select2/dropdown/closeOnSelect');
+            var AttachBody = $.fn.select2.amd.require('select2/dropdown/attachBody');
+
+            // AttachBody is a decorator mixin (expects a "decorated" super-constructor as its
+            // first argument), not a standalone class - it must be wired in via Utils.Decorate
+            // together with the base Dropdown/DropdownSearch/CloseOnSelect adapters, otherwise
+            // Select2 throws synchronously on init and .select2() never completes for the batch.
+            function CustomAttachBody(decorated, $el, options) {
+                AttachBody.call(this, decorated, $el, options);
+            }
+
+            Utils.Extend(CustomAttachBody, AttachBody);
+
+            CustomAttachBody.prototype._positionDropdown = function () {
+                var offset = this.$container.offset();
+                offset.bottom = offset.top + this.$container.outerHeight(false);
+
+                var container = { height: this.$container.outerHeight(false) };
+                container.top = offset.top;
+                container.bottom = offset.top + container.height;
+
+                var css = {
+                    left: offset.left,
+                    top: container.bottom
+                };
+
+                var $offsetParent = this.$dropdownParent;
+                if ($offsetParent.css('position') === 'static') {
+                    $offsetParent = $offsetParent.offsetParent();
+                }
+
+                var parentOffset = { top: 0, left: 0 };
+                if ($.contains(document.body, $offsetParent[0]) || $offsetParent[0].isConnected) {
+                    parentOffset = $offsetParent.offset();
+                }
+
+                css.top -= parentOffset.top;
+                css.left -= parentOffset.left;
+
+                this.$dropdown
+                    .removeClass('select2-dropdown--above select2-dropdown--below')
+                    .addClass('select2-dropdown--below');
+                this.$container
+                    .removeClass('select2-container--above select2-container--below')
+                    .addClass('select2-container--below');
+
+                this.$dropdownContainer.css(css);
+            };
+
+            var multiple = $element.prop('multiple');
+            var Adapter = multiple ? Dropdown : Utils.Decorate(Dropdown, DropdownSearch);
+
+            // minimumResultsForSearch isn't overridden by HumHub here (defaults to 0), so
+            // Select2 itself would skip the MinimumResultsForSearch decorator too - omitted.
+            Adapter = Utils.Decorate(Adapter, CloseOnSelect);
+            Adapter = Utils.Decorate(Adapter, CustomAttachBody);
+
+            return Adapter;
+        };
+
         module.register('select2', '[data-ui-select2]', function ($match) {
             const templateItem = function (item) {
                 const element = $(item.element);
@@ -197,6 +271,7 @@ humhub.module('ui.additions', function (module, require, $) {
                     templateSelection: templateItem,
                     dropdownAutoWidth: true,
                     scrollAfterSelect: true,
+                    dropdownAdapter: forceDropdownBelowAdapter($(this)),
                 });
             });
         });


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

**The PR fulfills these requirements:**

- [ ] All tests are passing
- [x] Changelog was modified

**Other information:**
https://github.com/humhub/humhub-internal/issues/1297