### PR TITLE
Remove unreachable `ContentContainerControllerAccess::containerAccess` validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ HumHub Changelog
 - Fix #8364: The comment/reply "Attach Files" trigger is a non-focusable `<span>`; clicking it dropped focus without moving it anywhere, which instantly hid the upload/submit button row again since it is only shown via `:focus-within`/`:has()` (#8318) — before the click's own action could run, so opening the file picker either did nothing or made the row disappear while its dialog was open. The trigger now gets focus like the adjacent handler dropdown-toggle button via `tabindex`/`role="button"`, and is keyboard-operable via Enter/Space; the button row also stays visible once a file has been attached, not just once the message has text
 - Enh #8372: Private content and private spaces are now hidden while impersonating a user, and each impersonation is logged — both configurable via the new `Yii::$app->user->impersonation` component; the impersonation state now fails closed (no auto-login cookie for the impersonated identity, only the impersonator's id in the session)
 - Fix #8371: Fix mixed param type nullable by default in `ForceExplicitNullableParamRector`
+- Fix #8383: Removed the unreachable `ContentContainerControllerAccess::RULE_CONTAINER_ACCESS` validator (`validateContainerAccess()`, `canAccessSpace()`, `getSpaceMembership()`, `canAccessUser()`) — the rule was never added to any access rule set, so it never ran; the space/profile visibility checks it duplicated are already enforced by the container controller behaviors
 
 1.19.0-beta.1 (July 21, 2026)
 --------------------

--- a/docs/develop/module-migrate.md
+++ b/docs/develop/module-migrate.md
@@ -343,6 +343,16 @@ Each minor release line has its own file with the breaking changes, new APIs and
     receives an auto-login cookie, only the impersonator's user id is stored in the session (no serialized
     record anymore), and ending an impersonation whose impersonator can no longer be resolved logs the
     session out instead of silently continuing as the impersonated user.
+- Removed the unreachable `ContentContainerControllerAccess::RULE_CONTAINER_ACCESS`
+  (`'containerAccess'`) rule and its validator `validateContainerAccess()`, along with the
+  private helpers it alone used (`canAccessSpace()`, `getSpaceMembership()`, `canAccessUser()`,
+  the `$_membership` property). The rule was registered but never added to any
+  `getAccessRules()`/`getFixedRules()`, so it never ran — the space and profile visibility
+  checks it duplicated are already enforced unconditionally by `space\behaviors\SpaceController`
+  and `user\behaviors\ProfileController` on `EVENT_BEFORE_ACTION`. No known module referenced
+  the rule. A module that added `[ContentContainerControllerAccess::RULE_CONTAINER_ACCESS]` to
+  its own `getAccessRules()` must remove it; the behaviors already provide equivalent
+  enforcement.
 
 ## Released versions
 

--- a/protected/humhub/modules/content/components/ContentContainerControllerAccess.php
+++ b/protected/humhub/modules/content/components/ContentContainerControllerAccess.php
@@ -8,11 +8,10 @@
 
 namespace humhub\modules\content\components;
 
-use Yii;
 use humhub\components\access\StrictAccess;
-use humhub\modules\space\models\Membership;
 use humhub\modules\space\models\Space;
 use humhub\modules\user\models\User;
+use Yii;
 
 /**
  * Class ContentContainerControllerAccess
@@ -27,14 +26,11 @@ class ContentContainerControllerAccess extends StrictAccess
     public const RULE_PROFILE_ONLY = 'profile';
 
     public const RULE_USER_GROUP_ONLY = 'userGroup';
-    public const RULE_CONTAINER_ACCESS = 'containerAccess';
 
     /**
      * @var ContentContainerActiveRecord
      */
     public $contentContainer;
-
-    private $_membership = false;
 
     /**
      * @inheritdoc
@@ -52,7 +48,6 @@ class ContentContainerControllerAccess extends StrictAccess
         $this->registerValidator([self::RULE_SPACE_ONLY => 'validateSpaceOnlyRule']);
         $this->registerValidator([self::RULE_PROFILE_ONLY => 'validateProfileOnlyRule']);
         $this->registerValidator([UserGroupAccessValidator::class, 'contentContainer' => $this->contentContainer]);
-        $this->registerValidator([self::RULE_CONTAINER_ACCESS => 'validateContainerAccess']);
     }
 
     /**
@@ -72,89 +67,6 @@ class ContentContainerControllerAccess extends StrictAccess
     }
 
     /**
-     * @return bool Additional ContentContainerActiveRecord specific checks
-     */
-    public function validateContainerAccess()
-    {
-        if ($this->isSpaceController()) {
-            return $this->canAccessSpace();
-        } else {
-            return $this->canAccessUser();
-        }
-    }
-
-    /**
-     * @return bool Space related access checks
-     */
-    private function canAccessSpace()
-    {
-        if ($this->contentContainer->isVisibleFor(Space::VISIBILITY_ALL)) {
-            return true;
-        }
-
-        // don't allow guests since visibility != VISIBILITY_ALL
-        if ($this->isGuest()) {
-            $this->code = 401;
-            return false;
-        }
-
-        if ($this->user->isSystemAdmin()) {
-            return true;
-        }
-
-        // @see SpaceModelMembership
-        $membership = $this->getSpaceMembership();
-
-        if ($membership) {
-            return true;
-        }
-
-        if ($this->isVisibleFor(Space::VISIBILITY_NONE)) {
-            $this->code = 404;
-            $this->reason = Yii::t('ContentModule.base', 'This space is not visible!');
-            return false;
-        }
-
-        return true;
-    }
-
-    /**
-     * @return Membership
-     */
-    private function getSpaceMembership()
-    {
-        if (!$this->isSpaceController() || $this->isGuest()) {
-            return null;
-        }
-
-        if ($this->_membership === false) {
-            $this->_membership = $this->contentContainer->getMembership($this->user->id);
-        }
-
-        return $this->_membership;
-    }
-
-    /**
-     * @return bool User related access checks
-     */
-    private function canAccessUser()
-    {
-        if ($this->contentContainer->status == User::STATUS_NEED_APPROVAL) {
-            $this->reason = Yii::t('UserModule.profile', 'This user account is not approved yet!');
-            $this->code = 404;
-            return false;
-        }
-
-        if ($this->isGuest() && $this->contentContainer->isVisibleFor(User::VISIBILITY_ALL)) {
-            $this->code = 401;
-            $this->reason = Yii::t('UserModule.profile', 'You need to login to view this user profile!');
-            return false;
-        }
-
-        //TODO: visibility + friendship check
-    }
-
-    /**
      * @inheritdoc
      */
     public function isAdmin()
@@ -163,23 +75,23 @@ class ContentContainerControllerAccess extends StrictAccess
             return true;
         }
 
-        if ($this->contentContainer instanceof Space) {
+        if ($this->isSpaceController()) {
             return $this->contentContainer->isAdmin($this->user);
         }
 
-        if ($this->contentContainer instanceof User) {
+        if ($this->isProfileController()) {
             return $this->user && $this->user->is($this->contentContainer);
         }
 
         return false;
     }
 
-    protected function isSpaceController()
+    protected function isSpaceController(): bool
     {
         return $this->contentContainer instanceof Space;
     }
 
-    protected function isProfileController()
+    protected function isProfileController(): bool
     {
         return $this->contentContainer instanceof User;
     }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Refactor

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [ ] All tests are passing
- [x] Changelog was modified

**Other information:**
https://github.com/humhub/humhub-internal/issues/1316