### PR TITLE
Fix keyboard accessibility for file-handler dropdown menu items without href

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ HumHub Changelog
 - Fix #8422: Replace removed `.sr-only` class with `.visually-hidden`
 - Fix #8434: `Badge::action()` and `Badge::withLink()` rendered the badge markup escaped inside the link, since the wrapping link encoded the label it is given in `Badge::run()` — which is the already rendered badge, not text
 - Enh #8425: Implement visible focus for elements in cards for keyboard accessibility
+- Fix #8269: File-handler dropdown menu items had no href, so they were skipped by Tab and could not be focused via keyboard or the dropdown's arrow-key navigation
 
 1.19.0-beta.2 (August 19, 2026)
 -------------------------------

--- a/protected/humhub/modules/file/widgets/FileHandlerButtonDropdown.php
+++ b/protected/humhub/modules/file/widgets/FileHandlerButtonDropdown.php
@@ -105,6 +105,13 @@ class FileHandlerButtonDropdown extends Widget
         if (isset($options['url'])) {
             $url = ArrayHelper::remove($options, 'url', '#');
             $options['href'] = $url;
+        } elseif (!isset($options['href'])) {
+            // The href makes the anchor keyboard focusable and part of the tab
+            // order (an <a> without href is skipped by Tab and cannot receive
+            // focus, e.g. via the dropdown's arrow-key navigation); the
+            // data-action-click handler already calls preventDefault(), so the
+            // fragment is never followed. See Link::withAction() for the same pattern.
+            $options['href'] = '#';
         }
 
         return Html::tag('a', $label, $options);


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] All tests are passing
- [x] Changelog was modified

**Other information:**
https://github.com/humhub/humhub/issues/8269