### PR TITLE
Remove deprecated function `curl_close()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ HumHub Changelog
 -------------------------------
 - Fix #8401: Module version migration crash when module versions cannot be determined
 - Fix #8400: Button text horizontal centering and spacing in People heading (since 1.19.0-beta.2)
+- Fix #8404: Remove deprecated function `curl_close()`
 
 1.19.0-beta.2 (August 19, 2026)
 -------------------------------

--- a/protected/humhub/libs/UrlOembedHttpClient.php
+++ b/protected/humhub/libs/UrlOembedHttpClient.php
@@ -47,7 +47,6 @@ class UrlOembedHttpClient implements UrlOembedClient
             }
         }
         $return = curl_exec($curl);
-        curl_close($curl);
 
         return $this->parseJson($return);
     }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] All tests are passing
- [x] Changelog was modified

**Other information:**
https://github.com/humhub/humhub-internal/issues/1322