### PR TITLE
Show a loading spinner on RichText content until the Markdown source has been rendered to HTML client side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ HumHub Changelog
 - Fix #8386: Fix collapsing of the widget "Member of these Spaces"
 - Fix #8391: Harden pagination cursor validation in Comments and Notifications against loose-type comparisons
 - Fix #8392: Wait for the comment submit button to become clickable in the stream acceptance tests, which intermittently failed on CI
+- Enh #8394: Show a loading spinner on RichText content until the Markdown source has been rendered to HTML client side
 
 1.18.4 (July 21, 2026)
 ----------------------

--- a/protected/humhub/modules/content/resources/js/humhub.ui.richtext.prosemirror.js
+++ b/protected/humhub/modules/content/resources/js/humhub.ui.richtext.prosemirror.js
@@ -167,6 +167,7 @@ humhub.module('ui.richtext.prosemirror', function (module, require, $) {
             this.options.edit = false;
             this.editor = new MarkdownEditor(this.$, this.options);
             this.$.html(this.editor.render());
+            this.$.attr('data-ui-richtext-rendered', '');
             additions.applyTo(this.$, {filter: ['highlightCode']});
             this.$.find('table').wrap('<div class="table-responsive"></div>');
             this.$.trigger('afterRender');

--- a/static/scss/_richtext.scss
+++ b/static/scss/_richtext.scss
@@ -646,6 +646,34 @@
         }
     }
 
+    // Spinner (matches .spinner-border, e.g. the wall stream loader) shown until Prosemirror renders the raw
+    // Markdown source (kept as plain text here) into HTML - JS sets data-ui-richtext-rendered once done, see
+    // RichText.prototype.init() in humhub.ui.richtext.prosemirror.js. Pseudo-element only: a real DOM/text
+    // node here would corrupt this.$.text(), which JS reads as the Markdown source. [data-edit] is the
+    // hidden element holding the editor's initial value and is excluded.
+    [data-ui-richtext]:not([data-ui-richtext-rendered]):not([data-edit]) {
+        position: relative;
+        min-height: calc(var(--bs-spinner-height, 2rem) + var(--bs-spinner-border-width, 0.25em) * 2);
+        color: transparent;
+        pointer-events: none;
+        user-select: none;
+
+        &::before {
+            content: '';
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            width: var(--bs-spinner-width, 2rem);
+            height: var(--bs-spinner-height, 2rem);
+            margin: calc(var(--bs-spinner-height, 2rem) / -2) 0 0 calc(var(--bs-spinner-width, 2rem) / -2);
+            color: var(--bs-body-color);
+            border: var(--bs-spinner-border-width, 0.25em) solid currentcolor;
+            border-right-color: transparent;
+            border-radius: 50%;
+            animation: var(--bs-spinner-animation-speed, 0.75s) linear infinite var(--bs-spinner-animation-name, spinner-border);
+        }
+    }
+
     #wallStream {
         [data-ui-markdown],
         [data-ui-richtext] {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature

**The PR fulfills these requirements:**

- [ ] All tests are passing
- [x] Changelog was modified

**Other information:**
https://github.com/humhub/humhub-internal/issues/1320