### PR TITLE
Enh: Customize Bootstrap through its Sass variables in `variables.scs…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ HumHub Changelog
 - Fix #8404: Remove deprecated function `curl_close()`
 - Fix #8415: A user picker or space picker request without a `keyword` parameter crashes with a `TypeError`
 - Enh: Add a space between at the top of the card icons (in the card header)
+- Enh: Customize Bootstrap through its Sass variables in `variables.scss` instead of redeclaring the generated `--bs-*` CSS variables in the component SCSS files (buttons, badges, dropdowns, list groups, navs, popovers, progress bars, tables and tooltips)
 
 1.19.0-beta.2 (August 19, 2026)
 -------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ HumHub Changelog
 - Fix #8400: Button text horizontal centering and spacing in People heading (since 1.19.0-beta.2)
 - Fix #8404: Remove deprecated function `curl_close()`
 - Fix #8415: A user picker or space picker request without a `keyword` parameter crashes with a `TypeError`
-- Enh: Add a space between at the top of the card icons (in the card header)
-- Enh: Customize Bootstrap through its Sass variables in `variables.scss` instead of redeclaring the generated `--bs-*` CSS variables in the component SCSS files (buttons, badges, dropdowns, list groups, navs, popovers, progress bars, tables and tooltips)
+- Enh #8419: Add a space between at the top of the card icons (in the card header)
+- Enh #8421: Customize Bootstrap through its Sass variables in `variables.scss` instead of redeclaring the generated `--bs-*` CSS variables in the component SCSS files (buttons, badges, dropdowns, list groups, navs, popovers, progress bars, tables and tooltips)
 
 1.19.0-beta.2 (August 19, 2026)
 -------------------------------

--- a/protected/humhub/resources/scss/_badge.scss
+++ b/protected/humhub/resources/scss/_badge.scss
@@ -13,8 +13,6 @@
     }
 
     .badge {
-        --bs-badge-font-size: 0.75rem;
-
         font-family: Arial, sans-serif;
         text-transform: uppercase;
         vertical-align: bottom;

--- a/protected/humhub/resources/scss/_button.scss
+++ b/protected/humhub/resources/scss/_button.scss
@@ -3,18 +3,13 @@
 // --------------------------------------------------
 
 // Bootstrap overwrite
-// See all available Bootstrap CSS variables: @humhub/protected/vendor/twbs/bootstrap/dist/css/bootstrap.css
+// Sizings, paddings, radius etc. are customized through Sass variables, see variables.scss.
+// Only selector-scoped customizations are declared here as `--bs-*` overrides.
 
 @if not $prev-button {
     .btn {
-        --bs-btn-padding-x: 1.1rem;
-        --bs-btn-padding-y: 0.5rem;
-        --bs-btn-font-weight: 600;
-        --bs-btn-border-radius: 3px;
         --hh-btn-gap: 0.6rem;
 
-        white-space: nowrap;
-        transition: color 0.3s, background-color 0.3s, border-color 0.3s;
         display: inline-flex;
         align-items: center;
         gap: var(--hh-btn-gap);
@@ -26,15 +21,10 @@
     }
 
     .btn-sm, .btn-group-sm > .btn {
-        --bs-btn-padding-x: 0.5rem;
-        --bs-btn-padding-y: 0.2rem;
         --hh-btn-gap: 0.4rem;
     }
 
     .btn-lg, .btn-group-lg > .btn {
-        --bs-btn-padding-x: 1.75rem;
-        --bs-btn-padding-y: 0.9rem;
-        --bs-btn-font-size: 1.1rem;
         --hh-btn-gap: 0.8rem;
     }
 

--- a/protected/humhub/resources/scss/_dropdown.scss
+++ b/protected/humhub/resources/scss/_dropdown.scss
@@ -4,11 +4,8 @@
 
 @if not $prev-dropdown {
     // Bootstrap overwrite
-    // See all available Bootstrap CSS variables: @humhub/protected/vendor/twbs/bootstrap/dist/css/bootstrap.css
+    // Global dropdown customizations are made through Sass variables, see variables.scss.
     .dropdown-menu {
-        --bs-dropdown-bg: var(--hh-background-color-main);
-        --bs-dropdown-font-size: 14px;
-
         // Fix: dropdown flipped upward by Popper (not enough space below,
         // e.g. browser zoom > 100%) can end up hidden behind the fixed
         // topbars (#topbar-first/.fixed-top: 1030, #topbar-second: 1029)

--- a/protected/humhub/resources/scss/_list-group.scss
+++ b/protected/humhub/resources/scss/_list-group.scss
@@ -3,13 +3,7 @@
 // --------------------------------------------------
 
 @if not $prev-list-group {
-    // Bootstrap overwrite
-    .list-group {
-        --bs-list-group-bg: var(--hh-background-color-main);
-        --bs-list-group-border-width: 0;
-        --bs-list-group-active-bg: var(--hh-background-color-secondary);
-        --bs-list-group-active-color: var(--hh-text-color-highlight);
-    }
+    // Bootstrap overwrite: see the list group Sass variables in variables.scss
 
     .list-group-item {
         padding: 6px 15px;

--- a/protected/humhub/resources/scss/_nav.scss
+++ b/protected/humhub/resources/scss/_nav.scss
@@ -3,16 +3,7 @@
 // --------------------------------------------------
 
 @if not $prev-nav {
-    // Bootstrap overwrite
-    // See all available Bootstrap CSS variables: @humhub/protected/vendor/twbs/bootstrap/dist/css/bootstrap.css
-
-    .nav {
-        --bs-nav-link-hover-color: var(--bs-link-color);
-    }
-
-    .nav-tabs {
-        --bs-nav-tabs-link-active-bg: var(--hh-background-color-main);
-    }
+    // Bootstrap overwrite: see the nav Sass variables in variables.scss
 
     .nav, .list-group {
         --hh-nav-icon-width: 20px;

--- a/protected/humhub/resources/scss/_popover.scss
+++ b/protected/humhub/resources/scss/_popover.scss
@@ -3,11 +3,9 @@
 // --------------------------------------------------
 
 @if not $prev-popover {
-    .popover {
-        border: 1px solid rgba(0, 0, 0, 0.15);
-        border-radius: 4px;
-        box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
+    // Bootstrap overwrite: see the popover Sass variables in variables.scss
 
+    .popover {
         .popover-title {
             background: none;
             border-bottom: none;

--- a/protected/humhub/resources/scss/_progress.scss
+++ b/protected/humhub/resources/scss/_progress.scss
@@ -3,12 +3,10 @@
 // --------------------------------------------------
 
 @if not $prev-progress {
+    // Bootstrap overwrite: see the progress Sass variables in variables.scss
+
     .progress {
-        height: 10px;
         margin-bottom: 15px;
-        box-shadow: none;
-        background: var(--hh-background-color-page);
-        border-radius: 10px;
     }
 
     .progress-bar-info {

--- a/protected/humhub/resources/scss/_table.scss
+++ b/protected/humhub/resources/scss/_table.scss
@@ -3,12 +3,7 @@
 // --------------------------------------------------
 
 @if not $prev-table {
-    // Bootstrap overwrite
-    // See all available Bootstrap CSS variables: @humhub/protected/vendor/twbs/bootstrap/dist/css/bootstrap.css
-    .table {
-        --bs-table-bg: var(--hh-background-color-main);
-        --bs-table-color: var(--bs-body-color);
-    }
+    // Bootstrap overwrite: see the table Sass variables in variables.scss
 
     table {
         margin-bottom: 0 !important;

--- a/protected/humhub/resources/scss/_tooltip.scss
+++ b/protected/humhub/resources/scss/_tooltip.scss
@@ -3,41 +3,14 @@
 // --------------------------------------------------
 
 @if not $prev-tooltip {
+    // Bootstrap overwrite: see the tooltip Sass variables in variables.scss.
+    // The arrow colors are derived from `$tooltip-bg` by Bootstrap itself.
+
     .tooltip-inner {
-        background-color: var(--bs-primary);
-        max-width: 400px;
         text-align: left;
         padding: 2px 8px 4px;
-        font-size: 12px;
         font-weight: bold;
         white-space: pre-wrap;
-        color: var(--hh-primary-contrast);
-    }
-
-    .tooltip {
-        &[data-popper-placement^="top"] {
-            .tooltip-arrow::before {
-                border-top-color: var(--bs-primary);
-            }
-        }
-
-        &[data-popper-placement^="right"] {
-            .tooltip-arrow::before {
-                border-right-color: var(--bs-primary);
-            }
-        }
-
-        &[data-popper-placement^="bottom"] {
-            .tooltip-arrow::before {
-                border-bottom-color: var(--bs-primary);
-            }
-        }
-
-        &[data-popper-placement^="left"] {
-            .tooltip-arrow::before {
-                border-left-color: var(--bs-primary);
-            }
-        }
     }
 
     .tooltip.in {

--- a/protected/humhub/resources/scss/variables.scss
+++ b/protected/humhub/resources/scss/variables.scss
@@ -2,6 +2,12 @@
 // Sass variables
 // For CSS variables, see _root.scss
 // All variables must have the !default flag to allow child-themes to overwrite them
+//
+// Bootstrap defaults must be customized here, by overwriting the Sass variable
+// (see @humhub/protected/vendor/twbs/bootstrap/scss/_variables.scss), and not by
+// redeclaring the generated `--bs-*` CSS variable in a component file. Only
+// customizations that are scoped to a specific selector (e.g. `.navbar.topbar`)
+// belong in a component file as a `--bs-*` override.
 // --------------------------------------------------
 
 $isFluid: false;
@@ -179,11 +185,96 @@ $container-max-widths: (
 // Badges
 //
 
-$badge-font-size: 10px !default;
+$badge-font-size: 0.75rem !default;
 $badge-font-weight: normal !default;
 $badge-padding-y: 3px !default;
 $badge-padding-x: 5px !default;
 $badge-border-radius: 2px !default;
+
+
+//
+// Buttons
+// --------------------------------------------------
+
+$btn-padding-y: 0.5rem !default;
+$btn-padding-x: 1.1rem !default;
+$btn-padding-y-sm: 0.2rem !default;
+$btn-padding-x-sm: 0.5rem !default;
+$btn-padding-y-lg: 0.9rem !default;
+$btn-padding-x-lg: 1.75rem !default;
+$btn-font-size-lg: 1.1rem !default;
+$btn-font-weight: 600 !default;
+$btn-white-space: nowrap !default;
+$btn-transition: color 0.3s, background-color 0.3s, border-color 0.3s !default;
+$btn-border-radius: 3px !default;
+$btn-border-radius-sm: $btn-border-radius !default;
+$btn-border-radius-lg: $btn-border-radius !default;
+
+
+//
+// Dropdowns
+// --------------------------------------------------
+
+$dropdown-bg: var(--hh-background-color-main) !default;
+
+
+//
+// List groups
+// --------------------------------------------------
+
+$list-group-bg: var(--hh-background-color-main) !default;
+$list-group-border-width: 0 !default;
+$list-group-active-color: var(--hh-text-color-highlight) !default;
+$list-group-active-bg: var(--hh-background-color-secondary) !default;
+
+
+//
+// Navs
+// --------------------------------------------------
+
+$nav-link-hover-color: var(--bs-link-color) !default;
+$nav-tabs-link-active-bg: var(--hh-background-color-main) !default;
+
+
+//
+// Popovers
+// --------------------------------------------------
+
+$popover-border-width: 1px !default;
+$popover-border-color: rgba(0, 0, 0, 0.15) !default;
+$popover-border-radius: 4px !default;
+$popover-box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175) !default;
+
+
+//
+// Progress bars
+// --------------------------------------------------
+
+$progress-height: 10px !default;
+$progress-bg: var(--hh-background-color-page) !default;
+$progress-border-radius: 10px !default;
+$progress-box-shadow: none !default;
+
+
+//
+// Tables
+// --------------------------------------------------
+
+$table-color: var(--bs-body-color) !default;
+$table-bg: var(--hh-background-color-main) !default;
+
+
+//
+// Tooltips
+// --------------------------------------------------
+
+$tooltip-max-width: 400px !default;
+// 12px. Bootstrap passes font sizes through RFS, which converts `px` to `rem`
+// assuming a 16px root font size, so font sizes must be expressed in `rem`
+// relatively to $font-size-root.
+$tooltip-font-size: divide(12px, $font-size-root) * 1rem !default;
+$tooltip-color: var(--hh-primary-contrast) !default;
+$tooltip-bg: var(--bs-primary) !default;
 
 
 //


### PR DESCRIPTION
…s` instead of redeclaring the generated `--bs-*` CSS variables in the component SCSS files (buttons, badges, dropdowns, list groups, navs, popovers, progress bars, tables and tooltips)

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [x] Yes: It could for child themes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included
- [x] Changelog was modified

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Done by Claude Opus from this request:

> In @protected/vendor/twbs/bootstrap /scss/_variables.scss we have several Sass variables. But in some locations such as @protected/humhub/resources/scss/_button.scss#L13 we overwrite the CSS variable. This is wrong, for this example, we should overwrite the Sass variable in @protected/hum hub/resources/scss/variables.scss by adding `$btn-border-radius: 3px;`. Can you check all the code in @rotected/humhub/resources/scss and fix what needs to be fixed to respect Bootstrap best practices?

I have tested all the changes, looks all good (no visual changes).

Claude report:

> Done. I moved every global Bootstrap customization from --bs-* CSS-variable overrides in the component files to the corresponding Sass variables in variables.scss, and verified the result by compiling the full stylesheet before and after and diffing the CSS.
> 
> What changed
> 
> variables.scss — new sections for buttons, dropdowns, list groups, navs, popovers, progress bars, tables, tooltips, plus a header note stating the rule.
> 
> Component files — removed the now-redundant overrides:
> 
>   File: _button.scss                                      
>   Removed: --bs-btn-padding-x/y, font-weight,             
>   border-radius, font-size (.btn, .btn-sm, .btn-lg),      
>   white-space, transition                                 
>   ────────────────────────────────────────                
>   File: _badge.scss                                       
>   Removed: --bs-badge-font-size                           
>   ────────────────────────────────────────                
>   File: _dropdown.scss                                    
>   Removed: --bs-dropdown-bg, --bs-dropdown-font-size      
>   ────────────────────────────────────────                
>   File: _list-group.scss                                  
>   Removed: whole .list-group block (4 vars)               
>   ────────────────────────────────────────                
>   File: _nav.scss                                         
>   Removed: .nav and .nav-tabs blocks                      
>   ────────────────────────────────────────                
>   File: _table.scss                                       
>   Removed: whole .table block                             
>   ────────────────────────────────────────                
>   File: _tooltip.scss                                     
>   Removed: bg/max-width/font-size/color + all four        
>   arrow-color rules — Bootstrap derives arrows from       
>   $tooltip-bg itself                                      
>   ────────────────────────────────────────                
>   File: _progress.scss                                    
>   Removed: height/bg/border-radius/box-shadow             
>   ────────────────────────────────────────                
>   File: _popover.scss                                     
>   Removed: border/border-radius/box-shadow   
> 
> Left alone deliberately: selector-scoped overrides that have no Sass equivalent — .btn-group > .btn, .dropdown-menu[data-popper-placement^="top"], .navbar.topbar, #layout-content .container's --bs-gutter-x, the _mixins.scss and _bootstrap3.scss ones.
> 
> Bugs this surfaced
> 
>   - $badge-font-size was dead. variables.scss said 10px   
>     while _badge.scss overrode --bs-badge-font-size:      
>     0.75rem. I set the Sass variable to 0.75rem (the value
>     actually rendering).                                  
>   - $dropdown-font-size: 14px was a no-op — identical to  
>     Bootstrap's 1rem default at HumHub's 14px root.       
>     Dropped rather than moved.                            
>   - RFS/root-font-size mismatch. Bootstrap runs font sizes
>     through RFS, which converts px → rem assuming a 16px  
>     root, but $font-size-root is 14px. My first pass      
>     naively used $tooltip-font-size: 12px and silently    
>     shrank tooltips to 10.5px — the CSS diff caught it.   
>     It's now divide(12px, $font-size-root) * 1rem, with a 
>     comment, and I confirmed it still yields 12px when a  
>     child theme sets a 16px root. Any future px value     
>     assigned to an RFS-wrapped variable has this trap;    
>     more broadly, $rfs-rem-value is left at 16 while the  
>     root is 14px, which is arguably worth fixing globally 
>     — but that's a separate change with wider blast       
>     radius, so I didn't touch it.    
> 
> Intentional behavior changes (please review)
> 
> Bootstrap derives other variables from the ones I set, so a few things shifted. All are consistency fixes, but they are visible:
> 
>   1. Striped/hover/active table text now uses             
>      --bs-body-color instead of --bs-emphasis-color (black
>      #000 vs #555). Previously only non-striped rows got  
>      the HumHub color — striped rows rendered noticeably  
>      darker. This is the most visible change.             
>   2. .dropdown-toggle-split padding 0.5625rem → 0.825rem  
>      (and lg: 0.75rem → 1.3125rem), now derived from      
>      $btn-padding-x. It was hard-coded off Bootstrap's    
>      narrower default and is now in line with .btn-group >
>      .btn's 0.8rem.                                       
>   3. $accordion-transition and                            
>      .form-control::file-selector-button inherit          
>      $btn-transition, so they pick up HumHub's 0.3s timing
>      (accordions also lose box-shadow from the transition 
>      list).                                               
>   4. .btn-sm/.btn-lg border-radius — I pinned             
>      $btn-border-radius-sm/-lg to 3px to preserve today's 
>      rendering, which relied on HumHub's .btn rule        
>      out-cascading Bootstrap's .btn-sm.                   
>   5. --bs-navbar-toggler-border-radius,                   
>      --bs-list-group-disabled-bg,                         
>      --bs-nav-tabs-link-active-border-color,              
>      --bs-popover-inner-border-radius follow their new    
>      sources; all are either invisible (list-group borders
>      are 0, active tab bottom border is transparent       
>      !important) or corrections.   
> 
> One consequence worth knowing: these values now apply even when a theme sets $prev-button: true etc., since variables.scss isn't behind those flags. Such themes can still override each Sass variable in their own variables.scss (imported first, !default respected) — verified by compiling with a child theme overriding $btn-border-radius and $tooltip-bg with every $prev-* flag on.
> 
> I added a CHANGELOG.md entry under 1.19.0-beta.3 (Unreleased) without a PR number, matching the last entry; add the number when the PR is opened. I have not committed anything.