### PR TITLE
Remove redundant space chooser lazy-load click handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ HumHub Changelog
 
 1.19.0-beta.2 (TBD)
 -------------------
+- Enh #8390: Removed the redundant My Spaces dropdown click handler — the lazy space list is already loaded on open, and the case where the dropdown was opened before its widget initialized is covered by the init-time check from #8384
 - Enh #8389: Removed the unused `$right` parameter from `BootstrapVariationsTrait::icon()` (`Button`/`Badge`/`Link`/`Alert`) and from `MenuLink::setIcon()` — `$options` is now the second parameter of `icon()` instead of the third, see `docs/develop/module-migrate.md`
 - Enh #8389: Buttons styling by using flex and gap instead of a right margin on the icon
 - Fix #8380: Activities of private spaces leaked into the activity summary mail and dashboard activity box of users with a pending space invite or join request

--- a/protected/humhub/modules/space/resources/js/humhub.space.chooser.js
+++ b/protected/humhub/modules/space/resources/js/humhub.space.chooser.js
@@ -81,24 +81,6 @@ humhub.module('space.chooser', function (module, require, $) {
             that.clearSelection();
         });
 
-        this.$menu.on('click', function () {
-            setTimeout(function () {
-                if (!that.lazyLoad) {
-                    return;
-                }
-
-                if (!that.$.hasClass('show')) {
-                    return;
-                }
-
-                if (that.$remoteSearch.children().length) {
-                    return;
-                }
-
-                that.triggerRemoteSearch('');
-            }, 0);
-        });
-
         // The dropdown toggle is plain Bootstrap markup and can be opened by the user
         // before this widget has finished initializing (e.g. while the page/assets are
         // still loading). In that case shown.bs.dropdown already fired with no listener


### PR DESCRIPTION
Follow-up to #8384 (issue #8375), which landed on `master` and reached `develop` with the last `master → develop` merge.

`SpaceChooser.initEvents()` carried two independent workarounds for the same problem — the My Spaces dropdown can be opened before its widget has finished initializing (the module init is async since #7913), so `shown.bs.dropdown` fires with no listener attached and the lazy space list is never requested:

- the `#space-menu` click handler added in #7913, which re-checked the state on a *later* toggle click, and
- the init-time check from #8384, which detects the already-open dropdown and starts the load immediately.

The click handler is redundant now:

- On the normal open, it does nothing. `triggerRemoteSearch()` runs synchronously from `shown.bs.dropdown` and `ui.loader.set()` replaces the content of `#space-menu-remote-search` with the loader, so by the time the handler's `setTimeout(…, 0)` fires, the `$remoteSearch.children().length` guard already short-circuits.
- On the race it was written for, it only recovered on the *next* click, leaving the dropdown visibly empty until the user reopened it. The init-time check covers the whole window: if the widget initializes after `shown.bs.dropdown` fired, the `show` class is present and the load starts right away; if it initializes before, the listener is attached in time.

No behaviour change on the normal path, and the race it guarded is handled earlier and without the extra reopen.