### PR TITLE
Fix tab order of the reset filters button in the search area

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ HumHub Changelog
 - Fix #8422: Replace removed `.sr-only` class with `.visually-hidden`
 - Fix #8434: `Badge::action()` and `Badge::withLink()` rendered the badge markup escaped inside the link, since the wrapping link encoded the label it is given in `Badge::run()` — which is the already rendered badge, not text
 - Enh #8425: Implement visible focus for elements in cards for keyboard accessibility
+- Fix #8423: Fix tab order of the reset filters button in the search area
 
 1.19.0-beta.2 (August 19, 2026)
 -------------------------------

--- a/protected/humhub/modules/content/widgets/SearchFilters.php
+++ b/protected/humhub/modules/content/widgets/SearchFilters.php
@@ -43,6 +43,9 @@ class SearchFilters extends DirectoryFilters
             'afterInput' => Html::submitButton('<span class="fa fa-search" aria-hidden="true"></span>', [
                 'class' => 'form-button-search',
                 'aria-label' => Yii::t('ContentModule.base', 'Search'),
+                // Pressing Enter in the keyword field already submits the form, so this
+                // button doesn't need its own tab stop.
+                'tabindex' => '-1',
             ]),
             'sortOrder' => 100,
         ]);

--- a/protected/humhub/modules/marketplace/widgets/ModuleFilters.php
+++ b/protected/humhub/modules/marketplace/widgets/ModuleFilters.php
@@ -45,7 +45,12 @@ class ModuleFilters extends DirectoryFilters
             'placeholder' => Yii::t('MarketplaceModule.base', 'Description, Name, Keywords...'),
             'type' => 'input',
             'wrapperClass' => 'flex-fill form-search-filter-keyword',
-            'afterInput' => Html::submitButton(Icon::get('search'), ['class' => 'form-button-search']),
+            'afterInput' => Html::submitButton(Icon::get('search'), [
+                'class' => 'form-button-search',
+                // Pressing Enter in the keyword field already submits the form, so this
+                // button doesn't need its own tab stop.
+                'tabindex' => '-1',
+            ]),
             'sortOrder' => 100,
         ]);
 

--- a/protected/humhub/modules/space/widgets/SpaceDirectoryFilters.php
+++ b/protected/humhub/modules/space/widgets/SpaceDirectoryFilters.php
@@ -36,6 +36,9 @@ class SpaceDirectoryFilters extends DirectoryFilters
             'afterInput' => Html::submitButton('<span class="fa fa-search" aria-hidden="true"></span>', [
                 'class' => 'form-button-search',
                 'aria-label' => Yii::t('SpaceModule.base', 'Search'),
+                // Pressing Enter in the keyword field already submits the form, so this
+                // button doesn't need its own tab stop.
+                'tabindex' => '-1',
             ]),
             'sortOrder' => 100,
         ]);

--- a/protected/humhub/modules/ui/widgets/DirectoryFilters.php
+++ b/protected/humhub/modules/ui/widgets/DirectoryFilters.php
@@ -64,7 +64,7 @@ abstract class DirectoryFilters extends Widget
 
     public function initActions(): void
     {
-        // Find min sort to put the actions after the first filter
+        // Find min sort to put the toggle-more action right after the first filter
         $minSortOrder = null;
         foreach ($this->filters as $data) {
             if (isset($data['sortOrder']) && ($minSortOrder === null || $minSortOrder > $data['sortOrder'])) {
@@ -90,6 +90,17 @@ abstract class DirectoryFilters extends Widget
         }
 
         if (isset($this->data['action-url']) || $this->isFiltered()) {
+            // The reset action is always displayed as the very last action (see the
+            // .form-search-action rules in _cards.scss), so it also has to be the
+            // last one in the DOM/tab order - otherwise keyboard navigation reaches
+            // it long before it is visually shown.
+            $maxSortOrder = null;
+            foreach ($this->filters as $data) {
+                if (isset($data['sortOrder']) && ($maxSortOrder === null || $maxSortOrder < $data['sortOrder'])) {
+                    $maxSortOrder = $data['sortOrder'];
+                }
+            }
+
             $this->addFilter('reset', [
                 'type' => 'info',
                 'wrapperClass' => 'form-search-action form-search-action-reset'
@@ -99,7 +110,7 @@ abstract class DirectoryFilters extends Widget
                     ->link([$this->pageUrl])
                     ->tooltip(Yii::t('UiModule.base', 'Reset filters'))
                     ->options(['aria-label' => Yii::t('UiModule.base', 'Reset filters')]),
-                'sortOrder' => ++$minSortOrder,
+                'sortOrder' => ($maxSortOrder ?? 0) + 1,
             ]);
         }
     }

--- a/protected/humhub/modules/user/widgets/PeopleFilters.php
+++ b/protected/humhub/modules/user/widgets/PeopleFilters.php
@@ -60,6 +60,9 @@ class PeopleFilters extends DirectoryFilters
             'afterInput' => Html::submitButton('<span class="fa fa-search" aria-hidden="true"></span>', [
                 'class' => 'form-button-search',
                 'aria-label' => Yii::t('UserModule.base', 'Search'),
+                // Pressing Enter in the keyword field already submits the form, so this
+                // button doesn't need its own tab stop.
+                'tabindex' => '-1',
             ]),
             'sortOrder' => 100,
         ]);

--- a/protected/humhub/resources/scss/_cards.scss
+++ b/protected/humhub/resources/scss/_cards.scss
@@ -83,7 +83,6 @@
             }
             @media (max-width: 548px) {
                 .form-search-action {
-                    order: initial;
                     &.form-search-action-toggle-more {
                         display: initial;
                     }
@@ -104,7 +103,6 @@
                 padding: 0;
                 font-size: 20px;
             }
-            order: 1;
             &.form-search-action-toggle-more {
                 display: none;
                 .btn:not(.collapsed) {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] All tests are passing
- [x] Changelog was modified

**Other information:**
https://github.com/humhub/humhub/issues/8423