### PR TITLE
Restore the class imports dropped from the moved views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ HumHub Changelog
 
 1.20.0 (Unreleased)
 -------------------
+- Fix #8475: Every stream filter panel crashed with `Class "FilterBlock" not found` because the move of the filter widgets dropped the import from `filterPanel.php` — view files carry no namespace, so a short class name there is not resolved against the widget's namespace (since #8469)
 - Enh #8473: Moved the `TopicAsset` dependency from `FilterAsset` to `StreamAsset` — the filter JavaScript has no relationship to topics, whereas the stream filter navigation is what renders a topic picker; the scripts a page loads are unchanged
 - Enh #8471: Removed the `ui` module — after its seven folders moved into the core namespace, the module class, its config, its three i18n categories (folded into `base`) and its test suite are gone; the deprecated class names keep resolving until 1.21 because `humhub\` is autoloaded from the `@humhub` alias rather than through a module registration
 - Enh #8469: Moved the filter part of the `ui` module into the core namespace — `humhub\widgets\filter\*` for the widgets, `humhub\models\filter\*` for the two abstract models and `humhub\assets\FilterAsset` — and dropped three views nothing rendered; the old class names stay as deprecated shims until 1.21

--- a/protected/humhub/widgets/filter/views/filterPanel.php
+++ b/protected/humhub/widgets/filter/views/filterPanel.php
@@ -7,6 +7,7 @@
  */
 
 use humhub\components\View;
+use humhub\widgets\filter\FilterBlock;
 
 /* @var $this View */
 /* @var $blocks [] */

--- a/protected/humhub/widgets/menu/views/dropdown-menu.php
+++ b/protected/humhub/widgets/menu/views/dropdown-menu.php
@@ -3,6 +3,8 @@
 use humhub\components\View;
 use humhub\helpers\Html;
 use humhub\widgets\bootstrap\Button;
+use humhub\widgets\menu\DropdownMenu;
+use humhub\widgets\menu\MenuEntry;
 
 /* @var $this View */
 /* @var $menu DropdownMenu */

--- a/protected/humhub/widgets/menu/views/left-navigation.php
+++ b/protected/humhub/widgets/menu/views/left-navigation.php
@@ -2,6 +2,8 @@
 
 use humhub\components\View;
 use humhub\helpers\Html;
+use humhub\widgets\menu\LeftNavigation;
+use humhub\widgets\menu\MenuEntry;
 
 /* @var $this View */
 /* @var $menu LeftNavigation */

--- a/protected/humhub/widgets/menu/views/sub-tab-menu.php
+++ b/protected/humhub/widgets/menu/views/sub-tab-menu.php
@@ -2,6 +2,8 @@
 
 use humhub\components\View;
 use humhub\helpers\Html;
+use humhub\widgets\menu\DropdownMenu;
+use humhub\widgets\menu\MenuEntry;
 
 /* @var $this View */
 /* @var $menu DropdownMenu */

--- a/protected/humhub/widgets/menu/views/tab-menu.php
+++ b/protected/humhub/widgets/menu/views/tab-menu.php
@@ -2,6 +2,8 @@
 
 use humhub\components\View;
 use humhub\helpers\Html;
+use humhub\widgets\menu\DropdownMenu;
+use humhub\widgets\menu\MenuEntry;
 
 /* @var $this View */
 /* @var $menu DropdownMenu */


### PR DESCRIPTION
Regression from #8469, reported from a Space page:

```
Class "FilterBlock" not found
in protected/humhub/widgets/filter/views/filterPanel.php
```

## What went wrong

When the filter widgets moved into one namespace, the mutual `use` statements between them became redundant and I removed them. That is correct for the class files — they share `humhub\widgets\filter` afterwards.

The same deletion was applied to the view files, and that was wrong. A view carries no `namespace` declaration, so a short class name in it resolves against the **global** namespace, never against the namespace of the widget rendering it. `filterPanel.php` renders `FilterBlock::widget($block)`, so every stream filter panel — dashboard, space and profile — died on render.

## Scope

I audited every view moved across #8464, #8467 and #8469 by diffing the `use` statements before and after the move and checking whether each removed class is actually referenced in the body:

| View | Removed import | Used at runtime |
|---|---|---|
| `widgets/filter/views/filterPanel.php` | `FilterBlock` | **yes — this crash** |
| `widgets/menu/views/tab-menu.php` | `MenuEntry`, `DropdownMenu` | no, `@var` only |
| `widgets/menu/views/sub-tab-menu.php` | `MenuEntry`, `DropdownMenu` | no, `@var` only |
| `widgets/menu/views/left-navigation.php` | `MenuEntry`, `LeftNavigation` | no, `@var` only |
| `widgets/menu/views/dropdown-menu.php` | `MenuEntry`, `DropdownMenu` | no, `@var` only |

The menu views never crashed — the names only appear in docblocks — but the annotations pointed at nothing resolvable, so their imports are restored too.

## Verification

Rather than only fixing the reported file, I checked the whole tree: a script walks all **386** namespace-less view files under `protected/humhub`, extracts every `X::` and `new X(` reference, and asserts each is either imported or resolvable as a global class against the autoloader. After this change no view moved by the `ui` dissolution has an unresolved reference.

- `php -l` clean on the five changed views

## Unrelated finding

The same audit flags one pre-existing case I have **not** touched here, since it long predates this work (#8210):

`protected/humhub/modules/user/widgets/views/peopleCard.php` calls `PeopleIcons::widget(['user' => $user])` while importing only `PeopleActionButtons`, `PeopleDetails`, `PeopleTagList` and `Image`. `humhub\modules\user\widgets\PeopleIcons` exists, but the view has no import for it. Happy to fix it in its own PR — say the word.