### PR TITLE
Remove the dead defaultDepends asset bundle mechanism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ HumHub Changelog
 
 1.19.0-beta.3 (Unreleased)
 -------------------------------
+- Enh #8411: Removed the `AssetBundle::$defaultDepends` mechanism — a property-name typo kept it from ever running, and activating it makes the core bundle depend on itself, see `docs/develop/module-migrate.md`
 - Fix #8401: Module version migration crash when module versions cannot be determined
 - Fix #8400: Button text horizontal centering and spacing in People heading (since 1.19.0-beta.2)
 - Fix #8404: Remove deprecated function `curl_close()`

--- a/docs/develop/module-migrate.md
+++ b/docs/develop/module-migrate.md
@@ -370,6 +370,17 @@ Each minor release line has its own file with the breaking changes, new APIs and
     call like `$menuLink->setIcon('user', true)` keeps "succeeding" but the icon is no longer
     right-aligned — audit every `->setIcon(...)` call that passes a second argument and call
     `->getLink()->right()` explicitly if right-alignment is still needed.
+- **Removed** `humhub\components\assets\AssetBundle::$defaultDepends` (unused by any known module).
+  It promised that a bundle implicitly depends on `CoreBundleAsset` without listing it in
+  `$depends`, but the code applying it read a misspelled property (`dependsDefault`) and has
+  therefore never run since it was added in 1.5 (#3941). It also cannot be repaired as written:
+  with the property name corrected, every bundle inside `CoreBundleAsset`'s own dependency tree
+  depends on it and Yii aborts the request with `A circular dependency is detected for bundle
+  'humhub\assets\CoreBundleAsset'`. A bundle needing the core bundle lists it in `$depends`
+  itself, which is what bundles have been doing all along. The `public $defaultDepends = false;`
+  opt-out in core bundles is gone with it; a module declaring the property keeps working (it
+  becomes an unused own property), but a bundle **configured** with `'defaultDepends' => ...`
+  now fails with `Setting unknown property`.
 
 ## Released versions
 

--- a/protected/humhub/assets/AnimateCssAsset.php
+++ b/protected/humhub/assets/AnimateCssAsset.php
@@ -20,11 +20,6 @@ class AnimateCssAsset extends AssetBundle
     /**
      * @inheritdoc
      */
-    public $defaultDepends = false;
-
-    /**
-     * @inheritdoc
-     */
     public $sourcePath = '@npm/animate.css';
 
     /**

--- a/protected/humhub/assets/AppAsset.php
+++ b/protected/humhub/assets/AppAsset.php
@@ -43,11 +43,6 @@ class AppAsset extends AssetBundle
     /**
      * @inheritdoc
      */
-    public $defaultDepends = false;
-
-    /**
-     * @inheritdoc
-     */
     public $jsPosition = View::POS_HEAD;
 
     public const BUNDLE_NAME = 'app';

--- a/protected/humhub/assets/BluebirdAsset.php
+++ b/protected/humhub/assets/BluebirdAsset.php
@@ -21,11 +21,6 @@ class BluebirdAsset extends AssetBundle
     /**
      * @inheritdoc
      */
-    public $defaultDepends = false;
-
-    /**
-     * @inheritdoc
-     */
     public $defer = false;
 
     /**

--- a/protected/humhub/assets/CoreApiAsset.php
+++ b/protected/humhub/assets/CoreApiAsset.php
@@ -34,11 +34,6 @@ class CoreApiAsset extends AssetBundle
     /**
      * @inheritdoc
      */
-    public $defaultDepends = false;
-
-    /**
-     * @inheritdoc
-     */
     public $js = [
         'js/humhub/humhub.core.js',
         'js/humhub/humhub.i18n.js', // Must be registered before all modules that require('i18n') at definition time

--- a/protected/humhub/assets/CoreBundleAsset.php
+++ b/protected/humhub/assets/CoreBundleAsset.php
@@ -36,8 +36,6 @@ class CoreBundleAsset extends AssetBundle
 
     public const BUNDLE_NAME = 'defer';
 
-    public $defaultDepends = false;
-
     public const STATIC_DEPENDS = [
         AppAsset::class,
         JqueryHighlightAsset::class,

--- a/protected/humhub/assets/CoreExtensionAsset.php
+++ b/protected/humhub/assets/CoreExtensionAsset.php
@@ -14,11 +14,6 @@ class CoreExtensionAsset extends AssetBundle
     /**
      * @inheritdoc
      */
-    public $defaultDepends = false;
-
-    /**
-     * @inheritdoc
-     */
     public $js = [
 
         'js/humhub/humhub.ui.form.elements.js',

--- a/protected/humhub/assets/IntersectionObserverPolyfillAsset.php
+++ b/protected/humhub/assets/IntersectionObserverPolyfillAsset.php
@@ -21,11 +21,6 @@ class IntersectionObserverPolyfillAsset extends AssetBundle
     /**
      * @inheritdoc
      */
-    public $defaultDepends = false;
-
-    /**
-     * @inheritdoc
-     */
     public $defer = false;
 
     /**

--- a/protected/humhub/assets/IntlMessageFormatAsset.php
+++ b/protected/humhub/assets/IntlMessageFormatAsset.php
@@ -7,7 +7,6 @@ use humhub\components\View;
 
 class IntlMessageFormatAsset extends AssetBundle
 {
-    public $defaultDepends = false;
     public $defer = false;
     public $jsPosition = View::POS_HEAD;
     public $sourcePath = '@npm/intl-messageformat';

--- a/protected/humhub/assets/JqueryTimeAgoAsset.php
+++ b/protected/humhub/assets/JqueryTimeAgoAsset.php
@@ -21,11 +21,6 @@ class JqueryTimeAgoAsset extends AssetBundle
     /**
      * @inheritdoc
      */
-    public $defaultDepends = false;
-
-    /**
-     * @inheritdoc
-     */
     public $defer = false;
 
     /**

--- a/protected/humhub/assets/JuiBootstrapBridgeAsset.php
+++ b/protected/humhub/assets/JuiBootstrapBridgeAsset.php
@@ -32,11 +32,6 @@ class JuiBootstrapBridgeAsset extends AssetBundle
     /**
      * @inheritdoc
      */
-    public $defaultDepends = false;
-
-    /**
-     * @inheritdoc
-     */
     public $jsPosition = View::POS_HEAD;
 
     /**

--- a/protected/humhub/assets/OpenSansAsset.php
+++ b/protected/humhub/assets/OpenSansAsset.php
@@ -43,11 +43,6 @@ class OpenSansAsset extends AssetBundle
     /**
      * @inheritdoc
      */
-    public $defaultDepends = false;
-
-    /**
-     * @inheritdoc
-     */
     public $jsPosition = View::POS_HEAD;
 
     /**

--- a/protected/humhub/assets/PjaxAsset.php
+++ b/protected/humhub/assets/PjaxAsset.php
@@ -26,11 +26,6 @@ class PjaxAsset extends AssetBundle
     /**
      * @inheritdoc
      */
-    public $defaultDepends = false;
-
-    /**
-     * @inheritdoc
-     */
     public $defer = false;
 
     /**

--- a/protected/humhub/components/assets/AssetBundle.php
+++ b/protected/humhub/components/assets/AssetBundle.php
@@ -2,11 +2,7 @@
 
 namespace humhub\components\assets;
 
-use humhub\assets\CoreBundleAsset;
 use humhub\components\View;
-use Yii;
-use yii\helpers\ArrayHelper;
-use yii\web\Application;
 use yii\web\AssetBundle as BaseAssetBundle;
 
 /**
@@ -116,14 +112,6 @@ class AssetBundle extends BaseAssetBundle
     public $preload = [];
 
     /**
-     * @var array|false default dependencies not required to be mentioned in $depends. Normally only deactivated in some
-     * core assets.
-     */
-    public $defaultDepends = [
-        CoreBundleAsset::class,
-    ];
-
-    /**
      * @inheritDoc
      */
     public function init()
@@ -164,10 +152,6 @@ class AssetBundle extends BaseAssetBundle
             $this->publishOptions['forceCopy'] = true;
         } elseif (!isset($this->publishOptions['forceCopy'])) {
             $this->publishOptions['forceCopy'] = false;
-        }
-
-        if ((!(Yii::$app instanceof Application) || !Yii::$app->request->isAjax) && !empty($this->dependsDefault)) {
-            $this->depends[] = ArrayHelper::merge($this->depends, $this->defaultDepends);
         }
     }
 

--- a/protected/humhub/config/assets.php
+++ b/protected/humhub/config/assets.php
@@ -64,7 +64,6 @@ return [
         AppAsset::BUNDLE_NAME => [
             'class' => AssetBundle::class,
             'defer' => false,
-            'defaultDepends' => false,
             'sourcePath' => '@humhub/resources',
             'basePath' => '@humhub/resources',
             'baseUrl' => '',
@@ -82,7 +81,6 @@ return [
             'class' => AssetBundle::class,
             'defer' => true,
             'jsPosition' => View::POS_HEAD,
-            'defaultDepends' => false,
             'sourcePath' => '@humhub/resources',
             'basePath' => '@humhub/resources',
             'baseUrl' => '',


### PR DESCRIPTION
`humhub\components\assets\AssetBundle::$defaultDepends` promises that every bundle implicitly depends on `CoreBundleAsset` without listing it in `$depends`. It has never done that: the code applying it reads a misspelled property.

```php
if ((!(Yii::$app instanceof Application) || !Yii::$app->request->isAjax) && !empty($this->dependsDefault)) {
    $this->depends[] = ArrayHelper::merge($this->depends, $this->defaultDepends);
}
```

`$this->dependsDefault` does not exist, so the branch has been dead since it was added in 1.5 (#3941). Its body is wrong too — it would append the merged array as a single nested element of `$depends`.

## Why remove instead of repair

With the property name corrected, the mechanism takes the site down: every bundle inside `CoreBundleAsset`'s own dependency tree then depends on `CoreBundleAsset`, and Yii aborts the request.

```
yii\base\InvalidConfigException: A circular dependency is detected for bundle 'humhub\assets\CoreBundleAsset'.
```

(Verified locally by fixing the property name and loading a page.) Making it work would mean auditing every bundle in that tree and opting each one out — for a behaviour nobody has been missing for five years. Bundles that need the core bundle list it in `$depends` themselves, which is what they have been doing all along.

## Scope

- the property, its dead branch and the imports that only served them
- the `public $defaultDepends = false;` opt-outs in 12 core bundles and the two entries in the asset build config — left behind they would set a property that no longer exists
- a `Removed` note in `docs/develop/module-migrate.md`

No runtime behaviour changes: the removed branch never executed.

## Module impact

A search across 167 module repositories (`humhub`, `humhub-contrib`, `cuzy-app`) finds no use of `defaultDepends`. A module that declares the property keeps working — it simply becomes an unused own property. A bundle *configured* with `'defaultDepends' => ...` would now fail with `Setting unknown property`; no module does that.