### PR TITLE
Prevent silent demotion of public content to private when saved by an editor lacking CreatePublicContent permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ HumHub Changelog
 - Fix #8442: DatePicker date-format mismatches (month names, digits, whitespace) between jQuery UI and PHP intl/ICU across 35+ locales
 - Fix #8445: Restrict direct space joins to free-join spaces, so "Invite and request" spaces require admin approval instead of instant membership
 - Fix #8446: Restrict Topic management (create/rename/delete) on user profiles to the profile owner or users with full content management permissions
+- Fix #8443: Prevent silent demotion of public content to private when saved by an editor lacking CreatePublicContent permission
 
 1.18.5 (August 19, 2026)
 ------------------------

--- a/protected/humhub/modules/content/models/Content.php
+++ b/protected/humhub/modules/content/models/Content.php
@@ -231,8 +231,19 @@ class Content extends ActiveRecord implements Movable, ContentOwner, Archiveable
         $this->pinned ??= 0;
         $this->state ??= Content::STATE_PUBLISHED;
 
-        $this->visibility ??= self::VISIBILITY_PRIVATE;
-        // Force to private content for private space or if user has no permission to create public content
+        $this->visibility = (int)($this->visibility ?? self::VISIBILITY_PRIVATE);
+        // Force to private content for private space or if user has no permission to create public content.
+        //
+        // NOTE: the "no permission to create public content" branch only applies when the visibility is
+        // actually being *changed* to public ($insert, or an existing record whose `visibility` attribute
+        // was just switched to public - see isAttributeChanged() below). The permission being checked here
+        // is about *making* content public, not about keeping it public - matching actionToggleVisibility()/
+        // VisibilityLink. Without this guard, ANY save of an already-public record (e.g. a trivial unrelated
+        // field edit) by an editor who can manage/edit the content but lacks CreatePublicContent in this
+        // container (e.g. a system admin editing another user's content for moderation, or a space role that
+        // has "Manage entries" but not "Create public content") would silently flip the content back to
+        // private for everyone else - with no warning shown anywhere in the UI. Reported and discussed in
+        // https://github.com/humhub/humhub/issues/8443 - has been silently demoting content since 1.15.3.
         if ($this->container instanceof Space
             && $this->container->visibility !== Space::VISIBILITY_ALL
             && $this->visibility === self::VISIBILITY_PUBLIC
@@ -240,6 +251,7 @@ class Content extends ActiveRecord implements Movable, ContentOwner, Archiveable
                 $this->container->visibility === Space::VISIBILITY_NONE
                 || (
                     Yii::$app->user->identity // Allow creating public content from console
+                    && ($insert || $this->isAttributeChanged('visibility', false))
                     && !$this->container->can(CreatePublicContent::class)
                 )
             )

--- a/protected/humhub/modules/content/tests/codeception/unit/models/ContentVisibilityTest.php
+++ b/protected/humhub/modules/content/tests/codeception/unit/models/ContentVisibilityTest.php
@@ -9,12 +9,12 @@
 
 namespace tests\codeception\unit\modules\content;
 
-use humhub\modules\content\tests\codeception\unit\TestContent;
-use modules\content\tests\codeception\_support\ContentModelTest;
-use tests\codeception\_support\HumHubDbTestCase;
-use Codeception\Specify;
-use humhub\modules\space\models\Space;
+use humhub\libs\BasePermission;
 use humhub\modules\content\models\Content;
+use humhub\modules\content\permissions\CreatePublicContent;
+use humhub\modules\content\tests\codeception\unit\TestContent;
+use humhub\modules\space\models\Space;
+use modules\content\tests\codeception\_support\ContentModelTest;
 use Yii;
 use yii\base\Exception;
 
@@ -125,5 +125,62 @@ class ContentVisibilityTest extends ContentModelTest
 
         $this->assertTrue($newModel->save());
         $this->assertEquals($newModel->content->visibility, Content::VISIBILITY_PRIVATE);
+    }
+
+    /**
+     * Regression test for https://github.com/humhub/humhub/issues/8443
+     *
+     * Saving an already public record must not silently demote it to private just because the
+     * current editor lacks CreatePublicContent in this container - that permission is about
+     * *making* content public, not about keeping it public (matches actionToggleVisibility()/
+     * VisibilityLink). Before the fix, ANY save of an already-public record (e.g. an unrelated
+     * field edit) by such an editor - a system admin editing another user's content for
+     * moderation, or a space role that can manage/edit content but not create public content -
+     * silently flipped it back to private for everyone else.
+     */
+    public function testExistingPublicContentStaysPublicWhenEditorLacksCreatePublicContentPermission()
+    {
+        $this->becomeUser('User1');
+        $this->space->visibility = Space::VISIBILITY_REGISTERED_ONLY;
+
+        $newModel = new TestContent($this->space, Content::VISIBILITY_PUBLIC, [
+            'message' => 'Test',
+        ]);
+        $this->assertTrue($newModel->save());
+        $this->assertEquals(Content::VISIBILITY_PUBLIC, $newModel->content->visibility);
+
+        // Take away this user's permission to *create* public content in this space ...
+        $this->space->permissionManager->setGroupState(Space::USERGROUP_ADMIN, CreatePublicContent::class, BasePermission::STATE_DENY);
+
+        // ... an unrelated re-save must not silently demote the already-public content.
+        $newModel->message = 'Updated message';
+        $this->assertTrue($newModel->save());
+        $this->assertEquals(Content::VISIBILITY_PUBLIC, $newModel->content->visibility);
+    }
+
+    /**
+     * The permission check must still block an *unauthorized* private -> public change - only the
+     * "leave an already-public record alone" case (tested above) is exempted.
+     */
+    public function testPrivateContentCannotBeEscalatedToPublicByUserWithoutCreatePublicContentPermission()
+    {
+        $this->becomeUser('User1');
+        $this->space->visibility = Space::VISIBILITY_REGISTERED_ONLY;
+
+        $newModel = new TestContent($this->space, Content::VISIBILITY_PRIVATE, [
+            'message' => 'Test',
+        ]);
+        $this->assertTrue($newModel->save());
+        $this->assertEquals(Content::VISIBILITY_PRIVATE, $newModel->content->visibility);
+
+        // User1 is the owner of space id=2 (see space fixture created_by), so getUserGroup()
+        // resolves to USERGROUP_OWNER rather than USERGROUP_ADMIN - deny both to make sure
+        // CreatePublicContent is actually denied regardless of which group applies.
+        $this->space->permissionManager->setGroupState(Space::USERGROUP_OWNER, CreatePublicContent::class, BasePermission::STATE_DENY);
+        $this->space->permissionManager->setGroupState(Space::USERGROUP_ADMIN, CreatePublicContent::class, BasePermission::STATE_DENY);
+
+        $newModel->content->visibility = Content::VISIBILITY_PUBLIC;
+        $this->assertTrue($newModel->content->save());
+        $this->assertEquals(Content::VISIBILITY_PRIVATE, $newModel->content->visibility);
     }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

**The PR fulfills these requirements:**

- [ ] All tests are passing
- [x] Changelog was modified

**Other information:**
https://github.com/humhub/humhub/issues/8443