### PR TITLE
Fix: A user picker or space picker request without a `keyword` parame…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ HumHub Changelog
 - Fix #8401: Module version migration crash when module versions cannot be determined
 - Fix #8400: Button text horizontal centering and spacing in People heading (since 1.19.0-beta.2)
 - Fix #8404: Remove deprecated function `curl_close()`
+- Fix: A user picker or space picker request without a `keyword` parameter crashes with a `TypeError`
 
 1.19.0-beta.2 (August 19, 2026)
 -------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ HumHub Changelog
 - Fix #8401: Module version migration crash when module versions cannot be determined
 - Fix #8400: Button text horizontal centering and spacing in People heading (since 1.19.0-beta.2)
 - Fix #8404: Remove deprecated function `curl_close()`
-- Fix: A user picker or space picker request without a `keyword` parameter crashes with a `TypeError`
+- Fix #8415: A user picker or space picker request without a `keyword` parameter crashes with a `TypeError`
 
 1.19.0-beta.2 (August 19, 2026)
 -------------------------------

--- a/protected/humhub/modules/content/components/AbstractActiveQueryContentContainer.php
+++ b/protected/humhub/modules/content/components/AbstractActiveQueryContentContainer.php
@@ -57,11 +57,11 @@ abstract class AbstractActiveQueryContentContainer extends ActiveQuery
     /**
      * Performs a container text search
      *
-     * @param string $keywords
+     * @param string|array|null $keywords
      * @param array|null $fields if empty the fields will be used from the method getSearchableFields()
      * @return self
      */
-    public function search(string $keywords, ?array $fields = null): ActiveQuery
+    public function search(string|array|null $keywords, ?array $fields = null): ActiveQuery
     {
         if (empty($keywords)) {
             return $this;

--- a/protected/humhub/modules/user/models/UserFilter.php
+++ b/protected/humhub/modules/user/models/UserFilter.php
@@ -74,7 +74,7 @@ class UserFilter extends User
      * Filter users by keyword
      *
      * @param ActiveQueryUser $query
-     * @param string|array $keyword
+     * @param string|array|null $keyword
      * @return ActiveQueryUser
      */
     public static function addKeywordFilter($query, $keyword)


### PR DESCRIPTION
…ter (e.g. `/user/search/json`, `/space/browse/search-json`) crashed with a `TypeError`, since `AbstractActiveQueryContentContainer::search()` only accepted a string although it already handles an empty keyword; it now accepts `string|array|null`

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included
- [x] Changelog was modified

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Fixes the error for the query `/user/search/json?space_id=56`

> TypeError: humhub\modules\content\components\AbstractActiveQueryCo ntentContainer::search(): Argument #1 ($keywords) must be of type string, null given, called in /var/ww/protected/humhub/modules/user/models/UserFilter .php on line 82 and defined in /var/ww/protected/humhub/modules/content/components/Abs tractActiveQueryContentContainer.php:64

Claude (Opus) report:

> Cause: AbstractActiveQueryContentContainer::search() (protected/humhub/modules/content/components/AbstractAct iveQueryContentContainer.php:64) declared string $keywords, but its very first statement is if (empty($keywords)) return $this; — i.e. it was written to tolerate an empty keyword. /user/search/json?space_id=56 carries no keyword, so Yii::$app->request->get('keyword') returns null and the call fails at the signature before that guard ever runs.
> 
> Fix: widened the parameter to string|array|null (array was already supported internally by setUpKeywords() and is what UserFilter::addKeywordFilter()'s docblock promises), plus the two docblocks.
> 
> This also fixes the identical crash on /space/browse/search-json without a keyword (protected/humhub/modules/space/controllers/BrowseContro ller.php:55), which passes the raw GET value the same way.
> 
> Notes: - Widening is source-compatible for all existing callers. A module subclass that overrides search() with a narrower string type would now be an incompatible signature — no core subclass does (ActiveQueryUser, ActiveQuerySpace don't override it), and I'd expect that to be very rare externally. Say the word if you'd rather I guard at the call sites instead and leave the abstract signature untouched. - The (string) casts at SearchController::actionMentioning() and in MentioningController are now redundant workarounds; I left them alone to keep the diff focused. - Changelog entry uses #8415 (next free number — latest issue/PR is 8414); adjust if the PR lands on a different number. - Note that space_id=56 is ignored by SearchController::actionJson() — it filters over all users, not space members. That's separate from the crash, so I left it; tell me if it should be looked at.