### PR TITLE
Ensure adding group members is restricted to groups the current user manages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ HumHub Changelog
 - Fix #8359: Display user sub name on invite after space creating
 - Fix #8361: Prevent non-creators from attaching or deleting another user's unassigned file
 - Fix #8365: Encode deletion reason in comment and content deletion notifications
+- Fix #8374: Ensure adding group members is restricted to groups the current user manages
 
 1.18.4 (July 21, 2026)
 ----------------------

--- a/protected/humhub/modules/admin/controllers/GroupController.php
+++ b/protected/humhub/modules/admin/controllers/GroupController.php
@@ -286,8 +286,12 @@ class GroupController extends Controller
         }
 
         $form = new AddGroupMemberForm();
+        $form->load(Yii::$app->request->post());
 
-        if ($form->load(Yii::$app->request->post()) && $form->validate()) {
+        // Ensure the current user is allowed to manage the group the members are added to
+        $this->checkGroupAccess($form->getGroup());
+
+        if ($form->validate()) {
             $form->save();
         }
 

--- a/protected/humhub/modules/admin/models/forms/AddGroupMemberForm.php
+++ b/protected/humhub/modules/admin/models/forms/AddGroupMemberForm.php
@@ -66,8 +66,9 @@ class AddGroupMemberForm extends Model
             throw new HttpException(404, Yii::t('AdminModule.user', 'Group not found!'));
         }
 
-        if ($group->is_admin_group && !Yii::$app->user->isAdmin()) {
-            throw new HttpException(403);
+        // Ensure the current user is allowed to manage this specific group
+        if (!$group->canManage()) {
+            throw new HttpException(403, 'No permission to manage this group.');
         }
 
         foreach ($this->userGuids as $userGuid) {

--- a/protected/humhub/modules/admin/tests/codeception/unit/AddGroupMemberTest.php
+++ b/protected/humhub/modules/admin/tests/codeception/unit/AddGroupMemberTest.php
@@ -1,0 +1,169 @@
+<?php
+
+/**
+ * @link https://www.humhub.org/
+ * @copyright Copyright (c) 2017 HumHub GmbH & Co. KG
+ * @license https://www.humhub.com/licences
+ */
+
+namespace tests\codeception\unit\modules\admin;
+
+use humhub\modules\admin\models\forms\AddGroupMemberForm;
+use humhub\modules\user\models\forms\EditGroupForm;
+use humhub\modules\user\models\Group;
+use humhub\modules\user\models\User;
+use tests\codeception\_support\HumHubDbTestCase;
+use Yii;
+use yii\web\HttpException;
+
+/**
+ * Ensures that adding group members is always bound to the group the members are added to,
+ * so a manager of one group cannot write memberships of a group they do not manage.
+ */
+class AddGroupMemberTest extends HumHubDbTestCase
+{
+    /**
+     * User2 is group manager of "Moderators" only and must not be able to add
+     * anyone (including himself) to the unrelated "Users" group.
+     */
+    public function testGroupManagerCannotAddMembersToForeignGroup()
+    {
+        $user = $this->becomeUser('User2');
+        $foreignGroup = Group::findOne(['name' => 'Users']);
+
+        $this->assertFalse($foreignGroup->canManage());
+
+        $form = new AddGroupMemberForm([
+            'groupId' => $foreignGroup->id,
+            'userGuids' => [$user->guid],
+        ]);
+
+        $this->assertTrue($form->validate());
+
+        try {
+            $form->save();
+            $this->fail('Adding members to a group without manage permission should be denied.');
+        } catch (HttpException $e) {
+            $this->assertEquals(403, $e->statusCode);
+        }
+
+        $this->assertFalse($foreignGroup->isMember($user));
+    }
+
+    /**
+     * The same request through the controller action must be denied as well.
+     */
+    public function testGroupManagerCannotAddMembersToForeignGroupViaController()
+    {
+        $user = $this->becomeUser('User2');
+        $foreignGroup = Group::findOne(['name' => 'Users']);
+
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        Yii::$app->request->enableCsrfValidation = false;
+        Yii::$app->request->setBodyParams([
+            'AddGroupMemberForm' => [
+                'groupId' => $foreignGroup->id,
+                'userGuids' => [$user->guid],
+            ],
+        ]);
+
+        try {
+            Yii::$app->runAction('admin/group/add-members');
+            $this->fail('Adding members to a group without manage permission should be denied.');
+        } catch (HttpException $e) {
+            $this->assertEquals(403, $e->statusCode);
+        }
+
+        $this->assertFalse($foreignGroup->isMember($user));
+    }
+
+    /**
+     * A group manager is still able to add members to a group they manage.
+     */
+    public function testGroupManagerCanAddMembersToOwnGroup()
+    {
+        $ownGroup = $this->createGroupManagedByUser2();
+        $newMember = User::findOne(['username' => 'User3']);
+
+        $this->becomeUser('User2');
+        $this->assertTrue($ownGroup->canManage());
+
+        $form = new AddGroupMemberForm([
+            'groupId' => $ownGroup->id,
+            'userGuids' => [$newMember->guid],
+        ]);
+
+        $this->assertTrue($form->validate());
+        $this->assertTrue($form->save());
+        $this->assertTrue($ownGroup->isMember($newMember));
+    }
+
+    /**
+     * An administrator is still able to add members to any group.
+     */
+    public function testAdminCanAddMembersToAnyGroup()
+    {
+        $groupIds = [
+            $this->createGroupManagedByUser2()->id,
+            Group::getAdminGroupId(),
+        ];
+
+        $this->becomeUser('Admin');
+        $newMember = User::findOne(['username' => 'User3']);
+
+        foreach ($groupIds as $groupId) {
+            $group = Group::findOne(['id' => $groupId]);
+
+            $form = new AddGroupMemberForm([
+                'groupId' => $group->id,
+                'userGuids' => [$newMember->guid],
+            ]);
+
+            $this->assertTrue($form->validate());
+            $this->assertTrue($form->save());
+            $this->assertTrue($group->isMember($newMember));
+        }
+    }
+
+    /**
+     * Creates a group managed by User2 without default Spaces, so that adding a member
+     * does not trigger any Space membership side effects.
+     */
+    private function createGroupManagedByUser2(): Group
+    {
+        $this->becomeUser('Admin');
+
+        $group = new EditGroupForm([
+            'name' => 'User2 Group',
+            'managerGuids' => [User::findOne(['username' => 'User2'])->guid],
+        ]);
+        $this->assertTrue($group->save());
+
+        return Group::findOne(['id' => $group->id]);
+    }
+
+    /**
+     * The admin group stays protected for non administrators.
+     */
+    public function testGroupManagerCannotAddMembersToAdminGroup()
+    {
+        $user = $this->becomeUser('User2');
+        $adminGroup = Group::getAdminGroup();
+
+        $form = new AddGroupMemberForm([
+            'groupId' => $adminGroup->id,
+            'userGuids' => [$user->guid],
+        ]);
+
+        $this->assertTrue($form->validate());
+
+        try {
+            $form->save();
+            $this->fail('Adding members to the administrator group should be denied.');
+        } catch (HttpException $e) {
+            $this->assertEquals(403, $e->statusCode);
+        }
+
+        $this->assertFalse($adminGroup->isMember($user));
+    }
+}


### PR DESCRIPTION
Internal report: https://github.com/humhub/humhub-internal/issues/1312

## Background

In `admin/GroupController`, every group-write action binds its permission check to the
group being written to via `checkGroupAccess()`, which resolves to `Group::canManage()`.
`actionAddMembers` was the only one that did not: it checked `canModifyMembers()`, which
resolves to `Yii::$app->user->isGroupManager()` and is therefore global (manager of *any*
group) rather than group-scoped.

`AddGroupMemberForm::save()` did not close the gap either, since it only guarded the
administrator group. As a result a manager of one group could add members, including
themselves, to any other non-admin group and inherit that group's permission set. The
administrator group was already protected, so administrator itself was not reachable.

## Changes

- `GroupController::actionAddMembers()` now calls `checkGroupAccess()` on the group taken
  from the submitted form, matching the six sibling write actions.
- `AddGroupMemberForm::save()` now requires `$group->canManage()`. This is strictly
  stronger than the previous administrator-group-only guard and covers it, so the
  direct-POST path is bound to the target group independently of the controller.

## Tests

New `AddGroupMemberTest` (admin unit suite), 5 tests / 21 assertions. Verified as a
differential: with the two source changes reverted, exactly the two escalation tests fail,
while the three tests covering legitimate behaviour pass either way.

| Test | without fix | with fix |
| --- | --- | --- |
| manager cannot add to a group they do not manage (form) | fail | pass |
| manager cannot add to a group they do not manage (controller) | fail | pass |
| manager can add to a group they manage | pass | pass |
| administrator can add to any group | pass | pass |
| manager cannot add to the administrator group | pass | pass |

Full `admin` unit + functional suite is green (27 tests, 277 assertions).
