### PR TITLE
Fix installer shown as 503 on a fresh install with a not-yet-created database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ HumHub Changelog
 1.19.0-beta.2 (TBD)
 -------------------
 - Fix #8350: A configured but unreachable database presented the web installer — offering to re-setup an already installed instance during a transient outage — instead of an error; such requests now return a 503
-- Fix #8393: A fresh install with a reachable DB server but a not-yet-created database (e.g. Docker, MySQL 1049) wrongly returned a 503 from #8350 instead of the installer; only a truly unreachable server now returns a 503
+- Fix #8393: #8350 returned a 503 for any database error, so a fresh or incompletely configured install (server reachable but the database missing, credentials wrong, or the DSN lacking a database name) was blocked instead of shown the installer; a 503 is now returned only when the database server itself is unreachable
 - Enh #8390: Removed the redundant My Spaces dropdown click handler — the lazy space list is already loaded on open, and the case where the dropdown was opened before its widget initialized is covered by the init-time check from #8384
 - Enh #8389: Removed the unused `$right` parameter from `BootstrapVariationsTrait::icon()` (`Button`/`Badge`/`Link`/`Alert`) and from `MenuLink::setIcon()` — `$options` is now the second parameter of `icon()` instead of the third, see `docs/develop/module-migrate.md`
 - Enh #8389: Buttons styling by using flex and gap instead of a right margin on the icon

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ HumHub Changelog
 1.19.0-beta.2 (TBD)
 -------------------
 - Fix #8350: A configured but unreachable database presented the web installer — offering to re-setup an already installed instance during a transient outage — instead of an error; such requests now return a 503
+- Fix #8393: A fresh install with a reachable DB server but a not-yet-created database (e.g. Docker, MySQL 1049) wrongly returned a 503 from #8350 instead of the installer; only a truly unreachable server now returns a 503
 - Enh #8390: Removed the redundant My Spaces dropdown click handler — the lazy space list is already loaded on open, and the case where the dropdown was opened before its widget initialized is covered by the init-time check from #8384
 - Enh #8389: Removed the unused `$right` parameter from `BootstrapVariationsTrait::icon()` (`Button`/`Badge`/`Link`/`Alert`) and from `MenuLink::setIcon()` — `$options` is now the second parameter of `icon()` instead of the third, see `docs/develop/module-migrate.md`
 - Enh #8389: Buttons styling by using flex and gap instead of a right margin on the icon

--- a/protected/humhub/components/InstallationState.php
+++ b/protected/humhub/components/InstallationState.php
@@ -126,10 +126,30 @@ class InstallationState extends BaseObject implements StaticInstanceInterface
         try {
             Yii::$app->db->open();
         } catch (\Exception $e) {
-            $this->databaseConnectionError = $e;
+            // A reachable server that merely lacks the configured database
+            // (fresh install, schema not created yet) is a not-yet-installed
+            // state, not an outage — only a genuinely unreachable server is
+            // recorded so the caller keeps redirecting to the installer here.
+            if (!$this->isMissingDatabaseError($e)) {
+                $this->databaseConnectionError = $e;
+            }
             return false;
         }
 
         return in_array('setting', Yii::$app->db->schema->getTableNames());
+    }
+
+    /**
+     * Whether a database connection error means the configured database does
+     * not exist (or is not accessible) rather than the server being unreachable.
+     * The server responded in this case, so it is reachable — e.g. a fresh
+     * Docker install whose database has not been created yet.
+     */
+    private function isMissingDatabaseError(\Throwable $e): bool
+    {
+        // MySQL: 1049 = unknown database, 1044 = access denied for the database.
+        $code = $e instanceof \yii\db\Exception ? ($e->errorInfo[1] ?? $e->getCode()) : $e->getCode();
+
+        return in_array((int)$code, [1049, 1044], true);
     }
 }

--- a/protected/humhub/components/InstallationState.php
+++ b/protected/humhub/components/InstallationState.php
@@ -125,31 +125,38 @@ class InstallationState extends BaseObject implements StaticInstanceInterface
     {
         try {
             Yii::$app->db->open();
+
+            return in_array('setting', Yii::$app->db->schema->getTableNames());
         } catch (\Exception $e) {
-            // A reachable server that merely lacks the configured database
-            // (fresh install, schema not created yet) is a not-yet-installed
-            // state, not an outage — only a genuinely unreachable server is
-            // recorded so the caller keeps redirecting to the installer here.
-            if (!$this->isMissingDatabaseError($e)) {
+            // A server that responds but reports the configured database or
+            // credentials are not (yet) usable is a not-yet-installed / partially
+            // configured state (fresh or incomplete install) — keep redirecting
+            // to the installer. Only a genuinely unreachable or unavailable
+            // server is recorded as an outage, so the caller returns a 503.
+            if (!$this->isDatabaseSetupError($e)) {
                 $this->databaseConnectionError = $e;
             }
+
             return false;
         }
-
-        return in_array('setting', Yii::$app->db->schema->getTableNames());
     }
 
     /**
-     * Whether a database connection error means the configured database does
-     * not exist (or is not accessible) rather than the server being unreachable.
-     * The server responded in this case, so it is reachable — e.g. a fresh
-     * Docker install whose database has not been created yet.
+     * Whether a database error means the server is reachable but the configured
+     * database/credentials are not (yet) set up — as opposed to the server being
+     * unreachable or unavailable. Such errors indicate a fresh or incompletely
+     * configured install (e.g. a Docker install whose database was not created
+     * yet, or a DSN missing the database name), not an outage of an installed
+     * instance, so the installer must stay reachable.
      */
-    private function isMissingDatabaseError(\Throwable $e): bool
+    private function isDatabaseSetupError(\Throwable $e): bool
     {
-        // MySQL: 1049 = unknown database, 1044 = access denied for the database.
-        $code = $e instanceof \yii\db\Exception ? ($e->errorInfo[1] ?? $e->getCode()) : $e->getCode();
+        // Native MySQL server-response codes (read from errorInfo, since getCode()
+        // may carry a SQLSTATE string for statement-level errors):
+        //   1049 unknown database        1046 no database selected (missing dbname)
+        //   1044 no access to database   1045 / 1698 access denied (authentication)
+        $code = (int)($e instanceof \yii\db\Exception ? ($e->errorInfo[1] ?? $e->getCode()) : $e->getCode());
 
-        return in_array((int)$code, [1049, 1044], true);
+        return in_array($code, [1044, 1045, 1046, 1049, 1698], true);
     }
 }

--- a/protected/humhub/tests/codeception/unit/components/InstallationStateTest.php
+++ b/protected/humhub/tests/codeception/unit/components/InstallationStateTest.php
@@ -71,4 +71,44 @@ class InstallationStateTest extends HumHubDbTestCase
             InstallationState::instance(true);
         }
     }
+
+    /**
+     * A configured database whose SERVER is reachable but whose database/schema
+     * does not exist yet (e.g. a fresh Docker install, MySQL error 1049) is a
+     * not-yet-installed state, NOT an outage. It must keep redirecting to the
+     * installer (which creates the database), not return a 503.
+     */
+    public function testConfiguredButMissingDatabaseIsNotUnreachable()
+    {
+        $originalDb = Yii::$app->get('db');
+        $originalCache = Yii::$app->get('cache');
+        $originalSettings = Yii::$app->get('settings');
+
+        try {
+            Yii::$app->set('cache', ['class' => DummyCache::class]);
+            // Reuse the real (reachable) server credentials but point at a
+            // database that does not exist -> the server responds with 1049.
+            $missingDsn = preg_replace('/dbname=[^;]*/', 'dbname=humhub_missing_db_test', $originalDb->dsn);
+            $this->assertNotSame($originalDb->dsn, $missingDsn, 'test DSN must carry a dbname');
+            Yii::$app->set('db', [
+                'class' => Connection::class,
+                'dsn' => $missingDsn,
+                'username' => $originalDb->username,
+                'password' => $originalDb->password,
+                'charset' => $originalDb->charset,
+            ]);
+            Yii::$app->set('settings', ['class' => SettingsManager::class, 'moduleId' => 'base']);
+
+            $state = InstallationState::instance(true);
+
+            $this->assertFalse($state->isDatabaseUnreachable(), 'A missing database is not an outage');
+            $this->assertNull($state->getDatabaseConnectionError());
+            $this->assertFalse($state->hasState(InstallationState::STATE_INSTALLED));
+        } finally {
+            Yii::$app->set('db', $originalDb);
+            Yii::$app->set('cache', $originalCache);
+            Yii::$app->set('settings', $originalSettings);
+            InstallationState::instance(true);
+        }
+    }
 }

--- a/protected/humhub/tests/codeception/unit/components/InstallationStateTest.php
+++ b/protected/humhub/tests/codeception/unit/components/InstallationStateTest.php
@@ -35,50 +35,104 @@ class InstallationStateTest extends HumHubDbTestCase
     }
 
     /**
-     * A configured but unreachable database must be detected as such and must
-     * NOT fall back to a lower state (which would present the installer for an
-     * already installed instance during a transient outage).
+     * A configured database whose SERVER is unreachable (connection refused) is
+     * a real outage: it must NOT fall back to a lower state that presents the
+     * installer for an already installed instance.
      */
-    public function testConfiguredButUnreachableDatabaseDoesNotFallBackToInstaller()
+    public function testUnreachableServerIsAnOutage()
     {
-        $originalDb = Yii::$app->get('db');
-        $originalCache = Yii::$app->get('cache');
-        $originalSettings = Yii::$app->get('settings');
-
-        try {
-            // No persistent cache -> the settings manager cannot resolve the
-            // stored state and is forced to probe the (dead) database.
-            Yii::$app->set('cache', ['class' => DummyCache::class]);
-            Yii::$app->set('db', [
+        $this->withDatabase(
+            fn(Connection $db) => [
                 'class' => Connection::class,
                 'dsn' => 'mysql:host=127.0.0.1;port=1;dbname=humhub_unreachable',
                 'username' => 'humhub',
                 'password' => 'humhub',
-            ]);
-            // Recreate the settings manager so its cached values are dropped and
-            // the (failing) load runs against the dead database.
-            Yii::$app->set('settings', ['class' => SettingsManager::class, 'moduleId' => 'base']);
-
-            $state = InstallationState::instance(true);
-
-            $this->assertTrue($state->isDatabaseUnreachable());
-            $this->assertInstanceOf(Throwable::class, $state->getDatabaseConnectionError());
-            $this->assertFalse($state->hasState(InstallationState::STATE_INSTALLED));
-        } finally {
-            Yii::$app->set('db', $originalDb);
-            Yii::$app->set('cache', $originalCache);
-            Yii::$app->set('settings', $originalSettings);
-            InstallationState::instance(true);
-        }
+            ],
+            function (InstallationState $state) {
+                $this->assertTrue($state->isDatabaseUnreachable());
+                $this->assertInstanceOf(Throwable::class, $state->getDatabaseConnectionError());
+                $this->assertFalse($state->hasState(InstallationState::STATE_INSTALLED));
+            },
+        );
     }
 
     /**
-     * A configured database whose SERVER is reachable but whose database/schema
-     * does not exist yet (e.g. a fresh Docker install, MySQL error 1049) is a
-     * not-yet-installed state, NOT an outage. It must keep redirecting to the
-     * installer (which creates the database), not return a 503.
+     * Server reachable but the database/schema does not exist yet (fresh Docker
+     * install, MySQL 1049): not an outage — keep showing the installer, which
+     * creates the database.
      */
-    public function testConfiguredButMissingDatabaseIsNotUnreachable()
+    public function testMissingDatabaseIsNotUnreachable()
+    {
+        $this->withDatabase(
+            fn(Connection $db) => [
+                'class' => Connection::class,
+                'dsn' => preg_replace('/dbname=[^;]*/', 'dbname=humhub_missing_db_test', $db->dsn),
+                'username' => $db->username,
+                'password' => $db->password,
+                'charset' => $db->charset,
+            ],
+            function (InstallationState $state) {
+                $this->assertFalse($state->isDatabaseUnreachable(), 'A missing database is not an outage');
+                $this->assertNull($state->getDatabaseConnectionError());
+                $this->assertFalse($state->hasState(InstallationState::STATE_INSTALLED));
+            },
+        );
+    }
+
+    /**
+     * Server reachable but the credentials are wrong (incomplete config, MySQL
+     * 1045/1698): the server responded, so it is not an outage — keep showing
+     * the installer rather than returning a 503.
+     */
+    public function testAuthenticationFailureIsNotUnreachable()
+    {
+        $this->withDatabase(
+            fn(Connection $db) => [
+                'class' => Connection::class,
+                'dsn' => $db->dsn,
+                'username' => $db->username,
+                'password' => $db->password . '_wrong_xyz',
+                'charset' => $db->charset,
+            ],
+            function (InstallationState $state) {
+                $this->assertFalse($state->isDatabaseUnreachable(), 'An auth failure is not an outage');
+                $this->assertFalse($state->hasState(InstallationState::STATE_INSTALLED));
+            },
+        );
+    }
+
+    /**
+     * An incomplete DSN without a database name: the connection opens but no
+     * database is selected (MySQL 1046). This must be handled gracefully (no
+     * uncaught error) and treated as a not-yet-configured install.
+     */
+    public function testMissingDatabaseNameIsNotUnreachable()
+    {
+        $this->withDatabase(
+            fn(Connection $db) => [
+                'class' => Connection::class,
+                'dsn' => preg_replace('/;?dbname=[^;]*/', '', $db->dsn),
+                'username' => $db->username,
+                'password' => $db->password,
+                'charset' => $db->charset,
+            ],
+            function (InstallationState $state) {
+                $this->assertFalse($state->isDatabaseUnreachable(), 'A missing database name is not an outage');
+                $this->assertFalse($state->hasState(InstallationState::STATE_INSTALLED));
+            },
+        );
+    }
+
+    /**
+     * Runs $assertions against a fresh InstallationState built on top of a
+     * temporary database configuration, then restores the real components.
+     * Caching is disabled so the settings manager cannot resolve the stored
+     * state and is forced to probe the (broken) database.
+     *
+     * @param callable $dbConfigFactory fn(Connection $originalDb): array
+     * @param callable $assertions      fn(InstallationState $state): void
+     */
+    private function withDatabase(callable $dbConfigFactory, callable $assertions): void
     {
         $originalDb = Yii::$app->get('db');
         $originalCache = Yii::$app->get('cache');
@@ -86,24 +140,10 @@ class InstallationStateTest extends HumHubDbTestCase
 
         try {
             Yii::$app->set('cache', ['class' => DummyCache::class]);
-            // Reuse the real (reachable) server credentials but point at a
-            // database that does not exist -> the server responds with 1049.
-            $missingDsn = preg_replace('/dbname=[^;]*/', 'dbname=humhub_missing_db_test', $originalDb->dsn);
-            $this->assertNotSame($originalDb->dsn, $missingDsn, 'test DSN must carry a dbname');
-            Yii::$app->set('db', [
-                'class' => Connection::class,
-                'dsn' => $missingDsn,
-                'username' => $originalDb->username,
-                'password' => $originalDb->password,
-                'charset' => $originalDb->charset,
-            ]);
+            Yii::$app->set('db', $dbConfigFactory($originalDb));
             Yii::$app->set('settings', ['class' => SettingsManager::class, 'moduleId' => 'base']);
 
-            $state = InstallationState::instance(true);
-
-            $this->assertFalse($state->isDatabaseUnreachable(), 'A missing database is not an outage');
-            $this->assertNull($state->getDatabaseConnectionError());
-            $this->assertFalse($state->hasState(InstallationState::STATE_INSTALLED));
+            $assertions(InstallationState::instance(true));
         } finally {
             Yii::$app->set('db', $originalDb);
             Yii::$app->set('cache', $originalCache);


### PR DESCRIPTION
Follow-up to #8350.

## Problem

#8350 made a **configured but unreachable** database return a 503 instead of presenting the web installer. But it recorded **every** `db->open()` failure as "unreachable" — including cases where the DB **server is reachable** and merely reports that the configured database or credentials are not (yet) usable. That regressed fresh and incompletely configured installs, which should still reach the installer:

- **Database not created yet** (fresh Docker install whose DB container does not pre-create the schema) → MySQL **1049 "Unknown database"**. Observed on `https://dockertest2.humhub.host/` returning HTTP 503 instead of the installer.
- **Wrong credentials** (incomplete/partial config) → MySQL **1045 / 1698 "Access denied"**.
- **DSN without a database name** → `open()` succeeds but the first schema query fails with **1046 "No database selected"**, which — because `getTableNames()` sat *outside* the try/catch — raised an uncaught error rather than showing the installer.

## Fix

`InstallationState::isDatabaseInstalled()` now:

1. Probes the schema **inside** the same try/catch, so an incomplete DSN (no database name) is handled gracefully instead of raising an uncaught "No database selected" error.
2. Classifies the failure by the native MySQL code (read from the thrown `yii\db\Exception` via `errorInfo[1]`, since `getCode()` may be a SQLSTATE string for statement-level errors — the same native codes HumHub already maps in `DatabaseHelper::handleConnectionErrors()`):
   - **Server responded, config/DB not usable** — `1049` unknown database, `1044` no DB access, `1045`/`1698` access denied, `1046` no database selected → a fresh or incompletely configured install → keep redirecting to the **installer** (no 503).
   - **Server unreachable or unavailable** — connection refused / host down / server gone (`2002`/`2003`/…), and anything else including overload (`1040` too many connections) → recorded as an outage → **503**, as introduced in #8350.

This deliberately keeps the original protection: an already installed instance whose server is down or overloaded still returns a 503 and never presents the installer to the public. Only errors where the server actively reports an unusable/not-set-up configuration fall through to the installer (which is where such a setup is completed anyway; installer routes were never blocked).

## Behavior

| Situation | #8350 | this PR |
|---|---|---|
| Server reachable, database missing (fresh Docker, 1049) | **503** ❌ | **installer** ✅ |
| Server reachable, wrong credentials (1045/1698) | **503** ❌ | **installer** ✅ |
| DSN without database name (1046) | **uncaught error** ❌ | **installer** ✅ |
| Server reachable, empty schema (db exists, no tables) | installer | installer (unchanged) |
| Server unreachable (connection refused, 2002/2003) | 503 | 503 (unchanged) |
| Installed instance, DB outage / overload (cold cache) | 503 | 503 (unchanged) |

## Tests

`InstallationStateTest` covers a healthy install, a truly unreachable server (dead port → 503), a missing database (1049), an authentication failure (1045/1698) and an incomplete DSN with no database name (1046) — the last three asserting `isDatabaseUnreachable()` is false so the installer stays reachable. All pass.