### PR TITLE
Fix stream endless scrolling and the mobile "Load more" button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ HumHub Changelog
 - Enh #8425: Implement visible focus for elements in cards for keyboard accessibility
 - Fix #8269: File-handler dropdown menu items had no href, so they were skipped by Tab and could not be focused via keyboard or the dropdown's arrow-key navigation
 - Fix #8423: Fix tab order of the reset filters button in the search area
+- Fix: Endless scrolling stalled whenever the loaded stream entries did not push the stream end indicator out of the observed area (compact streams, short entries, viewport not filled), because an `IntersectionObserver` only reports state *changes* — the stream now keeps loading until the observed area is filled
+- Fix: The mobile "Load more" button of a stream was hardwired to the `#wallStream` id, so it failed with "Handler not found" in any stream rendered with a custom `id`
 
 1.19.0-beta.2 (August 19, 2026)
 -------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,8 @@ HumHub Changelog
 - Enh #8425: Implement visible focus for elements in cards for keyboard accessibility
 - Fix #8269: File-handler dropdown menu items had no href, so they were skipped by Tab and could not be focused via keyboard or the dropdown's arrow-key navigation
 - Fix #8423: Fix tab order of the reset filters button in the search area
-- Fix: Endless scrolling stalled whenever the loaded stream entries did not push the stream end indicator out of the observed area (compact streams, short entries, viewport not filled), because an `IntersectionObserver` only reports state *changes* — the stream now keeps loading until the observed area is filled
-- Fix: The mobile "Load more" button of a stream was hardwired to the `#wallStream` id, so it failed with "Handler not found" in any stream rendered with a custom `id`
+- Fix #8438: Endless scrolling stalled whenever the loaded stream entries did not push the stream end indicator out of the observed area (compact streams, short entries, viewport not filled), because an `IntersectionObserver` only reports state *changes* — the stream now keeps loading until the observed area is filled
+- Fix #8438: The mobile "Load more" button of a stream was hardwired to the `#wallStream` id, so it failed with "Handler not found" in any stream rendered with a custom `id`
 
 1.19.0-beta.2 (August 19, 2026)
 -------------------------------

--- a/protected/humhub/modules/stream/resources/js/humhub.stream.Stream.js
+++ b/protected/humhub/modules/stream/resources/js/humhub.stream.Stream.js
@@ -87,29 +87,59 @@ humhub.module('stream.Stream', function (module, require, $) {
     };
 
     Stream.prototype.initScroll = function () {
-        if (window.IntersectionObserver && this.options.scrollSupport) {
-
-            var options = {root: this.$content[0], rootMargin: "50px"};
-            options = this.options.scrollOptions ? $.extend(options, this.options.scrollOptions) : options;
-            var $streamEnd = $('<div class="stream-end"></div>');
-            this.$content.append($streamEnd);
-
-            var that = this;
-            var observer = new IntersectionObserver(function (entries) {
-                if (that.preventScrollLoading()) {
-                    return;
-                }
-
-                if (entries.length && entries[0].isIntersecting) {
-                    that.load().finally(function () {
-                        that.state.scrollLock = false;
-                    });
-                }
-
-            }, options);
-
-            observer.observe($streamEnd[0]);
+        if (!window.IntersectionObserver || !this.options.scrollSupport) {
+            return;
         }
+
+        var options = {root: this.$content[0], rootMargin: "50px"};
+        options = this.options.scrollOptions ? $.extend(options, this.options.scrollOptions) : options;
+        var $streamEnd = $('<div class="stream-end"></div>');
+        this.$content.append($streamEnd);
+
+        // A stream can be re-initialized (filter change, reload), which empties the content and
+        // therefore detaches the previous stream end indicator.
+        if (this.scrollObserver) {
+            this.scrollObserver.disconnect();
+        }
+
+        var that = this;
+        this.scrollObserver = new IntersectionObserver(function (entries) {
+            if (that.preventScrollLoading()) {
+                return;
+            }
+
+            if (entries.length && entries[entries.length - 1].isIntersecting) {
+                that.load().finally(function () {
+                    that.state.scrollLock = false;
+                    that.continueScrollLoading($streamEnd[0]);
+                });
+            }
+
+        }, options);
+
+        this.scrollObserver.observe($streamEnd[0]);
+    };
+
+    /**
+     * An IntersectionObserver only reports *changes* of the intersection state. As long as the
+     * newly loaded entries do not push the stream end indicator out of the observed area - which
+     * is the normal case for compact streams whose entries are shorter than the root margin, or
+     * whenever the loaded entries do not fill the viewport - no further callback is triggered and
+     * the stream stalls until the user scrolls up and down again.
+     *
+     * Re-observing the indicator queues a fresh notification with its current intersection state
+     * and thereby keeps loading until the observed area is filled or the last entry was loaded.
+     *
+     * @param {Element} streamEnd the stream end indicator of the current stream content
+     * @since 1.19
+     */
+    Stream.prototype.continueScrollLoading = function (streamEnd) {
+        if (!this.scrollObserver || !streamEnd.isConnected || this.state.lastEntryLoaded) {
+            return;
+        }
+
+        this.scrollObserver.unobserve(streamEnd);
+        this.scrollObserver.observe(streamEnd);
     };
 
     Stream.prototype.preventScrollLoading = function () {

--- a/protected/humhub/modules/stream/widgets/views/wallStream.php
+++ b/protected/humhub/modules/stream/widgets/views/wallStream.php
@@ -10,6 +10,7 @@ use humhub\widgets\bootstrap\Button;
 /* @var $this View */
 /* @var $filterNav string */
 /* @var $contentContainer ContentContainerActiveRecord */
+/* @var $options array */
 
 StreamAsset::register($this);
 
@@ -41,7 +42,7 @@ StreamAsset::register($this);
 <div class="col-lg-12 text-center d-lg-none">
     <?= Button::primary(Yii::t('ContentModule.base', 'Load more'))
         ->id('btn-load-more')
-        ->action('loadMore', null, '#wallStream')
+        ->action('loadMore', null, '#' . $options['id'])
         ->lg() ?>
     <br/><br/>
 </div>


### PR DESCRIPTION
An IntersectionObserver only reports *changes* of the intersection state. Whenever the newly loaded entries did not push the stream end indicator out of the observed area - compact streams, entries shorter than the root margin, or a viewport the initial entries do not fill - no further callback was triggered and the stream stalled until the user scrolled up and down again. Re-observing the indicator after each scroll triggered load queues a fresh notification with its current intersection state, so loading continues until the observed area is filled or the last entry was loaded. The observer is now kept on the stream instance and disconnected when the stream is re-initialized, which also detaches the previous indicator.

The mobile "Load more" button was hardwired to the `#wallStream` id and therefore failed with "Handler not found" in any stream rendered with a custom id, e.g. a second stream on the same page.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [ ] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included
- [x] Changelog was modified

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

The Commit title has been created by Claude.
The 2 issues were when using `StreamViewer::widget()` with a different ID and with wall entries having a height less than 300px.
So no issue with Posts, but this PR allows using the StreamViewer with other modules in other situations.

---

Claude full report:

**1. Endless scroll stalls (the real cause of the hack)**

Stream.prototype.initScroll (protected/humhub/modules/st ream/resources/js/humhub.stream.Stream.js:89) observes a zero-height .stream-end sentinel with an IntersectionObserver. An IntersectionObserver only fires on changes of the intersection state. WallStream uses {root: null, rootMargin: "300px"}, and the stream loads 8 entries initially + 4 per request. In a compact list like Post Stream, 4 rows are shorter than the 300px margin — so after a load the sentinel is still intersecting, no new callback fires, and the stream is stuck at 8 + 4 = 12 posts until you scroll away and back. That matches both your symptoms exactly.

The 200px padding was compensating for this by pushing the sentinel out of the observed area on every load.

Fix: after each scroll-triggered load, re-observe the sentinel, which queues a fresh notification with its current state — so loading continues until the observed area is actually filled or the last entry is reached:

Stream.prototype.continueScrollLoading = function (streamEnd) { if (!this.scrollObserver || !streamEnd.isConnected || this.state.lastEntryLoaded) { return; } this.scrollObserver.unobserve(streamEnd); this.scrollObserver.observe(streamEnd); };

The observer is now kept on the instance and disconnect()ed on re-init (filter change / reload), which also stops the observer leak that existed before. This is the same idea SimpleStream.handleResponseActionForm() already applies for its paged variant — I left that one alone to avoid touching the action-form stream.

**2. Handler not found: loadMore on mobile**

protected/humhub/modules/stream/widgets/views/wallStream .php:44 hardwired the action target: ->action('loadMore', null, '#wallStream'). Post Stream renders StreamViewer with 'id' => 'post-stream-list', so #wallStream doesn't exist on that page and the action can't resolve a component. Now uses '#' . $options['id'].