### PR TITLE
Restrict Topic management (create/rename/delete) on user profiles to the profile owner or users with full content management permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ HumHub Changelog
 - Fix #8430: Make the password show/hide icon focusable and operable via keyboard
 - Fix #8439: Fix editing file-only Posts and clear `fileList[]` after posting so it isn't reused on the next post
 - Fix #8442: DatePicker date-format mismatches (month names, digits, whitespace) between jQuery UI and PHP intl/ICU across 35+ locales
+- Fix #8446: Restrict Topic management (create/rename/delete) on user profiles to the profile owner or users with full content management permissions
 
 1.18.5 (August 19, 2026)
 ------------------------

--- a/protected/humhub/modules/topic/controllers/ManageController.php
+++ b/protected/humhub/modules/topic/controllers/ManageController.php
@@ -44,7 +44,18 @@ class ManageController extends ContentContainerController
 
     public function beforeAction($action)
     {
-        if (!Topic::isAllowedToCreate($this->contentContainer) || ($this->contentContainer instanceof Space && !$this->contentContainer->can(ManageTopics::class))) {
+        if (!Topic::isAllowedToCreate($this->contentContainer)) {
+            throw new ForbiddenHttpException();
+        }
+
+        if ($this->contentContainer instanceof Space
+            && !$this->contentContainer->can(ManageTopics::class)) {
+            throw new ForbiddenHttpException();
+        }
+
+        if ($this->contentContainer instanceof User
+            && !$this->contentContainer->is(Yii::$app->user->getIdentity())
+            && !Yii::$app->user->getIdentity()?->canManageAllContent()) {
             throw new ForbiddenHttpException();
         }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

**The PR fulfills these requirements:**

- [ ] All tests are passing
- [x] Changelog was modified

**Other information:**
https://github.com/humhub/humhub-internal/issues/1334