### PR TITLE
Fix unstable pagination in space member lists

### DIFF
--- a/protected/humhub/modules/user/components/ActiveQueryUser.php
+++ b/protected/humhub/modules/user/components/ActiveQueryUser.php
@@ -103,7 +103,10 @@ class ActiveQueryUser extends AbstractActiveQueryContentContainer
     public function defaultOrder()
     {
         $this->joinWith('profile');
-        $this->addOrderBy(['profile.lastname' => SORT_ASC]);
+        $this->addOrderBy([
+            'profile.lastname' => SORT_ASC,
+            'user.id' => SORT_ASC,
+        ]);
 
         return $this;
     }


### PR DESCRIPTION
Summary

Fixes #8146.

Space member lists can currently show duplicate users across pages or skip users entirely when multiple users have the same or an empty last name.

The issue is caused by a non-deterministic default sort order in ActiveQueryUser::defaultOrder().

Cause

The space member list uses the following code path:

MembershipController → MemberListService → Membership::getSpaceMembersQuery() → ActiveQueryUser::defaultOrder()

ActiveQueryUser::defaultOrder() currently sorts users only by:

$this->addOrderBy(['profile.lastname' => SORT_ASC]);

When multiple users have the same last name, or no last name at all, these rows have identical sort values. The database is therefore free to return them in a different order between queries.

UserListBox subsequently applies OFFSET and LIMIT to this result. Since the underlying order is not deterministic, users can appear on multiple pages while others may be skipped.

Fix

Add user.id as a secondary sort criterion:

$this->addOrderBy([
    'profile.lastname' => SORT_ASC,
    'user.id' => SORT_ASC,
]);

Since user.id is unique, it provides a deterministic order while preserving the existing last-name sorting behavior.

This is intentionally a minimal change and does not alter the existing user-facing sorting logic.

Result

Space member pagination now produces stable and reproducible results, including when multiple users have identical or empty last names.