### PR TITLE
Fix encoding of deletion reason in comment and content deletion notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ HumHub Changelog
 - Fix #8357: Cast app name to string (This fixes the issue of instances with names consisting of numbers not being able to be added to the mobile app)
 - Enh #8346: Force Select2 dropdowns to always open below the field instead of flipping above when there's not enough space
 - Fix #8359: Display user sub name on invite after space creating
+- Fix #1311: Encode deletion reason in comment and content deletion notifications
 
 1.18.4 (July 21, 2026)
 ----------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ HumHub Changelog
 - Fix #8357: Cast app name to string (This fixes the issue of instances with names consisting of numbers not being able to be added to the mobile app)
 - Enh #8346: Force Select2 dropdowns to always open below the field instead of flipping above when there's not enough space
 - Fix #8359: Display user sub name on invite after space creating
-- Fix #1311: Encode deletion reason in comment and content deletion notifications
+- Fix #8365: Encode deletion reason in comment and content deletion notifications
 
 1.18.4 (July 21, 2026)
 ----------------------

--- a/protected/humhub/modules/comment/notifications/CommentDeleted.php
+++ b/protected/humhub/modules/comment/notifications/CommentDeleted.php
@@ -43,7 +43,7 @@ class CommentDeleted extends BaseNotification
         return Yii::t('CommentModule.notifications', 'Your comment \'{commentText}\' has been deleted by {displayName} for \'{reason}\'', [
             'displayName' => Html::tag('strong', Html::encode($this->originator->displayName)),
             'commentText' => $this->payload['commentText'],
-            'reason' => $this->payload['reason'],
+            'reason' => Html::encode($this->payload['reason']),
         ]);
     }
 

--- a/protected/humhub/modules/comment/tests/codeception/unit/CommentDeletedTest.php
+++ b/protected/humhub/modules/comment/tests/codeception/unit/CommentDeletedTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace tests\codeception\unit\modules\comment\notifications;
+
+use humhub\modules\comment\notifications\CommentDeleted;
+use humhub\modules\user\models\User;
+use tests\codeception\_support\HumHubDbTestCase;
+
+class CommentDeletedTest extends HumHubDbTestCase
+{
+    /* @codingStandardsIgnoreLine PSR2.Methods.MethodDeclaration.Underscore */
+    public function _fixtures(): array
+    {
+        return [];
+    }
+
+    private function buildNotification(string $reason, string $commentText): CommentDeleted
+    {
+        $notification = new CommentDeleted();
+        $notification->from(new User(['id' => 1, 'username' => 'admin']));
+        $notification->payload = [
+            'commentText' => $commentText,
+            'reason' => $reason,
+        ];
+
+        return $notification;
+    }
+
+    /**
+     * Regression test for the stored XSS via the admin deletion reason (issue #1311).
+     * The reason is a raw form string and must be HTML encoded in the notification.
+     */
+    public function testDeletionReasonIsEncoded()
+    {
+        $html = $this->buildNotification('<script>alert(1)</script>', 'a comment')->html();
+
+        $this->assertStringNotContainsString('<script>alert(1)</script>', $html);
+        $this->assertStringContainsString('&lt;script&gt;alert(1)&lt;/script&gt;', $html);
+    }
+
+    /**
+     * The comment preview is already HTML encoded by RichTextToShortTextConverter,
+     * so html() must not encode it a second time (no double encoding).
+     */
+    public function testCommentTextIsNotDoubleEncoded()
+    {
+        $html = $this->buildNotification('a reason', '&lt;b&gt;hi&lt;/b&gt;')->html();
+
+        $this->assertStringContainsString('&lt;b&gt;hi&lt;/b&gt;', $html);
+        $this->assertStringNotContainsString('&amp;lt;b&amp;gt;', $html);
+    }
+}

--- a/protected/humhub/modules/content/notifications/ContentDeleted.php
+++ b/protected/humhub/modules/content/notifications/ContentDeleted.php
@@ -42,8 +42,8 @@ class ContentDeleted extends BaseNotification
     {
         return Yii::t('ContentModule.notifications', 'Your {contentTitle} has been deleted by {displayName} for \'{reason}\'', [
             'displayName' => Html::tag('strong', Html::encode($this->originator->displayName)),
-            'contentTitle' => $this->payload['contentTitle'],
-            'reason' => $this->payload['reason'],
+            'contentTitle' => Html::encode($this->payload['contentTitle']),
+            'reason' => Html::encode($this->payload['reason']),
         ]);
     }
 }

--- a/protected/humhub/modules/content/tests/codeception/unit/ContentDeletedTest.php
+++ b/protected/humhub/modules/content/tests/codeception/unit/ContentDeletedTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace tests\codeception\unit\modules\content\notifications;
+
+use humhub\modules\content\notifications\ContentDeleted;
+use humhub\modules\user\models\User;
+use tests\codeception\_support\HumHubDbTestCase;
+
+class ContentDeletedTest extends HumHubDbTestCase
+{
+    /* @codingStandardsIgnoreLine PSR2.Methods.MethodDeclaration.Underscore */
+    public function _fixtures(): array
+    {
+        return [];
+    }
+
+    private function buildNotification(string $reason, string $contentTitle): ContentDeleted
+    {
+        $notification = new ContentDeleted();
+        $notification->from(new User(['id' => 1, 'username' => 'admin']));
+        $notification->payload = [
+            'contentTitle' => $contentTitle,
+            'reason' => $reason,
+        ];
+
+        return $notification;
+    }
+
+    /**
+     * Regression test for the stored XSS via the admin deletion reason (issue #1311).
+     * The reason is a raw form string and must be HTML encoded in the notification.
+     */
+    public function testDeletionReasonIsEncoded()
+    {
+        $html = $this->buildNotification('<script>alert(1)</script>', 'post "hello"')->html();
+
+        $this->assertStringNotContainsString('<script>alert(1)</script>', $html);
+        $this->assertStringContainsString('&lt;script&gt;alert(1)&lt;/script&gt;', $html);
+    }
+
+    /**
+     * contentTitle is built by RichTextToPlainTextConverter which does NOT encode,
+     * so html() must encode it to neutralize markup from the content body.
+     */
+    public function testContentTitleIsEncoded()
+    {
+        $html = $this->buildNotification('a reason', 'post "<img src=x onerror=alert(1)>"')->html();
+
+        $this->assertStringNotContainsString('<img src=x onerror=alert(1)>', $html);
+        $this->assertStringContainsString('&lt;img src=x onerror=alert(1)&gt;', $html);
+    }
+}


### PR DESCRIPTION
Ref: humhub/humhub-internal#1311

### Problem

When an admin deletes a comment or content item and notifies the author, the deletion reason (a raw admin form string) was interpolated into the notification HTML without encoding. `Yii::t()` does not escape substitutions, and the notification HTML is echoed unescaped into the notification dropdown (returned as JSON `output`, inserted via jQuery `.append()`), so a `<script>` in the reason executes in the recipient's session. Because the recipient can be a global administrator while the actor only needs to be a Space administrator, this crosses a privilege boundary.

### Fix

- `CommentDeleted::html()` — encode `reason`.
- `ContentDeleted::html()` — encode `reason` and `contentTitle`.

`commentText` is intentionally left as-is: it is produced by `RichTextToShortTextConverter`, which already HTML-encodes its output, so encoding it again would double-encode. `contentTitle` is the exception — it comes from `RichTextToPlainTextConverter`, which does not encode, so it needed escaping.

### Schema check

The deletion notifications were the only ones breaking the established pattern. All other notification `html()` methods route dynamic user/space/content data through `Html::encode()` (directly or via `getContentInfo()` / `getGroupUserDisplayNames()`, both of which encode). Two further unencoded interpolations exist but are not user-controllable and are left unchanged: `ChangedRolesMembership` role names (fixed i18n labels) and `NewVersionAvailable` version (from the remote update API).

### Tests

Added regression tests for both notifications asserting the reason (and `contentTitle`) is encoded, and that `commentText` is not double-encoded. Verified they fail on the unpatched code and pass with the fix.
