### PR TITLE
Ensure space member role changes are limited to assignable roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ HumHub Changelog
 - Fix #8359: Display user sub name on invite after space creating
 - Fix #8361: Prevent non-creators from attaching or deleting another user's unassigned file
 - Fix #8365: Encode deletion reason in comment and content deletion notifications
+- Fix #8375: Ensure space member role changes are limited to assignable roles
 
 1.18.4 (July 21, 2026)
 ----------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ HumHub Changelog
 - Fix #8359: Display user sub name on invite after space creating
 - Fix #8361: Prevent non-creators from attaching or deleting another user's unassigned file
 - Fix #8365: Encode deletion reason in comment and content deletion notifications
-- Fix #8375: Ensure space member role changes are limited to assignable roles
+- Fix #8376: Ensure space member role changes are limited to assignable roles
 
 1.18.4 (July 21, 2026)
 ----------------------

--- a/MIGRATE-DEV.md
+++ b/MIGRATE-DEV.md
@@ -5,8 +5,8 @@ Version 1.18.5
 ------------
 
 ### Changed
-- `Space::getUserGroup()` reports memberships whose stored group is not one of `admin`, `moderator` or `member` as `member` ([see PR #8375](https://github.com/humhub/humhub/pull/8375))
-- User groups not known to the content container no longer satisfy non-strict `userGroup` access rules in `UserGroupAccessValidator`. Custom content containers defining additional user groups have to extend `$spaceGroupLevel` / `$profileGroupLevel` ([see PR #8375](https://github.com/humhub/humhub/pull/8375))
+- `Space::getUserGroup()` reports memberships whose stored group is not one of `admin`, `moderator` or `member` as `member` ([see PR #8376](https://github.com/humhub/humhub/pull/8376))
+- User groups not known to the content container no longer satisfy non-strict `userGroup` access rules in `UserGroupAccessValidator`. Custom content containers defining additional user groups have to extend `$spaceGroupLevel` / `$profileGroupLevel` ([see PR #8376](https://github.com/humhub/humhub/pull/8376))
 
 ### New
 - `Membership::SCENARIO_EDIT_ROLE` limiting mass assignment to `group_id` when editing the role of an existing space membership

--- a/MIGRATE-DEV.md
+++ b/MIGRATE-DEV.md
@@ -1,6 +1,18 @@
 Module Migration Guide
 ======================
 
+Version 1.18.5
+------------
+
+### Changed
+- `Space::getUserGroup()` reports memberships whose stored group is not one of `admin`, `moderator` or `member` as `member` ([see PR #8375](https://github.com/humhub/humhub/pull/8375))
+- User groups not known to the content container no longer satisfy non-strict `userGroup` access rules in `UserGroupAccessValidator`. Custom content containers defining additional user groups have to extend `$spaceGroupLevel` / `$profileGroupLevel` ([see PR #8375](https://github.com/humhub/humhub/pull/8375))
+
+### New
+- `Membership::SCENARIO_EDIT_ROLE` limiting mass assignment to `group_id` when editing the role of an existing space membership
+- `Membership::getAssignableUserGroups()` returning the space user groups a membership can be assigned to
+- `UserGroupAccessValidator::getUserGroupLevels()` returning the known user groups of the current content container
+
 Version 1.18.3
 ------------
 

--- a/protected/humhub/modules/content/components/UserGroupAccessValidator.php
+++ b/protected/humhub/modules/content/components/UserGroupAccessValidator.php
@@ -58,6 +58,12 @@ class UserGroupAccessValidator extends ActionAccessValidator
                 return in_array($userGroup, $allowedGroups);
             }
 
+            // getUserGroupLevel() ranks unknown groups highest, which is intended for the
+            // allowed groups of a rule but must never grant access to an unknown user group.
+            if (!in_array($userGroup, $this->getUserGroupLevels(), true)) {
+                return false;
+            }
+
             foreach ($allowedGroups as $allowedUserGroup) {
                 if ($this->getUserGroupLevel($userGroup) >= $this->getUserGroupLevel($allowedUserGroup)) {
                     return true;
@@ -88,13 +94,24 @@ class UserGroupAccessValidator extends ActionAccessValidator
 
     public function getUserGroupLevel($userGroup)
     {
-        $userGroupLevelArr = ($this->contentContainer instanceof Space) ? $this->spaceGroupLevel : $this->profileGroupLevel;
+        $userGroupLevelArr = $this->getUserGroupLevels();
 
         if (!in_array($userGroup, $userGroupLevelArr)) {
             return PHP_INT_MAX;
         }
 
         return array_search($userGroup, $userGroupLevelArr);
+    }
+
+    /**
+     * Returns the known user groups of the current content container, ordered by level.
+     *
+     * @return string[]
+     * @since 1.18.5
+     */
+    public function getUserGroupLevels(): array
+    {
+        return ($this->contentContainer instanceof Space) ? $this->spaceGroupLevel : $this->profileGroupLevel;
     }
 
     protected function extractActions($rule)

--- a/protected/humhub/modules/space/models/Membership.php
+++ b/protected/humhub/modules/space/models/Membership.php
@@ -60,6 +60,13 @@ class Membership extends ActiveRecord
     public const STATUS_APPLICANT = 2;
     public const STATUS_MEMBER = 3;
 
+    /**
+     * Scenario used when only the space user group (role) of an existing membership is edited.
+     *
+     * @since 1.18.5
+     */
+    public const SCENARIO_EDIT_ROLE = 'editRole';
+
     public const USER_SPACES_CACHE_KEY = 'userSpaces_';
     public const USER_SPACEIDS_CACHE_KEY = 'userSpaceIds_';
 
@@ -73,6 +80,25 @@ class Membership extends ActiveRecord
     }
 
     /**
+     * Returns the space user groups a membership can be assigned to.
+     *
+     * The owner group is not included on purpose: it is derived from the space creator and can
+     * only be changed through the dedicated change owner workflow. The guest and user groups
+     * describe non members and are therefore not assignable either.
+     *
+     * @return string[]
+     * @since 1.18.5
+     */
+    public static function getAssignableUserGroups(): array
+    {
+        return [
+            Space::USERGROUP_ADMIN,
+            Space::USERGROUP_MODERATOR,
+            Space::USERGROUP_MEMBER,
+        ];
+    }
+
+    /**
      * @inheritdoc
      */
     public function rules()
@@ -82,7 +108,21 @@ class Membership extends ActiveRecord
             [['space_id', 'user_id', 'originator_user_id', 'status', 'created_by', 'updated_by'], 'integer'],
             [['request_message'], 'string'],
             [['last_visit', 'created_at', 'group_id', 'updated_at'], 'safe'],
+            [['group_id'], 'in', 'range' => static::getAssignableUserGroups(), 'on' => self::SCENARIO_EDIT_ROLE],
         ];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function scenarios()
+    {
+        $scenarios = parent::scenarios();
+
+        // Only the role itself may be set when editing the role of an existing membership.
+        $scenarios[self::SCENARIO_EDIT_ROLE] = ['group_id'];
+
+        return $scenarios;
     }
 
     /**

--- a/protected/humhub/modules/space/models/Space.php
+++ b/protected/humhub/modules/space/models/Space.php
@@ -595,6 +595,13 @@ class Space extends ContentContainerActiveRecord
             if ($this->isSpaceOwner($user->id)) {
                 return self::USERGROUP_OWNER;
             }
+
+            // A stored role which is not assignable must not grant more than a plain member,
+            // so that legacy or manipulated records cannot pass elevated role checks.
+            if (!in_array($membership->group_id, Membership::getAssignableUserGroups(), true)) {
+                return self::USERGROUP_MEMBER;
+            }
+
             return $membership->group_id;
         } else {
             return self::USERGROUP_USER;

--- a/protected/humhub/modules/space/modules/manage/controllers/MemberController.php
+++ b/protected/humhub/modules/space/modules/manage/controllers/MemberController.php
@@ -66,6 +66,14 @@ class MemberController extends Controller
                 throw new HttpException(404, 'Could not find membership!');
             }
 
+            // The owner role follows the space creator and is only changeable via change-owner.
+            if ($space->isSpaceOwner($membership->user_id)) {
+                throw new HttpException(403, 'The role of the space owner cannot be changed!');
+            }
+
+            // Restrict this endpoint to the role itself, see Membership::scenarios().
+            $membership->scenario = Membership::SCENARIO_EDIT_ROLE;
+
             if ($membership->load(Yii::$app->request->post()) && $membership->save()) {
 
                 ChangedRolesMembership::instance()

--- a/protected/humhub/modules/space/tests/codeception/functional/MemberRoleChangeCest.php
+++ b/protected/humhub/modules/space/tests/codeception/functional/MemberRoleChangeCest.php
@@ -1,0 +1,145 @@
+<?php
+
+/**
+ * @link https://www.humhub.org/
+ * @copyright Copyright (c) 2017 HumHub GmbH & Co. KG
+ * @license https://www.humhub.com/licences
+ */
+
+namespace humhub\modules\space\tests\codeception\functional;
+
+use FunctionalTester;
+use humhub\modules\space\models\Space;
+use PHPUnit\Framework\Assert;
+use Yii;
+
+/**
+ * Ensures the member role dropdown of the space member administration only assigns
+ * roles a space admin is allowed to assign.
+ *
+ * Space 4 fixture: created_by = 1, so Admin is the space owner.
+ * Memberships of space 4: user 1 (Admin) admin, user 2 (User1) admin, user 3 (User2) member.
+ * User1 is therefore a space admin without being the space owner.
+ */
+class MemberRoleChangeCest
+{
+    private const SPACE_ID = 4;
+    private const SPACE_ADMIN_ID = 2; // User1
+    private const SPACE_OWNER_ID = 1; // Admin
+
+    private function groupIdOf(int $userId, int $spaceId = self::SPACE_ID): ?string
+    {
+        return Yii::$app->db->createCommand(
+            'SELECT group_id FROM space_membership WHERE space_id = :s AND user_id = :u',
+            [':s' => $spaceId, ':u' => $userId],
+        )->queryScalar() ?: null;
+    }
+
+    private function submitRoleChange(FunctionalTester $I, int $userId, array $membership): void
+    {
+        $I->amOnSpace(self::SPACE_ID, '/space/manage/member', [], [
+            'dropDownColumnSubmit' => 1,
+            'user_id' => $userId,
+            'Membership' => $membership,
+        ]);
+    }
+
+    public function testSpaceAdminCanAssignRegularRoles(FunctionalTester $I)
+    {
+        $I->wantTo('ensure a space admin can still change a member role through the dropdown');
+
+        $I->amUser('User1');
+        $this->submitRoleChange($I, 3, ['group_id' => Space::USERGROUP_MODERATOR]);
+        $I->seeResponseCodeIs(200);
+
+        Assert::assertSame(Space::USERGROUP_MODERATOR, $this->groupIdOf(3));
+    }
+
+    public function testOwnerRoleIsNotAssignable(FunctionalTester $I)
+    {
+        $I->wantTo('ensure the owner role cannot be assigned through the dropdown');
+
+        $I->amUser('User1');
+        $this->submitRoleChange($I, self::SPACE_ADMIN_ID, ['group_id' => Space::USERGROUP_OWNER]);
+
+        Assert::assertSame(Space::USERGROUP_ADMIN, $this->groupIdOf(self::SPACE_ADMIN_ID));
+    }
+
+    public function testUnknownRoleIsNotAssignable(FunctionalTester $I)
+    {
+        $I->wantTo('ensure an unknown role cannot be assigned through the dropdown');
+
+        $I->amUser('User1');
+        $this->submitRoleChange($I, self::SPACE_ADMIN_ID, ['group_id' => 'notarole']);
+
+        Assert::assertSame(Space::USERGROUP_ADMIN, $this->groupIdOf(self::SPACE_ADMIN_ID));
+    }
+
+    public function testMembershipCannotBeMovedToAnotherSpace(FunctionalTester $I)
+    {
+        $I->wantTo('ensure the dropdown cannot repoint a membership to another space or user');
+
+        Assert::assertNull($this->groupIdOf(self::SPACE_ADMIN_ID, 1), 'precondition: no membership in space 1');
+
+        $I->amUser('User1');
+        $this->submitRoleChange($I, self::SPACE_ADMIN_ID, [
+            'space_id' => 1,
+            'user_id' => self::SPACE_ADMIN_ID,
+            'group_id' => Space::USERGROUP_ADMIN,
+        ]);
+
+        Assert::assertNull($this->groupIdOf(self::SPACE_ADMIN_ID, 1), 'no membership must be created in space 1');
+        Assert::assertSame(Space::USERGROUP_ADMIN, $this->groupIdOf(self::SPACE_ADMIN_ID));
+    }
+
+    public function testOwnerMembershipCannotBeChanged(FunctionalTester $I)
+    {
+        $I->wantTo('ensure the role of the space owner cannot be changed through the dropdown');
+
+        $I->amUser('User1');
+        $this->submitRoleChange($I, self::SPACE_OWNER_ID, ['group_id' => Space::USERGROUP_MEMBER]);
+        $I->seeResponseCodeIs(403);
+
+        Assert::assertSame(Space::USERGROUP_ADMIN, $this->groupIdOf(self::SPACE_OWNER_ID));
+    }
+
+    public function testStoredOwnerRoleDoesNotGrantOwnerActions(FunctionalTester $I)
+    {
+        $I->wantTo('ensure an already stored owner role does not pass owner only checks');
+
+        Yii::$app->db->createCommand()
+            ->update(
+                'space_membership',
+                ['group_id' => Space::USERGROUP_OWNER],
+                ['space_id' => self::SPACE_ID, 'user_id' => self::SPACE_ADMIN_ID],
+            )->execute();
+
+        $I->amUser('User1');
+        $I->amOnSpace(self::SPACE_ID, '/space/manage/member/change-owner');
+        $I->dontSeeResponseCodeIs(200);
+        $I->amOnSpace(self::SPACE_ID, '/space/manage/default/delete');
+        $I->dontSeeResponseCodeIs(200);
+    }
+
+    public function testStoredUnknownRoleDoesNotGrantOwnerActions(FunctionalTester $I)
+    {
+        $I->wantTo('ensure an already stored unknown role does not pass owner only checks');
+
+        Yii::$app->db->createCommand()
+            ->update(
+                'space_membership',
+                ['group_id' => 'notarole'],
+                ['space_id' => self::SPACE_ID, 'user_id' => self::SPACE_ADMIN_ID],
+            )->execute();
+
+        $I->amUser('User1');
+        $I->amOnSpace(self::SPACE_ID, '/space/manage/member/change-owner');
+        $I->dontSeeResponseCodeIs(200);
+        $I->amOnSpace(self::SPACE_ID, '/space/manage/default/delete');
+        $I->dontSeeResponseCodeIs(200);
+
+        // The manipulated role must not keep the space admin rights either.
+        $I->amOnSpace(self::SPACE_ID, '/space/manage/member');
+        $I->dontSeeResponseCodeIs(200);
+    }
+}


### PR DESCRIPTION
Validates the space user group (role) written by the member administration role dropdown, and makes the container access check reject roles it does not know.

Details: humhub/humhub-internal#1315 (private).

### Changes

- `space\models\Membership`: adds `SCENARIO_EDIT_ROLE`, whose only active attribute is `group_id`, and restricts `group_id` to `getAssignableUserGroups()` (`admin`, `moderator`, `member`) in that scenario. The owner role is not assignable: it is derived from `space.created_by` and changed through `member/change-owner`.
- `space\modules\manage\controllers\MemberController::actionIndex()`: applies that scenario to the role dropdown request, so it can only set the role of the membership it looked up, and rejects a request targeting the space owner's membership with 403. The dropdown already excluded that row via `readonly`.
- `space\models\Space::getUserGroup()`: a stored role outside the assignable set is reported as `member`, so records holding an unexpected value cannot pass elevated role checks.
- `content\components\UserGroupAccessValidator`: a user group that is not part of the container's known groups no longer satisfies a non-strict `userGroup` rule. `getUserGroupLevel()` keeps its current return contract, so an unknown group listed in a rule's allowed groups still denies access.

### Compatibility

No migration, no schema change. Assigning member, moderator and admin through the dropdown is unchanged, as is `Space::addMember()` with an explicit group. New public API: `Membership::SCENARIO_EDIT_ROLE`, `Membership::getAssignableUserGroups()`, `UserGroupAccessValidator::getUserGroupLevels()`.

Custom content containers that define user groups beyond those in `UserGroupAccessValidator::$spaceGroupLevel` / `$profileGroupLevel` now get no access from non-strict `userGroup` rules instead of full access. Both behaviour changes and the new API are noted in `MIGRATE-DEV.md`.

### Tests

New `space/tests/codeception/functional/MemberRoleChangeCest.php` (7 tests) covers assigning a regular role, the non-assignable and unknown role cases, the space owner's membership, and that a stored unexpected role grants no elevated access.
