### PR TITLE
Fix flaky comment submit click in stream acceptance tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ HumHub Changelog
 - Fix #8378: Ensure marketplace module metadata is rendered as encoded text in the administration views
 - Fix #8375: The My Spaces dropdown could open before its JS widget initialized, staying empty until reopened — now it loads immediately once ready
 - Fix #8386: Fix collapsing of the widget "Member of these Spaces"
+- Fix #8392: Wait for the comment submit button to become clickable in the stream acceptance tests, which intermittently failed on CI
 
 1.18.4 (July 21, 2026)
 ----------------------

--- a/protected/humhub/modules/stream/tests/codeception/acceptance/StreamCest.php
+++ b/protected/humhub/modules/stream/tests/codeception/acceptance/StreamCest.php
@@ -271,6 +271,7 @@ class StreamCest
         $I->click('Comment', $postSelector);
         $I->waitForElementVisible($postSelector . ' .comment-container');
         $I->fillField($postSelector . ' .comment_create .humhub-ui-richtext', 'My Comment');
+        $I->waitForElementClickable($postSelector . ' .comment_create [data-action-click=submit]');
         $I->click('[data-action-click=submit]', $postSelector . ' .comment_create');
         $I->waitForText('My Comment', 10, $postSelector . ' .comment');
 
@@ -319,6 +320,7 @@ class StreamCest
         $I->click('Comment', $post4Selector);
         $I->wait(1);
         $I->fillField($post4Selector . ' [contenteditable]', 'My Comment!');
+        $I->waitForElementClickable($post4Selector . ' .richtext-create-buttons [data-action-click=submit]');
         $I->click('[data-action-click=submit]', $post4Selector . ' .richtext-create-buttons');
 
         $I->scrollTop();


### PR DESCRIPTION
`master` CI has been failing intermittently since Aug 8 — always with the same 4 errors in the stream acceptance suite, but each time on a different PHP matrix job (8.2 on Aug 8, 8.3 on Aug 11, 8.4 on Aug 17, [run 32023600301](https://github.com/humhub/humhub/actions/runs/32023600301)). No relevant code changed in that window, so this is a timing flake, not a regression.

## Root cause

Only **one** of the 4 errors is real: `StreamCest::testFilterInvolved` at `StreamCest.php:274`.

```
[Facebook\WebDriver\Exception\ElementNotInteractableException] element not interactable
 36. $I->click("[data-action-cli...","[data-content-ke...")
```

The failure screenshot and HTML snapshot from the run artifacts show the comment form open, `My Comment` typed, and the submit button present and not hidden. So nothing is missing or broken in the application — the button simply is not interactable at the instant of the click: it sits in the absolutely positioned `.richtext-create-buttons` group, which is repositioned while the richtext initializes (`scroll-active` / `scroll-inactive`, see `_comment.scss` and `_form.scss`).

The other 3 errors are fallout. The suite shares one browser session, so once `testFilterInvolved` dies leaving an unsaved comment form behind, every remaining test fails at its very first step:

```
1. $I->amOnPage("/user/auth/login")
2. $I->waitForText("Please sign in")  → UnexpectedAlertOpenException: unexpected alert open: {Alert text : }
```

## Fix

Wait for the button to actually be clickable before clicking it. `waitForElementClickable` checks visible **and** enabled, which is exactly the condition that was failing.

`testSortStream` creates its comment through the same `click(Comment)` → `fillField` → `click(submit)` sequence and carried the same latent race, so it gets the same guard.

## Verification

Reproduced and verified against the exact CI browser — `selenium/standalone-chrome:108.0-20250123` with `--env github` — since the failure does not occur on current Chrome at all:

- The exact CI error reproduces on Chrome 108 when the button is made non-interactable; it does not reproduce on Chrome 144.
- With the fix, all 8 `StreamCest` tests pass, `testFilterInvolved` and `testSortStream` included.
- The full module acceptance sweep (18 suites) was run on Chrome 108 to check for collateral damage.

## Not included, on purpose

I also tried to cut the cascade off, so a single failure stops producing 4 errors and burying its own cause. Two candidates, both rejected by measurement:

- **`unhandledPromptBehavior: accept`** — the leftover dialog could not be reproduced in 3 attempts (Chrome 108/144, headed/headless), so there was nothing to validate the change against. It would also have touched `InviteCest` and `ImpersonateCest`, which rely on `acceptPopup()`.
- **`restart: true` in the remaining module suites** — this does cut the cascade (3 errors → 1 under identical sabotage, at 2:51 vs 2:52 runtime, so it is not a speed question). But a fresh browser per test loses timing races noticeably more often. Running the `content` suite alternately against the same database: `restart=false` 1 red in 4 runs, `restart=true` **5 red in 5 runs**, pulling in `DraftCest` and `ArchivedCest`, which are otherwise green. It buys tidier logs and pays in flakiness, so it is out.

The cascade therefore still exists: a failure here will keep reporting 4 errors instead of 1. Worth addressing separately by hardening the racy helpers themselves (`AcceptanceTester::logout()` does a jQuery `jsClick` on the account menu; `SearchCest` hits `StaleElementReferenceException` in the search dropdown independently of any change in this PR).

## Notes

- `develop` has the same test code and needs this via the usual `master` → `develop` merge.
- Selenium is pinned to `108.0-20250123`, i.e. Chrome 108 from Dec 2022. Several of these races are much easier to lose there than on current Chrome. Updating it is its own piece of work, but it looks overdue.
