### PR TITLE
The My Spaces dropdown could open before its JS widget initialized, staying empty until reopened — now it loads immediately once ready

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ HumHub Changelog
 - Fix #8365: Encode deletion reason in comment and content deletion notifications
 - Fix #8374: Ensure adding group members is restricted to groups the current user manages
 - Fix #8373: Ensure the oEmbed consent prompt encodes the requested URL so embedded markup stays inert
+- Fix #8375: The My Spaces dropdown could open before its JS widget initialized, staying empty until reopened — now it loads immediately once ready
 
 1.18.4 (July 21, 2026)
 ----------------------

--- a/protected/humhub/modules/space/resources/js/humhub.space.chooser.js
+++ b/protected/humhub/modules/space/resources/js/humhub.space.chooser.js
@@ -74,6 +74,15 @@ humhub.module('space.chooser', function (module, require, $) {
             that.clearSelection();
         });
 
+        // The dropdown toggle is plain Bootstrap markup and can be opened by the user
+        // before this widget has finished initializing (e.g. while the page/assets are
+        // still loading). In that case shown.bs.dropdown already fired with no listener
+        // attached yet, so the lazy space list never gets requested and the dropdown is
+        // left empty. Detect that state here and kick off the load immediately.
+        if (this.lazyLoad && this.$.hasClass('show')) {
+            this.triggerRemoteSearch('');
+        }
+
         if (!pjax.isActive()) {
             return;
         }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

**The PR fulfills these requirements:**

- [ ] All tests are passing
- [x] Changelog was modified

**Other information:**
https://github.com/humhub/humhub/issues/8375