### PR TITLE
Move the TopicAsset dependency from FilterAsset to StreamAsset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ HumHub Changelog
 
 1.20.0 (Unreleased)
 -------------------
+- Enh #8473: Moved the `TopicAsset` dependency from `FilterAsset` to `StreamAsset` — the filter JavaScript has no relationship to topics, whereas the stream filter navigation is what renders a topic picker; the scripts a page loads are unchanged
 - Enh #8471: Removed the `ui` module — after its seven folders moved into the core namespace, the module class, its config, its three i18n categories (folded into `base`) and its test suite are gone; the deprecated class names keep resolving until 1.21 because `humhub\` is autoloaded from the `@humhub` alias rather than through a module registration
 - Enh #8469: Moved the filter part of the `ui` module into the core namespace — `humhub\widgets\filter\*` for the widgets, `humhub\models\filter\*` for the two abstract models and `humhub\assets\FilterAsset` — and dropped three views nothing rendered; the old class names stay as deprecated shims until 1.21
 - Enh #8467: Moved the remaining widgets of the `ui` module into the core namespace as `humhub\widgets\{BaseImage, CropImage, CounterSet, CounterSetItem, DirectoryFilters}`, together with their three views; the old class names stay as deprecated shims until 1.21

--- a/docs/develop/module-migrate-1.20.md
+++ b/docs/develop/module-migrate-1.20.md
@@ -442,3 +442,14 @@ Breaking changes, new APIs and deprecations of the 1.20 release cycle.
     `humhub\tests\codeception\unit\{helpers,widgets}`; the module's `ThemeTest` became
     `ThemePublishTest` because the core suite already has a `ThemeTest` covering path mapping, and
     its single SCSS test joined the existing `ScssHelperTest`.
+
+- **`humhub\assets\FilterAsset` no longer depends on `humhub\modules\topic\assets\TopicAsset`.**
+  The dependency moved to `humhub\modules\stream\assets\StreamAsset`, where it belongs:
+  `humhub.ui.filter.js` requires only `ui.widget` and `util` and has no relationship to topics,
+  while it is `WallStreamFilterNavigation` — in the stream module — that configures a
+  `PickerFilterInput` with `TopicPicker`.
+
+  Nothing changes about the scripts a page loads: `TopicAsset` is registered by the core bundle
+  directly, and the transitive dependency closure of `CoreBundleAsset` is identical before and
+  after. Only a module that registers `FilterAsset` on its own *and* renders a topic picker has
+  to register `TopicAsset` itself now.

--- a/protected/humhub/assets/FilterAsset.php
+++ b/protected/humhub/assets/FilterAsset.php
@@ -10,7 +10,6 @@
 namespace humhub\assets;
 
 use humhub\components\assets\AssetBundle;
-use humhub\modules\topic\assets\TopicAsset;
 
 class FilterAsset extends AssetBundle
 {
@@ -24,12 +23,5 @@ class FilterAsset extends AssetBundle
      */
     public $js = [
         'js/humhub/humhub.ui.filter.js',
-    ];
-
-    /**
-     * @inheritdoc
-     */
-    public $depends = [
-        TopicAsset::class,
     ];
 }

--- a/protected/humhub/modules/stream/assets/StreamAsset.php
+++ b/protected/humhub/modules/stream/assets/StreamAsset.php
@@ -13,6 +13,7 @@ use humhub\components\assets\AssetBundle;
 use humhub\modules\content\assets\ContentAsset;
 use humhub\modules\content\assets\ContentContainerAsset;
 use humhub\assets\FilterAsset;
+use humhub\modules\topic\assets\TopicAsset;
 use humhub\modules\user\assets\UserAsset;
 
 /**
@@ -44,6 +45,7 @@ class StreamAsset extends AssetBundle
         ContentAsset::class,
         ContentContainerAsset::class,
         FilterAsset::class,
+        TopicAsset::class,
         UserAsset::class,
         CoreExtensionAsset::class,
     ];


### PR DESCRIPTION
Follow-up to the `ui` module dissolution (#8460, #8461, #8462, #8463, #8464, #8467, #8469, #8471). I flagged this while moving the filter folder and deliberately left it out of #8469, because it is behaviour, not naming.

## The dependency pointed the wrong way

`humhub\assets\FilterAsset` declared `humhub\modules\topic\assets\TopicAsset` — a core bundle reaching into a module. There is no relationship to justify it: `humhub.ui.filter.js` requires only `ui.widget` and `util`, and `humhub.topic.js` does not require `ui.filter` either.

It was introduced in #3941 (2020), which changed the dependency from `CoreApiAsset` to `TopicAsset`. At the time the filter folder still shipped `streamTopicPicker.php` and `topicFilterBlock.php`, both rendering a `TopicPicker` — so the bundle genuinely needed the topic script. #8469 removed those two views because nothing rendered them, which left the dependency behind without a reason.

What does render a topic picker is `WallStreamFilterNavigation`, in the stream module:

```php
'class' => PickerFilterInput::class,
'picker' => TopicPicker::class,
```

So `StreamAsset` is where the declaration belongs, and that is where it moves.

## Nothing changes about what a page loads

`TopicAsset` is listed in `CoreBundleAsset::STATIC_DEPENDS` directly, so it ships regardless. I verified this rather than assuming it: resolving the full transitive dependency closure of `CoreBundleAsset` against `origin/next` and against this branch gives **20 bundles in both, with nothing added and nothing removed**. `StreamAsset` on its own still reaches `TopicAsset`, now directly instead of through `FilterAsset`.

The only case that changes is a module registering `FilterAsset` standalone *and* rendering a topic picker — it has to register `TopicAsset` itself now. That is noted in the migration guide.

## What I did not change

I also flagged that `FilterAsset` is listed in `CoreBundleAsset::STATIC_DEPENDS` *and* reachable through `StreamAsset`, which depends on it. Having looked closer, I would leave that alone:

- The list is an explicit manifest of what goes into the bundle — `TopicAsset` is listed there too, even while `FilterAsset` was pulling it. Removing the entry would make the bundle's contents depend on a transitive chain instead of being stated.
- It saves nothing. I described this earlier as the reason the filter script ships on every page; that was my mistake. It ships because `StreamAsset` is in the global bundle and legitimately requires it. Dropping the redundant entry would not change a single byte, and slimming the global bundle is a much larger question than this PR.

## Verification

- `php -l` clean
- Transitive dependency closure of `CoreBundleAsset` compared against `origin/next`: identical, 20 bundles, no additions or removals