### PR TITLE
Ensure oEmbed consent prompt encodes requested URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ HumHub Changelog
 - Enh #8346: Force Select2 dropdowns to always open below the field instead of flipping above when there's not enough space
 - Fix #8359: Display user sub name on invite after space creating
 - Fix #8365: Encode deletion reason in comment and content deletion notifications
+- Fix #8373: Ensure the oEmbed consent prompt encodes the requested URL so embedded markup stays inert
 
 1.18.4 (July 21, 2026)
 ----------------------

--- a/protected/humhub/models/UrlOembed.php
+++ b/protected/humhub/models/UrlOembed.php
@@ -159,11 +159,14 @@ class UrlOembed extends ActiveRecord
 
             if (static::hasOEmbedSupport($url)) {
                 if (!$forceAllowedDomain && !self::isAllowedDomain($url)) {
-                    $result = self::confirmationContent($url);
-                } else {
-                    $urlOembed = static::findExistingOembed($url);
-                    $result = $urlOembed ? $urlOembed->preview : self::loadUrl($url);
+                    // The confirmation prompt is built from the (untrusted) requested url and must
+                    // never be run through the script reconstruction below, which would grant any
+                    // embedded markup a valid CSP nonce. Return it as-is (already safely encoded).
+                    return trim((string) preg_replace('/\s+/', ' ', self::confirmationContent($url)));
                 }
+
+                $urlOembed = static::findExistingOembed($url);
+                $result = $urlOembed ? $urlOembed->preview : self::loadUrl($url);
 
                 if (!empty($result)) {
                     // Fix to run the appended scripts after ajax/pjax loading
@@ -341,7 +344,7 @@ class UrlOembed extends ActiveRecord
 
         $html = Html::tag('strong', Yii::t('base', 'Allow content from external source'))
             . Html::tag('br')
-            . Yii::t('base', 'Do you want to enable content from \'{urlPrefix}\'?', ['urlPrefix' => Html::tag('strong', $urlPrefix)])
+            . Yii::t('base', 'Do you want to enable content from \'{urlPrefix}\'?', ['urlPrefix' => Html::tag('strong', Html::encode($urlPrefix))])
             . Html::tag('br')
             . Html::tag('label', '<input type="checkbox"> ' . Yii::t('base', 'Always allow content from this provider!'))
             . Html::tag('br')

--- a/protected/humhub/tests/codeception/unit/models/UrlOembedMock.php
+++ b/protected/humhub/tests/codeception/unit/models/UrlOembedMock.php
@@ -33,4 +33,9 @@ class UrlOembedMock extends UrlOembed
         return array_key_exists($url, static::$cache);
     }
 
+    public static function buildConfirmationContent(string $url): string
+    {
+        return static::confirmationContent($url);
+    }
+
 }

--- a/protected/humhub/tests/codeception/unit/models/UrlOembedTest.php
+++ b/protected/humhub/tests/codeception/unit/models/UrlOembedTest.php
@@ -124,6 +124,16 @@ class UrlOembedTest extends HumHubDbTestCase
         $this->assertEquals(2, UrlOembedMock::getFetchLoadCount());
     }
 
+    public function testConfirmationContentEncodesUrl()
+    {
+        $url = 'https:youtube.com<script>alert(1)</script>';
+        $html = UrlOembedMock::buildConfirmationContent($url);
+
+        // The requested url is attacker controllable and must be rendered inert
+        $this->assertStringNotContainsString('<script>', $html);
+        $this->assertStringContainsString('&lt;script&gt;', $html);
+    }
+
     private function getOembedRecordCount()
     {
         return UrlOembedMock::find()->count();


### PR DESCRIPTION
### What

Hardens the oEmbed consent-prompt rendering so a requested URL can no longer inject active markup into the prompt shown to viewers.

When embedded content requires consent, the prompt is built from the requested URL. A malformed value that still matches a provider pattern (e.g. containing `youtube.com`) fell back to the full URL, which was inserted into the prompt without output encoding. The rendering path then reconstructed embedded `<script>` elements with a valid CSP nonce, so attacker-supplied markup could execute in another authenticated user's session.

Refs security report / CVE-2026-18526.

### Changes

- `UrlOembed::confirmationContent()` now encodes the URL text (`Html::encode`) so any embedded markup is rendered inert.
- `UrlOembed::getOEmbed()` returns the consent prompt directly instead of running it through the `<script>` nonce-reconstruction step. That step is meant for trusted provider previews only and must not apply to the untrusted prompt (defense in depth).
- Added a regression test asserting the prompt contains no live `<script>` and shows the encoded form instead.

### Testing

- `UrlOembedTest`: 9/9 pass (incl. new test).
- Reproduced end-to-end before the change (prompt executed the injected script) and verified it no longer does after the change (URL rendered as inert text).

See: https://github.com/humhub/humhub-internal/issues/1313