### PR TITLE
Ensure request supplied membership button options stay inert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ HumHub Changelog
 - Fix #8365: Encode deletion reason in comment and content deletion notifications
 - Fix #8374: Ensure adding group members is restricted to groups the current user manages
 - Fix #8373: Ensure the oEmbed consent prompt encodes the requested URL so embedded markup stays inert
-- Fix #XXXX: Ensure membership button options supplied by the request are limited to presentation values and safely encoded in the response
+- Fix #8379: Ensure membership button options supplied by the request are limited to presentation values and safely encoded in the response
 
 1.18.4 (July 21, 2026)
 ----------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ HumHub Changelog
 - Fix #8365: Encode deletion reason in comment and content deletion notifications
 - Fix #8374: Ensure adding group members is restricted to groups the current user manages
 - Fix #8373: Ensure the oEmbed consent prompt encodes the requested URL so embedded markup stays inert
+- Fix #XXXX: Ensure membership button options supplied by the request are limited to presentation values and safely encoded in the response
 
 1.18.4 (July 21, 2026)
 ----------------------

--- a/protected/humhub/modules/space/controllers/MembershipController.php
+++ b/protected/humhub/modules/space/controllers/MembershipController.php
@@ -24,7 +24,6 @@ use humhub\widgets\modal\ModalClose;
 use Throwable;
 use Yii;
 use yii\base\InvalidConfigException;
-use yii\helpers\Json;
 use yii\web\ForbiddenHttpException;
 use yii\web\HttpException;
 use yii\web\Response;
@@ -137,7 +136,7 @@ class MembershipController extends ContentContainerController
                 'spaceId' => $space->id,
                 'newMembershipButton' => MembershipButton::widget([
                     'space' => $space,
-                    'options' => empty($model->options) ? [] : Json::decode($model->options),
+                    'options' => MembershipButton::sanitizeRequestOptions($model->options),
                 ]),
             ]);
         }
@@ -328,7 +327,7 @@ class MembershipController extends ContentContainerController
     protected function getActionResult(Space $space)
     {
         if ($this->request->isAjax && !Yii::$app->request->get('redirect', false)) {
-            $options = $this->request->post('options', []);
+            $options = MembershipButton::sanitizeRequestOptions($this->request->post('options', []));
 
             // Show/Hide the "Follow"/"Unfollow" buttons depending on updated membership state after AJAX action
             if ($space->isMember()) {

--- a/protected/humhub/modules/space/tests/codeception/unit/RequestMembershipSaveViewTest.php
+++ b/protected/humhub/modules/space/tests/codeception/unit/RequestMembershipSaveViewTest.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace tests\codeception\unit\modules\space;
+
+use humhub\modules\space\models\Membership;
+use humhub\modules\space\models\Space;
+use humhub\modules\space\widgets\MembershipButton;
+use tests\codeception\_support\HumHubDbTestCase;
+use Yii;
+use yii\helpers\Json;
+
+/**
+ * Ensures request supplied membership button options stay inert when the membership
+ * button is re-rendered after a membership request (see security report #1318).
+ */
+class RequestMembershipSaveViewTest extends HumHubDbTestCase
+{
+    /**
+     * Options which must never be taken over from the request, since the rendered
+     * button is inserted as markup by the client.
+     */
+    public function testUnsafeRequestOptionsAreDiscarded()
+    {
+        $payloads = [
+            // Breaks out of the JavaScript string literal in requestMembershipSave.php
+            '{"cancelPendingMembership":{"title":"\');alert(1);//"}}',
+            // Injects markup into the button content
+            '{"cancelPendingMembership":{"title":"<img src=x onerror=alert(1)>"}}',
+            // Injects markup which the client renders as confirm dialog body
+            '{"cancelPendingMembership":{"attrs":{"data-action-confirm":"<img src=x onerror=alert(1)>"}}}',
+            // Redirects the button action to a foreign target
+            '{"becomeMember":{"attrs":{"data-action-url":"https://evil.tld/x"}}}',
+            '{"cancelMembership":{"url":"javascript:alert(1)"}}',
+            // Unknown buttons are not configurable at all
+            '{"evilButton":{"mode":"link"}}',
+        ];
+
+        foreach ($payloads as $payload) {
+            $this->assertSame([], MembershipButton::sanitizeRequestOptions($payload), $payload);
+        }
+    }
+
+    /**
+     * Malformed or unexpected input must not raise an error.
+     */
+    public function testInvalidRequestOptionsAreIgnored()
+    {
+        $this->assertSame([], MembershipButton::sanitizeRequestOptions('{not json'));
+        $this->assertSame([], MembershipButton::sanitizeRequestOptions('"scalar"'));
+        $this->assertSame([], MembershipButton::sanitizeRequestOptions(''));
+        $this->assertSame([], MembershipButton::sanitizeRequestOptions(null));
+        $this->assertSame([], MembershipButton::sanitizeRequestOptions(['becomeMember' => 'not-an-array']));
+    }
+
+    /**
+     * The presentation options used by the space header and the space directory must
+     * still survive the round trip through the request.
+     */
+    public function testPresentationRequestOptionsArePreserved()
+    {
+        $this->assertSame(
+            ['becomeMember' => ['mode' => 'link'], 'acceptInvite' => ['mode' => 'link']],
+            MembershipButton::sanitizeRequestOptions('{"becomeMember":{"mode":"link"},"acceptInvite":{"mode":"link"}}'),
+        );
+
+        $this->assertSame(
+            [
+                'cancelMembership' => ['visible' => true, 'attrs' => ['class' => 'btn btn-sm btn-outline-accent']],
+                'acceptInvite' => ['togglerClass' => 'btn btn-accent btn-sm'],
+            ],
+            MembershipButton::sanitizeRequestOptions(
+                '{"cancelMembership":{"visible":true,"attrs":{"class":"btn btn-sm btn-outline-accent"}},'
+                . '"acceptInvite":{"togglerClass":"btn btn-accent btn-sm"}}',
+            ),
+        );
+
+        // A class value can not be used to inject further attributes
+        $this->assertSame(
+            ['becomeMember' => ['attrs' => ['class' => 'btn onmouseoveralert1 x']]],
+            MembershipButton::sanitizeRequestOptions('{"becomeMember":{"attrs":{"class":"btn\" onmouseover=alert(1) x=\""}}}'),
+        );
+    }
+
+    /**
+     * End to end check of the response which is rendered after a membership request:
+     * the payload must neither reach the button markup nor break out of the script.
+     */
+    public function testPendingMembershipButtonIsRenderedSafely()
+    {
+        $this->becomeUser('User1');
+
+        // Space 1 uses the application join policy, so requesting membership
+        // leaves the current user as an applicant with a pending button.
+        $space = Space::findOne(['id' => 1]);
+        $space->requestMembership(Yii::$app->user->id, 'Let me in!');
+
+        $membership = Membership::findMembership(1, Yii::$app->user->id);
+        $this->assertNotNull($membership);
+        $this->assertEquals(Membership::STATUS_APPLICANT, $membership->status);
+
+        $payload = "');alert('injected');//";
+        $buttonHtml = MembershipButton::widget([
+            'space' => $space,
+            'options' => MembershipButton::sanitizeRequestOptions(
+                Json::encode(['cancelPendingMembership' => ['title' => $payload]]),
+            ),
+        ]);
+
+        $this->assertStringNotContainsString($payload, $buttonHtml);
+
+        $script = Yii::$app->getView()->renderFile(
+            Yii::getAlias('@humhub/modules/space/views/membership/requestMembershipSave.php'),
+            ['spaceId' => $space->id, 'newMembershipButton' => $buttonHtml],
+        );
+
+        $this->assertStringNotContainsString($payload, $script);
+    }
+
+    /**
+     * Independent of the sanitized options, the save view must embed the button markup
+     * as an encoded JavaScript string literal, so neither a quote nor a closing script
+     * tag can terminate the surrounding context.
+     */
+    public function testSaveViewEncodesButtonMarkupForJavaScript()
+    {
+        $script = Yii::$app->getView()->renderFile(
+            Yii::getAlias('@humhub/modules/space/views/membership/requestMembershipSave.php'),
+            ['spaceId' => 1, 'newMembershipButton' => '<a title="\'">x</a></script>'],
+        );
+
+        // The markup is escaped, so the raw tags never reach the script context.
+        $this->assertStringNotContainsString('<a ', $script);
+        $this->assertStringNotContainsString('</a>', $script);
+        $this->assertStringContainsString('\\u003C', $script);
+        $this->assertStringContainsString('\\u0027', $script);
+
+        // Only the view's own closing tag remains.
+        $this->assertSame(1, substr_count($script, '</script>'));
+    }
+}

--- a/protected/humhub/modules/space/views/membership/requestMembershipSave.php
+++ b/protected/humhub/modules/space/views/membership/requestMembershipSave.php
@@ -3,6 +3,7 @@
 use humhub\helpers\Html;
 use humhub\widgets\modal\Modal;
 use humhub\widgets\modal\ModalButton;
+use yii\helpers\Json;
 
 /* @var $spaceId int */
 /* @var $newMembershipButton string */
@@ -18,5 +19,5 @@ use humhub\widgets\modal\ModalButton;
 <?php Modal::endDialog() ?>
 
 <script <?= Html::nonce() ?>>
-    $('[data-space-request-membership=<?= $spaceId ?>]').replaceWith('<?= $newMembershipButton ?>');
+    $('[data-space-request-membership=<?= (int) $spaceId ?>]').replaceWith(<?= Json::htmlEncode($newMembershipButton) ?>);
 </script>

--- a/protected/humhub/modules/space/widgets/MembershipButton.php
+++ b/protected/humhub/modules/space/widgets/MembershipButton.php
@@ -13,6 +13,7 @@ use humhub\helpers\Html;
 use humhub\modules\space\models\Space;
 use humhub\modules\ui\icon\widgets\Icon;
 use Yii;
+use yii\base\InvalidArgumentException;
 use yii\helpers\ArrayHelper;
 use yii\helpers\Json;
 
@@ -25,6 +26,27 @@ use yii\helpers\Json;
 class MembershipButton extends Widget
 {
     /**
+     * Buttons which may be configured by the request when the button is re-rendered
+     * after a membership change.
+     */
+    private const REQUEST_BUTTONS = [
+        'requestMembership',
+        'becomeMember',
+        'acceptInvite',
+        'declineInvite',
+        'cancelPendingMembership',
+        'cancelMembership',
+        'cannotCancelMembership',
+    ];
+
+    /**
+     * Presentation only options which may be supplied by the request. Everything else
+     * (titles, urls and action attributes) is server generated and must not be
+     * overridable, since the rendered button is inserted as markup by the client.
+     */
+    private const REQUEST_OPTIONS = ['mode', 'mode_method', 'visible', 'groupClass', 'togglerClass'];
+
+    /**
      * @var Space
      */
     public $space;
@@ -33,6 +55,72 @@ class MembershipButton extends Widget
      * @var array Options buttons
      */
     public $options = [];
+
+    /**
+     * Reduces request supplied button options to a set of harmless presentation options.
+     *
+     * @param mixed $options JSON encoded or already decoded button options
+     * @return array the sanitized options
+     * @since 1.18.5
+     */
+    public static function sanitizeRequestOptions($options): array
+    {
+        if (is_string($options)) {
+            try {
+                $options = Json::decode($options);
+            } catch (InvalidArgumentException $e) {
+                return [];
+            }
+        }
+
+        if (!is_array($options)) {
+            return [];
+        }
+
+        $sanitized = [];
+
+        foreach ($options as $button => $config) {
+            if (!in_array($button, self::REQUEST_BUTTONS, true) || !is_array($config)) {
+                continue;
+            }
+
+            foreach ($config as $option => $value) {
+                if (!in_array($option, self::REQUEST_OPTIONS, true)) {
+                    continue;
+                }
+
+                switch ($option) {
+                    case 'mode':
+                        if ($value === 'link') {
+                            $sanitized[$button][$option] = $value;
+                        }
+                        break;
+                    case 'mode_method':
+                        if (in_array($value, ['GET', 'POST'], true)) {
+                            $sanitized[$button][$option] = $value;
+                        }
+                        break;
+                    case 'visible':
+                        $sanitized[$button][$option] = (bool)$value;
+                        break;
+                    default:
+                        $sanitized[$button][$option] = static::sanitizeCssClass($value);
+                        break;
+                }
+            }
+
+            if (isset($config['attrs']['class'])) {
+                $sanitized[$button]['attrs']['class'] = static::sanitizeCssClass($config['attrs']['class']);
+            }
+        }
+
+        return $sanitized;
+    }
+
+    private static function sanitizeCssClass($value): string
+    {
+        return is_string($value) ? preg_replace('/[^\w \-]/', '', $value) : '';
+    }
 
     private function getDefaultOptions()
     {


### PR DESCRIPTION
See: https://github.com/humhub/humhub-internal/issues/1318

### Changes

- `MembershipButton::sanitizeRequestOptions()` (new): reduces request supplied options to known buttons and to the presentation options that actually need to survive the round trip (`mode`, `mode_method`, `visible`, `groupClass`, `togglerClass` and `attrs.class`, with class values reduced to `[\w \-]`). Titles, URLs and action attributes stay server generated. Accepts a JSON string or an already decoded array and returns an empty array for malformed, scalar or empty input, so a malformed value no longer surfaces as an uncaught exception.
- `MembershipController::actionRequestMembershipForm()`: passes the submitted options through `sanitizeRequestOptions()` instead of `Json::decode()`.
- `MembershipController::getActionResult()`: passes the posted options through `sanitizeRequestOptions()`. This is the second entry point into the same widget and is reachable from `revoke-membership`, `request-membership` and `invite-accept`.
- `views/membership/requestMembershipSave.php`: emits the button via `Json::htmlEncode()` rather than interpolating it into a quoted literal, so the value is safe both as a JavaScript string and inside the `<script>` element. `$spaceId` is cast to int.

### Behavior change

Option keys outside the presentation set are now dropped when they arrive from the request. Widget callers that pass options directly are unaffected. Third party code that relies on round tripping other option keys through the membership request would lose them, so a `MIGRATE-DEV.md` entry may be warranted.

### Tests

New `RequestMembershipSaveViewTest` (space unit suite), 5 tests: rejection of non presentation options, tolerance of malformed input, preservation of the presentation options used by the space header and the space directory, and the encoding in the save response.

- Space unit: 11/11 pass.
- Space functional: 14/14 pass.

Also verified against a running instance that the join flow is unchanged: the Pending button still renders with its icon, class set and confirm text, and the `mode => link` options set by `profileHeaderControls.php` still survive the round trip.
