### PR TITLE
Make the core functional test suite runnable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ HumHub Changelog
 - Fix #8438: The mobile "Load more" button of a stream was hardwired to the `#wallStream` id, so it failed with "Handler not found" in any stream rendered with a custom `id`
 - Fix #8448: Destructive admin actions (remove all space members, delete profile category, reset invite link, remove licence) ran on GET via CSRF
 - Enh #8452: `docs/develop/module-migrate.md` is now only an index — each release line keeps its breaking changes in its own `module-migrate-<version>.md`, so `develop` and `next` no longer collide in a shared `Unreleased` section
+- Enh #8454: The core functional test suite could not run a single test — `FixtureHelper::_afterSuite()` unloaded fixtures against the application the Yii2 module destroys after every test, aborting the whole run; the suite also lacked the `Asserts` module
 
 1.19.0-beta.2 (August 19, 2026)
 -------------------------------

--- a/protected/humhub/tests/codeception/_support/FixtureHelper.php
+++ b/protected/humhub/tests/codeception/_support/FixtureHelper.php
@@ -7,12 +7,13 @@ use humhub\modules\live\tests\codeception\fixtures\LiveFixture;
 use humhub\modules\user\tests\codeception\fixtures\UserFullFixture;
 use yii\test\FixtureTrait;
 use yii\test\InitDbFixture;
+use Yii;
 
 /**
- * This helper is used to populate the database with needed fixtures before any tests are run.
- * In this example, the database is populated with the demo login user, which is used in acceptance
- * and functional tests.  All fixtures will be loaded before the suite is started and unloaded after it
- * completes.
+ * Populates the database with the fixtures a suite needs before its tests run, and unloads them
+ * afterwards.
+ *
+ * Enabled by the core functional suite only; every other suite uses {@see DynamicFixtureHelper}.
  */
 class FixtureHelper extends Module
 {
@@ -48,6 +49,16 @@ class FixtureHelper extends Module
      */
     public function _afterSuite()
     {
+        // The Yii2 module destroys the application after every single test
+        // (Yii2::_after() -> Connector\Yii2::resetApplication()), so by the time the suite ends
+        // there is no application - and therefore no DB connection - left to unload against.
+        // Nothing is lost: with `cleanup` the Yii2 module already unloads after each test, and
+        // _beforeSuite() unloads before it loads. The guard keeps this usable from a suite that
+        // does keep its application.
+        if (Yii::$app === null) {
+            return;
+        }
+
         $this->unloadFixtures();
     }
 

--- a/protected/humhub/tests/codeception/functional.suite.yml
+++ b/protected/humhub/tests/codeception/functional.suite.yml
@@ -8,6 +8,7 @@
 actor: FunctionalTester
 modules:
     enabled:
+      - Asserts
       - Filesystem
       - Yii2
       - tests\codeception\_support\FixtureHelper


### PR DESCRIPTION
## The defect

`protected/humhub/tests/codeception/functional/` has never contained a test, so the suite's teardown never ran. It is broken:

- `FixtureHelper::_afterSuite()` unloads fixtures over the database.
- `Yii2::_after()` calls `Connector\Yii2::resetApplication()`, which sets `Yii::$app = null` **after every single test**.

So by the time the suite ends there is no application, and therefore no DB connection, left. The first test added to this suite aborts the entire run:

```
Error: Call to a member function get() on null in yii2/db/Schema.php:747
  #0 Schema->getTableMetadata()
  ...
  #9 FixtureHelper->unloadFixtures()
  #10 FixtureHelper->_afterSuite()
Aborted due to warnings.  ##[error]Process completed with exit code 6.
```

Unloading there is redundant anyway: with `cleanup` the Yii2 module already unloads after each test, and `_beforeSuite()` unloads before it loads.

The suite also had no `Asserts` module, so `assert*` steps did not exist in it.

## Blast radius

`FixtureHelper` is enabled by this one suite only — every other suite (38 of them) uses `DynamicFixtureHelper`, a separate module that does not derive from it. Its class docblock claimed acceptance suites use it as well; that was stale and is corrected here.

## Verification

This is a port of the fix in humhub/humhub#8453 on `next`, where it **is** exercised: that PR adds the first three tests to this suite, and CI went from a full-run abort to green on PHP 8.2, 8.3, 8.4 and 8.5.

On this branch the suite stays empty, so develop's own CI cannot prove the change — it will simply be green as before. The files are byte-identical to the `next` versions, so the two branches merge cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E2SUrd2fGkf6GZY9Xcd8qN