### PR TITLE
Ensure marketplace module metadata is encoded in administration views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ HumHub Changelog
 - Fix #8359: Display user sub name on invite after space creating
 - Fix #8361: Prevent non-creators from attaching or deleting another user's unassigned file
 - Fix #8365: Encode deletion reason in comment and content deletion notifications
-- Fix #XXXX: Ensure marketplace module metadata is rendered as encoded text in the administration views
+- Fix #8378: Ensure marketplace module metadata is rendered as encoded text in the administration views
 
 1.18.4 (July 21, 2026)
 ----------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ HumHub Changelog
 - Fix #8359: Display user sub name on invite after space creating
 - Fix #8361: Prevent non-creators from attaching or deleting another user's unassigned file
 - Fix #8365: Encode deletion reason in comment and content deletion notifications
+- Fix #XXXX: Ensure marketplace module metadata is rendered as encoded text in the administration views
 
 1.18.4 (July 21, 2026)
 ----------------------

--- a/protected/humhub/modules/marketplace/models/Module.php
+++ b/protected/humhub/modules/marketplace/models/Module.php
@@ -240,10 +240,17 @@ class Module extends Model
         return new FilterService($this);
     }
 
-    public function marketplaceLink(string $text): Link
+    /**
+     * Builds a link to the module's marketplace page.
+     *
+     * Module metadata originates from the remote marketplace API and is therefore
+     * untrusted. The label is encoded by default; pass $encode = false only when
+     * $text is already safe markup generated locally (e.g. Html::img()).
+     */
+    public function marketplaceLink(string $text, bool $encode = true): Link
     {
         return Link::asLink($text, $this->marketplaceUrl)
-            ->encodeLabel(false)
+            ->encodeLabel($encode)
             ->blank();
     }
 }

--- a/protected/humhub/modules/marketplace/views/purchase/list.php
+++ b/protected/humhub/modules/marketplace/views/purchase/list.php
@@ -57,19 +57,19 @@ Assets::register($this);
                 <div class="flex-shrink-0 me-2">
                     <img class="rounded me-3" data-src="holder.js/64x64" alt="64x64"
                          style="width: 64px; height: 64px;"
-                         src="<?= empty($module['moduleImageUrl']) ? Yii::getAlias('@web-static/img/default_module.jpg') : $module['moduleImageUrl'] ?>">
+                         src="<?= Html::encode(empty($module['moduleImageUrl']) ? Yii::getAlias('@web-static/img/default_module.jpg') : $module['moduleImageUrl']) ?>">
                 </div>
 
                 <div class="flex-grow-1">
                     <h5 class="mt-0">
                         <strong>
-                            <?= $module['name'] ?>
+                            <?= Html::encode($module['name']) ?>
                             <?php if (Yii::$app->moduleManager->hasModule($module['id'])): ?>
                                 <small><?= Badge::info(Yii::t('MarketplaceModule.base', 'Installed')) ?></small>
                             <?php endif; ?>
                         </strong>
                     </h5>
-                    <p><?= $module['description']; ?></p>
+                    <p><?= Html::encode($module['description']); ?></p>
 
                     <div class="module-controls">
                         <?php if (!Yii::$app->moduleManager->hasModule($module['id'])): ?>
@@ -79,8 +79,8 @@ Assets::register($this);
                             &middot;
                         <?php endif; ?>
                         <?= Html::a(Yii::t('MarketplaceModule.base', 'More info'), $module['marketplaceUrl'], ['target' => '_blank']); ?>
-                        &middot; <?= Yii::t('MarketplaceModule.base', 'Latest version:'); ?> <?= $module['latestVersion']; ?>
-                        &middot; <?= Yii::t('MarketplaceModule.base', 'License Key:'); ?> <?= $module['licence_key']; ?>
+                        &middot; <?= Yii::t('MarketplaceModule.base', 'Latest version:'); ?> <?= Html::encode($module['latestVersion']); ?>
+                        &middot; <?= Yii::t('MarketplaceModule.base', 'License Key:'); ?> <?= Html::encode($module['licence_key']); ?>
                     </div>
                 </div>
             </div>

--- a/protected/humhub/modules/marketplace/widgets/views/module-installed-card.php
+++ b/protected/humhub/modules/marketplace/widgets/views/module-installed-card.php
@@ -22,7 +22,7 @@ use humhub\modules\ui\icon\widgets\Icon;
             'data-src' => 'holder.js/94x94',
             'alt' => '94x94',
             'style' => 'width:94px;height:94px',
-        ])) ?>
+        ]), false) ?>
         <?= ModuleControls::widget(['module' => $module]) ?>
     </div>
     <div class="card-body">

--- a/protected/humhub/modules/marketplace/widgets/views/module-uninstalled-card.php
+++ b/protected/humhub/modules/marketplace/widgets/views/module-uninstalled-card.php
@@ -22,13 +22,13 @@ use humhub\modules\ui\icon\widgets\Icon;
             'data-src' => 'holder.js/94x94',
             'alt' => '94x94',
             'style' => 'width:94px;height:94px',
-        ])) ?>
+        ]), false) ?>
         <?= ModuleControls::widget(['module' => $module]) ?>
     </div>
     <div class="card-body">
         <div
             class="card-title"><?= $module->marketplaceLink($module->name) . ($module->featured ? ' ' . Icon::get('star')->color('info') : '') ?></div>
-        <div><?= $module->latestVersion ?></div>
+        <div><?= Html::encode($module->latestVersion) ?></div>
         <div><?= $module->marketplaceLink($module->description) ?></div>
     </div>
     <?= ModuleActionButtons::widget(['module' => $module]) ?>

--- a/protected/humhub/modules/marketplace/widgets/views/module-update-card.php
+++ b/protected/humhub/modules/marketplace/widgets/views/module-update-card.php
@@ -26,9 +26,9 @@ Assets::register($this);
         ]) ?>
     </div>
     <div class="card-body">
-        <div class="card-title"><?= $module->name ?></div>
-        <div><?= Yii::$app->moduleManager->getModule($module->id)->getVersion() ?>
-            → <?= $module->latestCompatibleVersion ?></div>
+        <div class="card-title"><?= Html::encode($module->name) ?></div>
+        <div><?= Html::encode(Yii::$app->moduleManager->getModule($module->id)->getVersion()) ?>
+            → <?= Html::encode($module->latestCompatibleVersion) ?></div>
     </div>
     <?= ModuleUpdateActionButtons::widget(['module' => $module]) ?>
 </div>


### PR DESCRIPTION
Module metadata returned by the marketplace API (name, description, versions,
image URL, license key) was rendered into the administration views without HTML
encoding. This change treats that metadata as untrusted input and encodes it at
every output sink.

Internal issue: [humhub-internal#1317](https://github.com/humhub/humhub-internal/issues/1317)

### Changes

- `models/Module.php`: `marketplaceLink()` now encodes its label by default and
  takes a new `bool $encode = true` parameter. The label is the anchor's inner
  content, so the flag is only disabled where that content is locally generated
  markup.
- `widgets/views/module-installed-card.php`, `module-uninstalled-card.php`:
  pass `false` for the `Html::img()` logo link (safe markup, URL already encoded
  by `Html::img()`); `latestVersion` is now encoded. `name` and `description`
  are covered by the new default.
- `widgets/views/module-update-card.php`: encode `name` and the displayed
  versions.
- `views/purchase/list.php`: encode `moduleImageUrl` (attribute context),
  `name`, `description`, `latestVersion` and `licence_key`.

Locally sourced values (installed module version, module id, installation id)
are unchanged.

### Compatibility

`Module::marketplaceLink()` is public and its default output changes from raw to
encoded. No core caller relies on the previous behaviour; external callers that
pass ready-made markup need to opt out with `$encode = false`.

### Testing

Verified against a mocked marketplace API response: metadata renders as text in
both the browse cards and the purchase list, while module logos and marketplace
links render unchanged.
