### PR TITLE
Fix: `Badge::action()` and `Badge::withLink()` rendered the badge mar…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ HumHub Changelog
 - Enh #8419: Add a space between at the top of the card icons (in the card header)
 - Enh #8421: Customize Bootstrap through its Sass variables in `variables.scss` instead of redeclaring the generated `--bs-*` CSS variables in the component SCSS files (buttons, badges, dropdowns, list groups, navs, popovers, progress bars, tables and tooltips)
 - Fix #8422: Replace removed `.sr-only` class with `.visually-hidden`
+- Fix: `Badge::action()` and `Badge::withLink()` rendered the badge markup escaped inside the link, since the wrapping link encoded the label it is given in `Badge::run()` — which is the already rendered badge, not text
 
 1.19.0-beta.2 (August 19, 2026)
 -------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ HumHub Changelog
 - Enh #8419: Add a space between at the top of the card icons (in the card header)
 - Enh #8421: Customize Bootstrap through its Sass variables in `variables.scss` instead of redeclaring the generated `--bs-*` CSS variables in the component SCSS files (buttons, badges, dropdowns, list groups, navs, popovers, progress bars, tables and tooltips)
 - Fix #8422: Replace removed `.sr-only` class with `.visually-hidden`
-- Fix: `Badge::action()` and `Badge::withLink()` rendered the badge markup escaped inside the link, since the wrapping link encoded the label it is given in `Badge::run()` — which is the already rendered badge, not text
+- Fix #8434: `Badge::action()` and `Badge::withLink()` rendered the badge markup escaped inside the link, since the wrapping link encoded the label it is given in `Badge::run()` — which is the already rendered badge, not text
 
 1.19.0-beta.2 (August 19, 2026)
 -------------------------------

--- a/protected/humhub/tests/codeception/unit/widgets/BadgeWidgetTest.php
+++ b/protected/humhub/tests/codeception/unit/widgets/BadgeWidgetTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace humhub\tests\codeception\unit\widgets;
+
+use humhub\widgets\bootstrap\Badge;
+use humhub\widgets\bootstrap\Link;
+use tests\codeception\_support\HumHubDbTestCase;
+
+class BadgeWidgetTest extends HumHubDbTestCase
+{
+    private const XSS_LABEL = '<img src=x onerror=alert(1)>';
+    private const XSS_LABEL_ENCODED = '&lt;img src=x onerror=alert(1)&gt;';
+
+    public function testLabelIsEncodedByDefault()
+    {
+        $this->assertStringContainsString(
+            self::XSS_LABEL_ENCODED,
+            (string)Badge::none(self::XSS_LABEL),
+        );
+    }
+
+    /**
+     * The link added by action() wraps the rendered badge, so it must not encode its label again.
+     */
+    public function testActionKeepsTheBadgeMarkupUnescaped()
+    {
+        $result = (string)Badge::none('3')->icon('comment-o')->action('comment.toggleComment', null, '#comment_C1P');
+
+        $this->assertStringContainsString('data-action-click="comment.toggleComment"', $result);
+        $this->assertStringContainsString('data-action-click-target="#comment_C1P"', $result);
+        $this->assertMatchesRegularExpression('/<a [^>]*>\s*<span [^>]*class="badge"/', $result);
+        $this->assertStringNotContainsString('&lt;span', $result);
+    }
+
+    /**
+     * The badge label stays encoded even once the badge is wrapped in a link.
+     */
+    public function testActionKeepsTheLabelEncoded()
+    {
+        $result = (string)Badge::none(self::XSS_LABEL)->action('foo');
+
+        $this->assertStringContainsString(self::XSS_LABEL_ENCODED, $result);
+        $this->assertStringNotContainsString(self::XSS_LABEL, $result);
+    }
+
+    public function testWithLinkKeepsTheBadgeMarkupUnescapedAndTheLabelEncoded()
+    {
+        $result = (string)Badge::none(self::XSS_LABEL)->withLink(Link::withAction(null, 'foo'));
+
+        $this->assertMatchesRegularExpression('/<a [^>]*>\s*<span [^>]*class="badge"/', $result);
+        $this->assertStringContainsString(self::XSS_LABEL_ENCODED, $result);
+        $this->assertStringNotContainsString(self::XSS_LABEL, $result);
+    }
+
+    /**
+     * The label of a link given to withLink() is replaced by the rendered badge, so it never reaches the output.
+     */
+    public function testWithLinkDiscardsTheLabelOfTheGivenLink()
+    {
+        $result = (string)Badge::none('safe')->withLink(Link::to(self::XSS_LABEL));
+
+        $this->assertStringContainsString('>safe<', $result);
+        $this->assertStringNotContainsString(self::XSS_LABEL, $result);
+        $this->assertStringNotContainsString(self::XSS_LABEL_ENCODED, $result);
+    }
+
+    public function testLabelIsNotEncodedWhenExplicitlyDisabled()
+    {
+        $badge = new Badge(['label' => '<b>markup</b>', 'encodeLabel' => false]);
+
+        $this->assertStringContainsString('<b>markup</b>', (string)$badge);
+    }
+}

--- a/protected/humhub/widgets/bootstrap/Badge.php
+++ b/protected/humhub/widgets/bootstrap/Badge.php
@@ -61,7 +61,9 @@ class Badge extends Widget
         $result = Html::tag('span', $text, $this->options);
 
         if ($this->link) {
-            $result = (string) $this->link->setLabel($result);
+            // The link wraps the rendered badge, so its label is always HTML.
+            // $this->encodeLabel only applies to the label inside the badge, above.
+            $result = (string) $this->link->encodeLabel(false)->setLabel($result);
         }
 
         return $result;
@@ -114,7 +116,7 @@ class Badge extends Widget
     }
 
     /**
-     * Adds a data-action-click handler to the button.
+     * Wraps the badge in a link with a data-action-click handler.
      * @param $handler
      * @param null $url
      * @param null $target
@@ -122,8 +124,8 @@ class Badge extends Widget
      */
     public function action($handler, $url = null, $target = null)
     {
-        $this->link = Link::withAction($this->label, $handler, $url, $target)
-            ->encodeLabel($this->encodeLabel);
+        // The label of the link is the rendered badge, set in run()
+        $this->link = Link::withAction(null, $handler, $url, $target);
         return $this;
     }
 


### PR DESCRIPTION
…kup escaped inside the link, since the wrapping link encoded the label it is given in `Badge::run()` — which is the already rendered badge, not text

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included
- [ ] Changelog was modified

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
