### PR TITLE
Limit request supplied membership and friendship button options to presentation values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ HumHub Changelog
 - Fix #8365: Encode deletion reason in comment and content deletion notifications
 - Fix #8374: Ensure adding group members is restricted to groups the current user manages
 - Fix #8373: Ensure the oEmbed consent prompt encodes the requested URL so embedded markup stays inert
-- Fix #8379: Limit request supplied membership and friendship button options to presentation values, so titles, urls and action attributes stay server generated, and encode the membership button markup in the membership request response so it cannot break out of the script context
+- Fix #8381: Limit request supplied membership and friendship button options to presentation values, so titles, urls and action attributes stay server generated, and encode the membership button markup in the membership request response so it cannot break out of the script context
 
 1.18.4 (July 21, 2026)
 ----------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ HumHub Changelog
 - Fix #8365: Encode deletion reason in comment and content deletion notifications
 - Fix #8374: Ensure adding group members is restricted to groups the current user manages
 - Fix #8373: Ensure the oEmbed consent prompt encodes the requested URL so embedded markup stays inert
+- Fix #8379: Encode the membership button markup in the membership request response so it cannot break out of the script context
 
 1.18.4 (July 21, 2026)
 ----------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ HumHub Changelog
 - Fix #8365: Encode deletion reason in comment and content deletion notifications
 - Fix #8374: Ensure adding group members is restricted to groups the current user manages
 - Fix #8373: Ensure the oEmbed consent prompt encodes the requested URL so embedded markup stays inert
-- Fix #8379: Encode the membership button markup in the membership request response so it cannot break out of the script context
+- Fix #8379: Limit request supplied membership and friendship button options to presentation values, so titles, urls and action attributes stay server generated, and encode the membership button markup in the membership request response so it cannot break out of the script context
 
 1.18.4 (July 21, 2026)
 ----------------------

--- a/protected/humhub/modules/friendship/controllers/RequestController.php
+++ b/protected/humhub/modules/friendship/controllers/RequestController.php
@@ -95,7 +95,7 @@ class RequestController extends Controller
     protected function getActionResult(User $user)
     {
         if ($this->request->isAjax) {
-            $options = $this->request->post('options', []);
+            $options = FriendshipButton::sanitizeRequestOptions($this->request->post('options', []));
 
             // Show/Hide the "Follow"/"Unfollow" buttons depending on updated friendship state after AJAX action
             $options['cancelFriendRequest']['attrs']['data-show-buttons'] = $user->isFollowedByUser() ? '.unfollowButton' : '.followButton';

--- a/protected/humhub/modules/friendship/tests/codeception/unit/FriendshipButtonRequestOptionsTest.php
+++ b/protected/humhub/modules/friendship/tests/codeception/unit/FriendshipButtonRequestOptionsTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace tests\codeception\unit\modules\friendship;
+
+use humhub\modules\friendship\widgets\FriendshipButton;
+use humhub\modules\user\models\User;
+use tests\codeception\_support\HumHubDbTestCase;
+use Yii;
+use yii\helpers\Json;
+
+/**
+ * FriendshipButton has the same option round trip as MembershipButton: the button is
+ * re-rendered after a friendship change and `RequestController::getActionResult()` feeds the
+ * posted options straight into the widget. Unlike the membership path there is no query string
+ * entry point, so this is not reflected — it is closed together with the reported issue because
+ * it is the same unfiltered request-to-markup path (see security report #1318).
+ */
+class FriendshipButtonRequestOptionsTest extends HumHubDbTestCase
+{
+    /**
+     * Options which must never be taken over from the request.
+     */
+    public function testUnsafeRequestOptionsAreDiscarded()
+    {
+        $payloads = [
+            '{"friends":{"title":"<img src=x onerror=alert(1)>"}}',
+            '{"addFriend":{"attrs":{"data-action-confirm":"<img src=x onerror=alert(1)>"}}}',
+            '{"addFriend":{"attrs":{"data-action-url":"https://evil.tld/x"}}}',
+            '{"cancelFriendRequest":{"attrs":{"data-action-click":"evil.handler"}}}',
+            // Unknown buttons are not configurable at all
+            '{"evilButton":{"togglerClass":"btn"}}',
+        ];
+
+        foreach ($payloads as $payload) {
+            $this->assertSame([], FriendshipButton::sanitizeRequestOptions($payload), $payload);
+        }
+    }
+
+    /**
+     * Malformed or unexpected input must not raise an error.
+     */
+    public function testInvalidRequestOptionsAreIgnored()
+    {
+        $this->assertSame([], FriendshipButton::sanitizeRequestOptions('{not json'));
+        $this->assertSame([], FriendshipButton::sanitizeRequestOptions('"scalar"'));
+        $this->assertSame([], FriendshipButton::sanitizeRequestOptions(''));
+        $this->assertSame([], FriendshipButton::sanitizeRequestOptions(null));
+        $this->assertSame([], FriendshipButton::sanitizeRequestOptions(['addFriend' => 'not-an-array']));
+    }
+
+    /**
+     * The presentation options the people directory relies on must still survive the round trip.
+     */
+    public function testPresentationRequestOptionsArePreserved()
+    {
+        $this->assertSame(
+            [
+                'friends' => ['attrs' => ['class' => 'btn btn-sm btn-outline-accent']],
+                'acceptFriendRequest' => ['togglerClass' => 'btn btn-sm btn-outline-accent'],
+            ],
+            FriendshipButton::sanitizeRequestOptions(
+                '{"friends":{"attrs":{"class":"btn btn-sm btn-outline-accent"}},'
+                . '"acceptFriendRequest":{"togglerClass":"btn btn-sm btn-outline-accent"}}',
+            ),
+        );
+    }
+
+    /**
+     * A class value must not be usable to break out of the attribute.
+     */
+    public function testClassValuesCannotInjectAttributes()
+    {
+        $this->assertSame(
+            ['addFriend' => ['attrs' => ['class' => 'btn onmouseoveralert1 x']]],
+            FriendshipButton::sanitizeRequestOptions('{"addFriend":{"attrs":{"class":"btn\" onmouseover=alert(1) x=\""}}}'),
+        );
+    }
+
+    /**
+     * End to end: the presentation part still renders, the rest stays server generated.
+     */
+    public function testPayloadDoesNotReachTheRenderedButton()
+    {
+        Yii::$app->getModule('friendship')->settings->set('enable', 1);
+        // 'User2' is id 3, so id 2 is a different user and the button is visible.
+        $this->becomeUser('User2');
+
+        $options = FriendshipButton::sanitizeRequestOptions(Json::encode([
+            'addFriend' => [
+                // Legitimate presentation, has to survive
+                'attrs' => ['class' => 'btn btn-accent btn-sm'],
+                // Must be dropped
+                'title' => '<img src=x onerror=alert(1)>',
+                'url' => 'javascript:alert(1)',
+            ],
+        ]));
+
+        $html = FriendshipButton::widget([
+            'user' => User::findOne(['id' => 2]),
+            'options' => $options,
+        ]);
+
+        $this->assertNotSame('', trim($html));
+        $this->assertStringContainsString('btn-accent', $html);
+        $this->assertStringNotContainsString('onerror', $html);
+    }
+}

--- a/protected/humhub/modules/friendship/widgets/FriendshipButton.php
+++ b/protected/humhub/modules/friendship/widgets/FriendshipButton.php
@@ -12,6 +12,7 @@ use humhub\modules\friendship\models\Friendship;
 use humhub\modules\ui\icon\widgets\Icon;
 use humhub\modules\user\models\User;
 use Yii;
+use yii\base\InvalidArgumentException;
 use yii\base\Widget;
 use yii\helpers\ArrayHelper;
 use yii\helpers\Json;
@@ -25,6 +26,24 @@ use yii\helpers\Url;
 class FriendshipButton extends Widget
 {
     /**
+     * Buttons which may be addressed by request supplied options.
+     */
+    private const REQUEST_BUTTONS = [
+        'friends',
+        'addFriend',
+        'acceptFriendRequest',
+        'denyFriendRequest',
+        'cancelFriendRequest',
+    ];
+
+    /**
+     * Presentation only options which may be supplied by the request. Everything else —
+     * titles and all `data-action-*` attributes — is server generated and must not be
+     * overridable, since the rendered button is inserted as markup by the client.
+     */
+    private const REQUEST_OPTIONS = ['groupClass', 'togglerClass'];
+
+    /**
      * @var User the target user
      */
     public $user;
@@ -33,6 +52,57 @@ class FriendshipButton extends Widget
      * @var array Options buttons
      */
     public $options = [];
+
+    /**
+     * Reduces request supplied button options to a set of harmless presentation options.
+     *
+     * The button is re-rendered after a friendship change and has to keep the presentation of
+     * the context it was rendered in, so the options make a round trip through the client.
+     * Only the presentation state that actually needs to survive that round trip is accepted.
+     *
+     * @param mixed $options JSON encoded or already decoded button options
+     * @return array the sanitized options
+     * @since 1.18.5
+     */
+    public static function sanitizeRequestOptions($options): array
+    {
+        if (is_string($options)) {
+            try {
+                $options = Json::decode($options);
+            } catch (InvalidArgumentException $e) {
+                return [];
+            }
+        }
+
+        if (!is_array($options)) {
+            return [];
+        }
+
+        $sanitized = [];
+
+        foreach ($options as $button => $config) {
+            if (!in_array($button, self::REQUEST_BUTTONS, true) || !is_array($config)) {
+                continue;
+            }
+
+            foreach ($config as $option => $value) {
+                if (in_array($option, self::REQUEST_OPTIONS, true)) {
+                    $sanitized[$button][$option] = static::sanitizeCssClass($value);
+                }
+            }
+
+            if (isset($config['attrs']['class'])) {
+                $sanitized[$button]['attrs']['class'] = static::sanitizeCssClass($config['attrs']['class']);
+            }
+        }
+
+        return $sanitized;
+    }
+
+    private static function sanitizeCssClass($value): string
+    {
+        return is_string($value) ? preg_replace('/[^\w \-]/', '', $value) : '';
+    }
 
     private function getDefaultOptions()
     {

--- a/protected/humhub/modules/space/controllers/MembershipController.php
+++ b/protected/humhub/modules/space/controllers/MembershipController.php
@@ -24,7 +24,6 @@ use humhub\widgets\modal\ModalClose;
 use Throwable;
 use Yii;
 use yii\base\InvalidConfigException;
-use yii\helpers\Json;
 use yii\web\ForbiddenHttpException;
 use yii\web\HttpException;
 use yii\web\Response;
@@ -137,7 +136,7 @@ class MembershipController extends ContentContainerController
                 'spaceId' => $space->id,
                 'newMembershipButton' => MembershipButton::widget([
                     'space' => $space,
-                    'options' => empty($model->options) ? [] : Json::decode($model->options),
+                    'options' => MembershipButton::sanitizeRequestOptions($model->options),
                 ]),
             ]);
         }
@@ -328,7 +327,7 @@ class MembershipController extends ContentContainerController
     protected function getActionResult(Space $space)
     {
         if ($this->request->isAjax && !Yii::$app->request->get('redirect', false)) {
-            $options = $this->request->post('options', []);
+            $options = MembershipButton::sanitizeRequestOptions($this->request->post('options', []));
 
             // Show/Hide the "Follow"/"Unfollow" buttons depending on updated membership state after AJAX action
             if ($space->isMember()) {

--- a/protected/humhub/modules/space/tests/codeception/unit/MembershipButtonRequestOptionsTest.php
+++ b/protected/humhub/modules/space/tests/codeception/unit/MembershipButtonRequestOptionsTest.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace tests\codeception\unit\modules\space;
+
+use humhub\modules\space\models\Space;
+use humhub\modules\space\widgets\MembershipButton;
+use tests\codeception\_support\HumHubDbTestCase;
+use yii\helpers\Json;
+
+/**
+ * The membership button is re-rendered after a membership change and its options make a round
+ * trip through the client, so request supplied options must be reduced to presentation state
+ * before they reach the widget (see security report #1318).
+ */
+class MembershipButtonRequestOptionsTest extends HumHubDbTestCase
+{
+    /**
+     * Options which must never be taken over from the request, since the rendered button is
+     * inserted as markup by the client.
+     */
+    public function testUnsafeRequestOptionsAreDiscarded()
+    {
+        $payloads = [
+            // Breaks out of the JavaScript string literal in requestMembershipSave.php
+            '{"cancelPendingMembership":{"title":"\');alert(1);//"}}',
+            // Injects markup into the button content
+            '{"cancelPendingMembership":{"title":"<img src=x onerror=alert(1)>"}}',
+            // Injects markup which the client renders as confirm dialog body
+            '{"cancelPendingMembership":{"attrs":{"data-action-confirm":"<img src=x onerror=alert(1)>"}}}',
+            // Retargets the button action
+            '{"becomeMember":{"attrs":{"data-action-url":"https://evil.tld/x"}}}',
+            '{"cancelMembership":{"url":"javascript:alert(1)"}}',
+            // Suppresses the client side action handler
+            '{"becomeMember":{"attrs":{"data-action-click":"evil.handler"}}}',
+            // Unknown buttons are not configurable at all
+            '{"evilButton":{"mode":"link"}}',
+        ];
+
+        foreach ($payloads as $payload) {
+            $this->assertSame([], MembershipButton::sanitizeRequestOptions($payload), $payload);
+        }
+    }
+
+    /**
+     * Malformed or unexpected input must not raise an error. A malformed value used to surface
+     * as an uncaught exception from Json::decode().
+     */
+    public function testInvalidRequestOptionsAreIgnored()
+    {
+        $this->assertSame([], MembershipButton::sanitizeRequestOptions('{not json'));
+        $this->assertSame([], MembershipButton::sanitizeRequestOptions('"scalar"'));
+        $this->assertSame([], MembershipButton::sanitizeRequestOptions('42'));
+        $this->assertSame([], MembershipButton::sanitizeRequestOptions(''));
+        $this->assertSame([], MembershipButton::sanitizeRequestOptions(null));
+        $this->assertSame([], MembershipButton::sanitizeRequestOptions(0));
+        $this->assertSame([], MembershipButton::sanitizeRequestOptions(['becomeMember' => 'not-an-array']));
+    }
+
+    /**
+     * The presentation options the space header and the space directory rely on must still
+     * survive the round trip, otherwise the button loses its styling after an AJAX action.
+     */
+    public function testPresentationRequestOptionsArePreserved()
+    {
+        // profileHeaderControls.php
+        $this->assertSame(
+            ['becomeMember' => ['mode' => 'link'], 'acceptInvite' => ['mode' => 'link']],
+            MembershipButton::sanitizeRequestOptions('{"becomeMember":{"mode":"link"},"acceptInvite":{"mode":"link"}}'),
+        );
+
+        // SpaceDirectoryActionButtons
+        $this->assertSame(
+            [
+                'cancelMembership' => ['visible' => true, 'attrs' => ['class' => 'btn btn-sm btn-outline-accent']],
+                'acceptInvite' => ['togglerClass' => 'btn btn-accent btn-sm'],
+            ],
+            MembershipButton::sanitizeRequestOptions(
+                '{"cancelMembership":{"visible":true,"attrs":{"class":"btn btn-sm btn-outline-accent"}},'
+                . '"acceptInvite":{"togglerClass":"btn btn-accent btn-sm"}}',
+            ),
+        );
+    }
+
+    /**
+     * A class value must not be usable to break out of the attribute and inject further ones.
+     */
+    public function testClassValuesCannotInjectAttributes()
+    {
+        $this->assertSame(
+            ['becomeMember' => ['attrs' => ['class' => 'btn onmouseoveralert1 x']]],
+            MembershipButton::sanitizeRequestOptions('{"becomeMember":{"attrs":{"class":"btn\" onmouseover=alert(1) x=\""}}}'),
+        );
+    }
+
+    /**
+     * Only 'link' mode and the two known methods are accepted.
+     */
+    public function testModeValuesAreConstrained()
+    {
+        $this->assertSame([], MembershipButton::sanitizeRequestOptions('{"becomeMember":{"mode":"evil"}}'));
+        $this->assertSame([], MembershipButton::sanitizeRequestOptions('{"becomeMember":{"mode_method":"DELETE"}}'));
+        $this->assertSame(
+            ['becomeMember' => ['mode_method' => 'GET']],
+            MembershipButton::sanitizeRequestOptions('{"becomeMember":{"mode_method":"GET"}}'),
+        );
+    }
+
+    /**
+     * End to end: the presentation part of a mixed payload still renders the button, while the
+     * title, the action url and the confirm text stay server generated.
+     */
+    public function testPayloadDoesNotReachTheRenderedButton()
+    {
+        // 'User2' (id 3) is a member of Space 1, so the cancelMembership button applies once
+        // its presentation option makes it visible.
+        $this->becomeUser('User2');
+
+        $payload = "');alert('injected');//";
+        $options = MembershipButton::sanitizeRequestOptions(
+            Json::encode([
+                'cancelMembership' => [
+                    // Legitimate presentation, has to survive
+                    'visible' => true,
+                    'attrs' => ['class' => 'btn btn-sm btn-outline-accent'],
+                    // Must all be dropped
+                    'title' => $payload,
+                    'url' => 'javascript:alert(1)',
+                ],
+            ]),
+        );
+
+        $html = MembershipButton::widget([
+            'space' => Space::findOne(['id' => 1]),
+            'options' => $options,
+        ]);
+
+        // The presentation survived, so the button is actually rendered.
+        $this->assertNotSame('', trim($html));
+        $this->assertStringContainsString('btn-outline-accent', $html);
+
+        // Nothing attacker controlled reached the markup; the title is the server default.
+        $this->assertStringNotContainsString($payload, $html);
+        $this->assertStringNotContainsString('javascript:', $html);
+        $this->assertStringContainsString('revoke-membership', $html);
+    }
+}

--- a/protected/humhub/modules/space/tests/codeception/unit/RequestMembershipSaveViewTest.php
+++ b/protected/humhub/modules/space/tests/codeception/unit/RequestMembershipSaveViewTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace tests\codeception\unit\modules\space;
+
+use tests\codeception\_support\HumHubDbTestCase;
+use Yii;
+
+/**
+ * The membership request response replaces the membership button on the client. The
+ * rendered markup is handed to JavaScript, so it must be embedded as an encoded string
+ * literal instead of being interpolated into a quoted literal.
+ */
+class RequestMembershipSaveViewTest extends HumHubDbTestCase
+{
+    private function renderSaveView($spaceId, string $buttonHtml): string
+    {
+        return Yii::$app->getView()->renderFile(
+            Yii::getAlias('@humhub/modules/space/views/membership/requestMembershipSave.php'),
+            ['spaceId' => $spaceId, 'newMembershipButton' => $buttonHtml],
+        );
+    }
+
+    /**
+     * Returns the argument the save view passes to replaceWith(), as it appears in the source.
+     */
+    private function getReplaceWithArgument(string $script): string
+    {
+        $this->assertSame(1, preg_match('/\.replaceWith\((.*)\);/', $script, $matches));
+
+        return $matches[1];
+    }
+
+    /**
+     * Neither a quote nor a closing script tag may terminate the surrounding context.
+     */
+    public function testButtonMarkupIsEncodedForJavaScript()
+    {
+        $script = $this->renderSaveView(1, '<a title="\'">x</a></script><img src=x onerror=alert(1)>');
+        $argument = $this->getReplaceWithArgument($script);
+
+        // Angle brackets and quotes are hex escaped, so neither the string literal nor
+        // the script element can be terminated by the markup.
+        $this->assertStringNotContainsString('<', $argument);
+        $this->assertStringNotContainsString('>', $argument);
+        $this->assertStringNotContainsString("'", $argument);
+        $this->assertStringNotContainsString('"', substr($argument, 1, -1));
+    }
+
+    /**
+     * The button markup still arrives unchanged at replaceWith() once the JavaScript
+     * string literal is evaluated.
+     */
+    public function testEncodedButtonMarkupDecodesToTheOriginalMarkup()
+    {
+        $buttonHtml = '<a href="#" class="btn btn-accent active" title="Pending">Pending</a>';
+        $argument = $this->getReplaceWithArgument($this->renderSaveView(1, $buttonHtml));
+
+        $this->assertSame($buttonHtml, json_decode($argument, true));
+    }
+
+    /**
+     * The space id is interpolated into a selector and must always be numeric.
+     */
+    public function testSpaceIdIsCastToInt()
+    {
+        $script = $this->renderSaveView('1"]).x(', '');
+
+        $this->assertStringContainsString('[data-space-request-membership=1]', $script);
+        $this->assertStringNotContainsString('.x(', $script);
+    }
+}

--- a/protected/humhub/modules/space/views/membership/requestMembershipSave.php
+++ b/protected/humhub/modules/space/views/membership/requestMembershipSave.php
@@ -3,6 +3,7 @@
 use humhub\helpers\Html;
 use humhub\widgets\modal\Modal;
 use humhub\widgets\modal\ModalButton;
+use yii\helpers\Json;
 
 /* @var $spaceId int */
 /* @var $newMembershipButton string */
@@ -18,5 +19,5 @@ use humhub\widgets\modal\ModalButton;
 <?php Modal::endDialog() ?>
 
 <script <?= Html::nonce() ?>>
-    $('[data-space-request-membership=<?= $spaceId ?>]').replaceWith('<?= $newMembershipButton ?>');
+    $('[data-space-request-membership=<?= (int)$spaceId ?>]').replaceWith(<?= Json::htmlEncode($newMembershipButton) ?>);
 </script>

--- a/protected/humhub/modules/space/widgets/MembershipButton.php
+++ b/protected/humhub/modules/space/widgets/MembershipButton.php
@@ -13,6 +13,7 @@ use humhub\helpers\Html;
 use humhub\modules\space\models\Space;
 use humhub\modules\ui\icon\widgets\Icon;
 use Yii;
+use yii\base\InvalidArgumentException;
 use yii\helpers\ArrayHelper;
 use yii\helpers\Json;
 
@@ -25,6 +26,26 @@ use yii\helpers\Json;
 class MembershipButton extends Widget
 {
     /**
+     * Buttons which may be addressed by request supplied options.
+     */
+    private const REQUEST_BUTTONS = [
+        'requestMembership',
+        'becomeMember',
+        'acceptInvite',
+        'declineInvite',
+        'cancelPendingMembership',
+        'cancelMembership',
+        'cannotCancelMembership',
+    ];
+
+    /**
+     * Presentation only options which may be supplied by the request. Everything else —
+     * titles, urls and all `data-action-*` attributes — is server generated and must not be
+     * overridable, since the rendered button is inserted as markup by the client.
+     */
+    private const REQUEST_OPTIONS = ['mode', 'mode_method', 'visible', 'groupClass', 'togglerClass'];
+
+    /**
      * @var Space
      */
     public $space;
@@ -33,6 +54,76 @@ class MembershipButton extends Widget
      * @var array Options buttons
      */
     public $options = [];
+
+    /**
+     * Reduces request supplied button options to a set of harmless presentation options.
+     *
+     * The button is re-rendered after a membership change and has to keep the presentation of
+     * the context it was rendered in, so the options make a round trip through the client.
+     * Only the presentation state that actually needs to survive that round trip is accepted.
+     *
+     * @param mixed $options JSON encoded or already decoded button options
+     * @return array the sanitized options
+     * @since 1.18.5
+     */
+    public static function sanitizeRequestOptions($options): array
+    {
+        if (is_string($options)) {
+            try {
+                $options = Json::decode($options);
+            } catch (InvalidArgumentException $e) {
+                return [];
+            }
+        }
+
+        if (!is_array($options)) {
+            return [];
+        }
+
+        $sanitized = [];
+
+        foreach ($options as $button => $config) {
+            if (!in_array($button, self::REQUEST_BUTTONS, true) || !is_array($config)) {
+                continue;
+            }
+
+            foreach ($config as $option => $value) {
+                if (!in_array($option, self::REQUEST_OPTIONS, true)) {
+                    continue;
+                }
+
+                switch ($option) {
+                    case 'mode':
+                        if ($value === 'link') {
+                            $sanitized[$button][$option] = $value;
+                        }
+                        break;
+                    case 'mode_method':
+                        if (in_array($value, ['GET', 'POST'], true)) {
+                            $sanitized[$button][$option] = $value;
+                        }
+                        break;
+                    case 'visible':
+                        $sanitized[$button][$option] = (bool)$value;
+                        break;
+                    default:
+                        $sanitized[$button][$option] = static::sanitizeCssClass($value);
+                        break;
+                }
+            }
+
+            if (isset($config['attrs']['class'])) {
+                $sanitized[$button]['attrs']['class'] = static::sanitizeCssClass($config['attrs']['class']);
+            }
+        }
+
+        return $sanitized;
+    }
+
+    private static function sanitizeCssClass($value): string
+    {
+        return is_string($value) ? preg_replace('/[^\w \-]/', '', $value) : '';
+    }
 
     private function getDefaultOptions()
     {


### PR DESCRIPTION
Supersedes #8379 for the stable line. See humhub/humhub-internal#1318.

The membership and friendship buttons are re-rendered after a membership or friendship change, and their options make a round trip through the client via `data-button-options`. The request could therefore override any option, including the button `title` (rendered as raw anchor content by `Html::a()`), its `url`, and attributes such as `data-action-confirm` and `data-action-url`. The response is inserted as markup by the client.

### Changes

**Trust boundary.** New `MembershipButton::sanitizeRequestOptions()`, applied at both entry points that feed request data into the widget — `actionRequestMembershipForm()` and `getActionResult()`. The round trip only ever needs to carry presentation state: `profileHeaderControls.php` supplies `mode => link`, `SpaceDirectoryActionButtons` supplies `attrs.class`, `visible` and `togglerClass`. The method therefore accepts only known button keys and only `mode` (`link`), `mode_method` (`GET`/`POST`), `visible`, `groupClass`, `togglerClass` and `attrs.class`, with class values reduced to `[\w \-]`. Titles, urls and all `data-action-*` attributes are no longer overridable from the request. Malformed, scalar or empty input returns `[]`, which also removes an uncaught `Json::decode()` exception (HTTP 500).

**Same treatment for `FriendshipButton`**, applied in `RequestController::getActionResult()`. Its allowlist is narrower (`groupClass`, `togglerClass`, `attrs.class`) because that widget has no link mode. Note on severity: unlike the membership path this one has no query-string entry point, so it is not reflected — it requires a valid CSRF token and is self-inflicted only. It is included because it is the same unfiltered request-to-markup path.

**Sink, defense in depth.** `requestMembershipSave.php` emits the button via `Json::htmlEncode()` rather than interpolating it into a single-quoted JavaScript literal, and casts `$spaceId` to int. The `JSON_HEX_TAG|APOS|QUOT|AMP` flags make the value safe both as a JavaScript string and inside the `<script>` element, so neither a quote nor a `</script>` can terminate the surrounding context. This also fixes a plain bug: an apostrophe in a space name used to break the response.

Not encoding the title in `membershipButton.php` is deliberate — the default titles legitimately contain markup (`Icon::get(...)`), so a blanket `Html::encode()` would render the icons as text, and it would leave the `attrs` overrides untouched.

### Behavior change

Option keys outside the presentation set are dropped when they arrive from the request. Callers passing options directly to the widget are unaffected. Third-party code relying on round-tripping other option keys would lose them; 1.19 replaces this mechanism with named variants (see the `develop` PR).

### Tests

New `MembershipButtonRequestOptionsTest` (6) and `FriendshipButtonRequestOptionsTest` (7) covering option rejection, malformed input, preservation of the presentation options the core call sites use, class-value escaping, and an end-to-end render. New `RequestMembershipSaveViewTest` (3) covering the sink.

Space unit 15/15, space functional 14/14, friendship unit 7/7. php-cs-fixer clean.