### PR TITLE
Encode the redirect URL in the htmlRedirect view as a safe JS string so it can no longer break out of the inline <script> block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ HumHub Changelog
 - Fix #8445: Restrict direct space joins to free-join spaces, so "Invite and request" spaces require admin approval instead of instant membership
 - Fix #8446: Restrict Topic management (create/rename/delete) on user profiles to the profile owner or users with full content management permissions
 - Fix #8443: Prevent silent demotion of public content to private when saved by an editor lacking CreatePublicContent permission
+- Fix #8451: Encode the redirect URL in the htmlRedirect view as a safe JS string so it can no longer break out of the inline <script> block
 
 1.18.5 (August 19, 2026)
 ------------------------

--- a/protected/humhub/views/htmlRedirect.php
+++ b/protected/humhub/views/htmlRedirect.php
@@ -5,17 +5,9 @@ use yii\helpers\Json;
 
 /* @var $url string */
 
-// Encode once for a JavaScript string-literal context (this already includes the quotes).
-$jsUrl = Json::htmlEncode($url);
-// Remove test.php#xy (#xy) part, then encode the trimmed value as well.
-$jsUrlWithoutHash = Json::htmlEncode(explode('#', (string) $url)[0]);
+// Remove test.php#xy (#xy) part, then encode for a JavaScript string-literal context
+// (Json::htmlEncode already includes the quotes and is safe to embed in <script>).
 ?>
 <script <?= Html::nonce() ?>>
-    // If current URL == New Url (absolute || relative) then only Refresh
-    if (window.location.pathname + window.location.search + window.location.hash == <?= $jsUrl ?>
-        || window.location.href == <?= $jsUrl ?>) {
-        window.location.href = <?= $jsUrlWithoutHash ?>;
-    } else {
-        window.location.href = <?= $jsUrlWithoutHash ?>;
-    }
+    window.location.href = <?= Json::htmlEncode(explode('#', (string) $url)[0]) ?>;
 </script>

--- a/protected/humhub/views/htmlRedirect.php
+++ b/protected/humhub/views/htmlRedirect.php
@@ -1,22 +1,21 @@
-<script <?= \humhub\helpers\Html::nonce() ?>>
+<?php
 
+use humhub\helpers\Html;
+use yii\helpers\Json;
+
+/* @var $url string */
+
+// Encode once for a JavaScript string-literal context (this already includes the quotes).
+$jsUrl = Json::htmlEncode($url);
+// Remove test.php#xy (#xy) part, then encode the trimmed value as well.
+$jsUrlWithoutHash = Json::htmlEncode(explode('#', (string) $url)[0]);
+?>
+<script <?= Html::nonce() ?>>
     // If current URL == New Url (absolute || relative) then only Refresh
-    if (window.location.pathname + window.location.search + window.location.hash == '<?php echo $url; ?>' || '<?php echo $url; ?>' == window.location.href) {
-
-            <?php
-            //echo "window.location.reload();\n"; // Drops warning on Posts
-            // Remove test.php#xy  (#xy) part
-            $temp = explode("#", (string) $url);
-            $url = $temp[0];
-            ?>
-
-        if (window.location.search == '') {
-            window.location.href = '<?php echo $url; ?>';
-        } else {
-            window.location.href = '<?php echo $url; ?>';
-        }
-
+    if (window.location.pathname + window.location.search + window.location.hash == <?= $jsUrl ?>
+        || window.location.href == <?= $jsUrl ?>) {
+        window.location.href = <?= $jsUrlWithoutHash ?>;
     } else {
-        window.location.href = '<?php echo $url; ?>';
+        window.location.href = <?= $jsUrlWithoutHash ?>;
     }
 </script>


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

**The PR fulfills these requirements:**

- [ ] All tests are passing
- [x] Changelog was modified

**Other information:**
https://github.com/humhub/humhub-internal/issues/1336