### PR TITLE
Button restyling and remove right param to icon/setIcon method in BS widgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ HumHub Changelog
 
 1.19.0-beta.2 (TBD)
 -------------------
-- Enh #TBD: Removed the unused `$right` parameter from `BootstrapVariationsTrait::icon()` (`Button`/`Badge`/`Link`/`Alert`) and from `MenuLink::setIcon()` — `$options` is now the second parameter of `icon()` instead of the third, see `docs/develop/module-migrate.md`
+- Enh #8389: Removed the unused `$right` parameter from `BootstrapVariationsTrait::icon()` (`Button`/`Badge`/`Link`/`Alert`) and from `MenuLink::setIcon()` — `$options` is now the second parameter of `icon()` instead of the third, see `docs/develop/module-migrate.md`
+- Enh #8389: Buttons styling by using flex and gap instead of a right margin on the icon
 - Fix #8380: Activities of private spaces leaked into the activity summary mail and dashboard activity box of users with a pending space invite or join request
 - Fix #8366: Duplicate key error when concurrent requests stored the same setting, e.g. theme variables after a theme switch
 - Enh #8363: A download served by a redirect to a temporary storage URL (a mount whose `useTemporaryUrls()` returns true, e.g. the S3 module) arrived in the browser named `file` and without a usable content type — uploads are stored under an object key ending in `file` and the redirect target carries no `Content-Disposition`, so the browser derived both from the URL path; `DownloadAction` now passes the file name and mime type to `temporaryUrl()` via the new storage-neutral `MountConfigInterface::CONFIG_CONTENT_DISPOSITION` and `CONFIG_CONTENT_TYPE` config keys, which backends able to override response headers on a temporary URL (S3's `response-content-disposition`) honor and others ignore. Added `FileHelper::getContentDispositionHeaderValue()` for the header value, since `Response::getDispositionHeaderValue()` builds the same thing but is protected

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ HumHub Changelog
 
 1.19.0-beta.2 (TBD)
 -------------------
+- Enh #TBD: Removed the unused `$right` parameter from `BootstrapVariationsTrait::icon()` (`Button`/`Badge`/`Link`/`Alert`) and from `MenuLink::setIcon()` — `$options` is now the second parameter of `icon()` instead of the third, see `docs/develop/module-migrate.md`
 - Fix #8380: Activities of private spaces leaked into the activity summary mail and dashboard activity box of users with a pending space invite or join request
 - Fix #8366: Duplicate key error when concurrent requests stored the same setting, e.g. theme variables after a theme switch
 - Enh #8363: A download served by a redirect to a temporary storage URL (a mount whose `useTemporaryUrls()` returns true, e.g. the S3 module) arrived in the browser named `file` and without a usable content type — uploads are stored under an object key ending in `file` and the redirect target carries no `Content-Disposition`, so the browser derived both from the URL path; `DownloadAction` now passes the file name and mime type to `temporaryUrl()` via the new storage-neutral `MountConfigInterface::CONFIG_CONTENT_DISPOSITION` and `CONFIG_CONTENT_TYPE` config keys, which backends able to override response headers on a temporary URL (S3's `response-content-disposition`) honor and others ignore. Added `FileHelper::getContentDispositionHeaderValue()` for the header value, since `Response::getDispositionHeaderValue()` builds the same thing but is protected

--- a/docs/develop/module-migrate.md
+++ b/docs/develop/module-migrate.md
@@ -353,6 +353,23 @@ Each minor release line has its own file with the breaking changes, new APIs and
   the rule. A module that added `[ContentContainerControllerAccess::RULE_CONTAINER_ACCESS]` to
   its own `getAccessRules()` must remove it; the behaviors already provide equivalent
   enforcement.
+- Removed the `$right` parameter from `humhub\widgets\bootstrap\BootstrapVariationsTrait::icon()`
+  (used by `Button`, `Badge`, `Link` and `Alert`). The parameter was never read by the method —
+  right-aligning an icon already goes through the separate `->right()` method — so this only
+  changes the signature: `icon(string|Icon|null $icon, $options = [])`, `$options` is now the
+  **second** parameter instead of the third.
+  **Warning:** PHP silently ignores extra arguments, so a call like `->icon('user', true)` made
+  for the old `$right` flag does not fail — `true` is now passed as `$options` to `Icon::get()`,
+  which fatals with "Cannot use a scalar value as an array". Audit every `->icon(...)` call that
+  passes a second argument and drop it, or move a third-argument `$options` array into the second
+  position.
+  - `humhub\modules\ui\menu\MenuLink::setIcon()` also dropped its `$right` parameter for the same
+    reason (it only forwarded into `icon()`, and `right()` on the underlying `Button`/`Badge` is
+    the correct way to align an icon). `setIcon($icon, $right)` → `setIcon($icon)`.
+    **Warning:** PHP silently ignores the now-unused second argument instead of erroring, so a
+    call like `$menuLink->setIcon('user', true)` keeps "succeeding" but the icon is no longer
+    right-aligned — audit every `->setIcon(...)` call that passes a second argument and call
+    `->getLink()->right()` explicitly if right-alignment is still needed.
 
 ## Released versions
 

--- a/protected/humhub/modules/file/widgets/FileDownload.php
+++ b/protected/humhub/modules/file/widgets/FileDownload.php
@@ -21,7 +21,7 @@ class FileDownload extends Button
     {
         if ($withIcon) {
             $mimeIconClass = MimeHelper::getMimeIconClassByExtension($file);
-            $this->icon(Html::tag('i', '', ['class' => 'mime ' . $mimeIconClass, 'style' => 'width:10px;height:10px;']), false, true);
+            $this->icon(Html::tag('i', '', ['class' => 'mime ' . $mimeIconClass, 'style' => 'width:10px;height:10px;']));
         }
 
         if ($showSize) {

--- a/protected/humhub/modules/ui/menu/MenuLink.php
+++ b/protected/humhub/modules/ui/menu/MenuLink.php
@@ -126,13 +126,12 @@ class MenuLink extends MenuEntry
 
     /**
      * @param $icon Icon|string the icon instance or icon name
-     * @param bool $right
      * @return static
      * @throws Exception
      */
-    public function setIcon($icon, $right = false)
+    public function setIcon($icon)
     {
-        $this->getLink()->icon($icon, $right);
+        $this->getLink()->icon($icon);
         return $this;
     }
 

--- a/protected/humhub/resources/scss/_button.scss
+++ b/protected/humhub/resources/scss/_button.scss
@@ -11,15 +11,13 @@
         --bs-btn-padding-y: 0.5rem;
         --bs-btn-font-weight: 600;
         --bs-btn-border-radius: 3px;
+        --hh-btn-gap: 0.6rem;
 
         white-space: nowrap;
         transition: color 0.3s, background-color 0.3s, border-color 0.3s;
-
-        &:not(.btn-icon-only) {
-            i.fa {
-                margin-right: 0.6rem;
-            }
-        }
+        display: inline-flex;
+        align-items: center;
+        gap: var(--hh-btn-gap);
 
         &.input {
             outline: none;
@@ -29,24 +27,14 @@
     .btn-sm, .btn-group-sm > .btn {
         --bs-btn-padding-x: 0.5rem;
         --bs-btn-padding-y: 0.2rem;
-
-        &:not(.btn-icon-only) {
-            i.fa {
-                margin-right: 0.4rem;
-            }
-        }
+        --hh-btn-gap: 0.4rem;
     }
 
     .btn-lg, .btn-group-lg > .btn {
         --bs-btn-padding-x: 1.75rem;
         --bs-btn-padding-y: 0.9rem;
         --bs-btn-font-size: 1.1rem;
-
-        &:not(.btn-icon-only) {
-            i.fa {
-                margin-right: 0.8rem;
-            }
-        }
+        --hh-btn-gap: 0.8rem;
     }
 
     .btn-group > .btn {

--- a/protected/humhub/widgets/bootstrap/BootstrapVariationsTrait.php
+++ b/protected/humhub/widgets/bootstrap/BootstrapVariationsTrait.php
@@ -87,7 +87,7 @@ trait BootstrapVariationsTrait
         return static::instance($label);
     }
 
-    public function icon(string|Icon|null $icon, bool $right = false, $options = []): static
+    public function icon(string|Icon|null $icon, $options = []): static
     {
         // Extract icon from FontAwesome 4 HTML element
         // TODO: remove later ($icon should be the name of the Icon or an instance of Icon)
@@ -97,10 +97,6 @@ trait BootstrapVariationsTrait
         }
 
         $this->icon = Icon::get($icon, $options);
-
-        if ($right) {
-            $this->icon?->right();
-        }
 
         return $this;
     }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [x] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included
- [x] Changelog was modified

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

- Enh: Removed the unused `$right` parameter from `BootstrapVariationsTrait::icon()` (`Button`/`Badge`/`Link`/`Alert`) and from `MenuLink::setIcon()` — `$options` is now the second parameter of `icon()` instead of the third, see `docs/develop/module-migrate.md`
- Enh: Buttons styling by using flex and gap instead of a right margin on the icon

https://github.com/humhub/humhub-internal/issues/1319